### PR TITLE
docs: add ShadCN to introduction tagline

### DIFF
--- a/src/app/(registry)/docs/page.tsx
+++ b/src/app/(registry)/docs/page.tsx
@@ -18,8 +18,8 @@ export default function IntroductionPage() {
           <div className="flex flex-col gap-4">
             <p className="paragraph-large-primary text-fg-secondary">
               QuantumBlack Design System is a set of beautifully-designed,
-              accessible components built with Radix UI and styled with your
-              design tokens. Open Source. Open Code.
+              accessible components based on ShadCN, built with Radix UI and
+              styled with your design tokens. Open Source. Open Code.
             </p>
 
             <p className="paragraph-large-primary text-fg-secondary">

--- a/src/app/(registry)/docs/page.tsx
+++ b/src/app/(registry)/docs/page.tsx
@@ -18,7 +18,7 @@ export default function IntroductionPage() {
           <div className="flex flex-col gap-4">
             <p className="paragraph-large-primary text-fg-secondary">
               QuantumBlack Design System is a set of beautifully-designed,
-              accessible components based on ShadCN, built with Radix UI and
+              accessible components based on shadcn, built with Radix UI and
               styled with your design tokens. Open Source. Open Code.
             </p>
 


### PR DESCRIPTION
Updates the Introduction page opening paragraph so it explicitly states that components are **based on ShadCN**, in addition to Radix UI and design tokens, and keeps the **Open Source. Open Code.** positioning.

## Change

- `src/app/(registry)/docs/page.tsx`: insert "based on ShadCN," before "built with Radix UI".

## Checklist

- [x] `npm run lint` passes

Made with [Cursor](https://cursor.com)