### PR TITLE
refactor(time-input): wrap trigger icon with IconShell

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -138,7 +138,8 @@
       "description": "Custom time input with composable segment-based hh:mm entry, keyboard navigation, and clock icon trigger. Exports TimeInputRoot, TimeSegmentInput, TimeSeparator, TimeInputTrigger, and TimeInput convenience wrapper.",
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
-        "__REGISTRY_URL__/r/input.json"
+        "__REGISTRY_URL__/r/input.json",
+        "__REGISTRY_URL__/r/icon-shell.json"
       ],
       "files": [
         {

--- a/src/components/ui/time-input.tsx
+++ b/src/components/ui/time-input.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 
 import { cn } from '../../lib/utils';
 import { Schedule } from '../icons';
+import { IconShell } from './icon-shell';
 import { inputVariantStyles } from './input';
 
 // ============================================================================
@@ -453,9 +454,9 @@ const triggerSizeMap = {
 } as const;
 
 const triggerIconSizeMap = {
-  sm: 'size-4',
-  default: 'size-4',
-  lg: 'size-6',
+  sm: 'sm',
+  default: 'sm',
+  lg: 'default',
 } as const;
 
 export interface TimeInputTriggerProps extends Omit<
@@ -481,16 +482,18 @@ function TimeInputTrigger({
       className={cn(
         'inline-flex shrink-0 items-center justify-center',
         'cursor-pointer rounded-none border-0 bg-transparent p-0 outline-none',
-        'text-fill-active',
+        'text-fill-content-active',
         'disabled:text-fg-disabled disabled:cursor-not-allowed',
         triggerSizeMap[size],
         className,
       )}
       {...props}>
       {children ?? (
-        <Schedule
-          className={cn('text-[length:inherit]', triggerIconSizeMap[size])}
-        />
+        <IconShell
+          size={triggerIconSizeMap[size]}
+          variant={disabled ? 'disabled' : 'secondary'}>
+          <Schedule />
+        </IconShell>
       )}
     </button>
   );


### PR DESCRIPTION
Replace the raw <Schedule> Icon in TimeInputTrigger with an IconShell wrapper.

To fix style and color