### PR TITLE
feat: add aspect-ratio component to registry and demo

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -27,6 +27,21 @@
       ]
     },
     {
+      "name": "aspect-ratio",
+      "type": "registry:ui",
+      "title": "Aspect Ratio",
+      "description": "Constrains content to a fixed width-to-height ratio — ideal for images, video placeholders, and media cards.",
+      "dependencies": ["@radix-ui/react-aspect-ratio"],
+      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "files": [
+        {
+          "path": "src/components/ui/aspect-ratio.tsx",
+          "type": "registry:file",
+          "target": "components/ui/aspect-ratio.tsx"
+        }
+      ]
+    },
+    {
       "name": "avatar",
       "type": "registry:ui",
       "title": "Avatar",

--- a/src/app/demo/[name]/index.tsx
+++ b/src/app/demo/[name]/index.tsx
@@ -12,6 +12,13 @@ import {
   examples as alertExamples,
 } from '@/app/demo/[name]/ui/alert';
 import {
+  AspectRatioDemo,
+  AspectRatioLandscapeRatios,
+  AspectRatioPortraitRatios,
+  aspectRatio,
+  examples as aspectRatioExamples,
+} from '@/app/demo/[name]/ui/aspect-ratio';
+import {
   AvatarCheckboxList,
   AvatarDemo,
   AvatarDisabled,
@@ -342,6 +349,11 @@ export const exampleComponentMaps: Record<
     AlertVariants,
     AlertWithoutIcon,
   },
+  'aspect-ratio': {
+    AspectRatioDemo,
+    AspectRatioLandscapeRatios,
+    AspectRatioPortraitRatios,
+  },
   avatar: {
     AvatarDemo,
     AvatarSizes,
@@ -588,6 +600,7 @@ export const exampleComponentMaps: Record<
 // Example metadata for new format demos
 export const examplesMeta: Record<string, ExampleMeta[]> = {
   alert: alertExamples,
+  'aspect-ratio': aspectRatioExamples,
   avatar: avatarExamples,
   badge: badgeExamples,
   button: buttonExamples,
@@ -628,6 +641,11 @@ export const demos: { [name: string]: Demo | NewDemo } = {
     ...alert,
     examples: alertExamples,
     exampleComponents: exampleComponentMaps.alert,
+  },
+  'aspect-ratio': {
+    ...aspectRatio,
+    examples: aspectRatioExamples,
+    exampleComponents: exampleComponentMaps['aspect-ratio'],
   },
   avatar: {
     ...avatar,

--- a/src/app/demo/[name]/ui/aspect-ratio.tsx
+++ b/src/app/demo/[name]/ui/aspect-ratio.tsx
@@ -58,11 +58,11 @@ export function AspectRatioLandscapeRatios() {
     height: number;
   }[] = [
     { ratio: 1, ratioLabel: '1:1', width: 500, height: 500 },
-    { ratio: 5 / 4, ratioLabel: '5:4', width: 500, height: 500 },
-    { ratio: 4 / 3, ratioLabel: '4:3', width: 500, height: 500 },
-    { ratio: 3 / 2, ratioLabel: '3:2', width: 500, height: 500 },
-    { ratio: 16 / 9, ratioLabel: '16:9', width: 500, height: 500 },
-    { ratio: 2, ratioLabel: '2:1', width: 500, height: 500 },
+    { ratio: 5 / 4, ratioLabel: '5:4', width: 500, height: 400 },
+    { ratio: 4 / 3, ratioLabel: '4:3', width: 400, height: 300 },
+    { ratio: 3 / 2, ratioLabel: '3:2', width: 600, height: 400 },
+    { ratio: 16 / 9, ratioLabel: '16:9', width: 640, height: 360 },
+    { ratio: 2, ratioLabel: '2:1', width: 600, height: 300 },
   ];
 
   return (

--- a/src/app/demo/[name]/ui/aspect-ratio.tsx
+++ b/src/app/demo/[name]/ui/aspect-ratio.tsx
@@ -4,7 +4,7 @@ import { type DemoExample, createLegacyDemo } from '@/lib/demo-utils';
 const DUMMY = 'https://placehold.co';
 
 function dummyImage(width: number, height: number, label: string) {
-  return `${DUMMY}/${width}x${height}?text=${label}`;
+  return `${DUMMY}/${width}x${height}?text=${encodeURIComponent(label)}`;
 }
 
 /** Single media frame using 16:9 — common video and hero proportion */

--- a/src/app/demo/[name]/ui/aspect-ratio.tsx
+++ b/src/app/demo/[name]/ui/aspect-ratio.tsx
@@ -1,0 +1,142 @@
+import { AspectRatio } from '@/components/ui/aspect-ratio';
+import { type DemoExample, createLegacyDemo } from '@/lib/demo-utils';
+
+const DUMMY = 'https://placehold.co';
+
+function dummyImage(width: number, height: number, label: string) {
+  return `${DUMMY}/${width}x${height}?text=${label}`;
+}
+
+/** Single media frame using 16:9 — common video and hero proportion */
+export function AspectRatioDemo() {
+  return (
+    <div className="min-w-[400px] p-4">
+      <AspectRatio ratio={16 / 9}>
+        <img
+          src={dummyImage(640, 360, '16:9')}
+          alt="Example constrained to 16:9"
+          className="h-full w-full rounded-md object-cover"
+        />
+      </AspectRatio>
+    </div>
+  );
+}
+
+function RatioTile({
+  ratio,
+  ratioLabel,
+  orientationLabel,
+  width,
+  height,
+  className,
+}: Readonly<{
+  ratio: number;
+  ratioLabel: string;
+  orientationLabel: string;
+  width: number;
+  height: number;
+  className?: string;
+}>) {
+  return (
+    <div className={className}>
+      <AspectRatio ratio={ratio}>
+        <img
+          src={dummyImage(width, height, ratioLabel)}
+          alt={`${ratioLabel} ${orientationLabel} placeholder`}
+          className="h-full w-full rounded-md object-cover"
+        />
+      </AspectRatio>
+    </div>
+  );
+}
+
+export function AspectRatioLandscapeRatios() {
+  const tiles: {
+    ratio: number;
+    ratioLabel: string;
+    width: number;
+    height: number;
+  }[] = [
+    { ratio: 1, ratioLabel: '1:1', width: 500, height: 500 },
+    { ratio: 5 / 4, ratioLabel: '5:4', width: 500, height: 500 },
+    { ratio: 4 / 3, ratioLabel: '4:3', width: 500, height: 500 },
+    { ratio: 3 / 2, ratioLabel: '3:2', width: 500, height: 500 },
+    { ratio: 16 / 9, ratioLabel: '16:9', width: 500, height: 500 },
+    { ratio: 2, ratioLabel: '2:1', width: 500, height: 500 },
+  ];
+
+  return (
+    <div className="grid max-w-5xl min-w-[400px] grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+      {tiles.map(tile => (
+        <RatioTile
+          key={tile.ratioLabel}
+          ratio={tile.ratio}
+          ratioLabel={tile.ratioLabel}
+          orientationLabel="Landscape"
+          width={tile.width}
+          height={tile.height}
+          className="size-[100px]"
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Portrait-oriented frames — height greater than width (ratio less than 1). */
+export function AspectRatioPortraitRatios() {
+  const tiles: {
+    ratio: number;
+    ratioLabel: string;
+    width: number;
+    height: number;
+  }[] = [
+    { ratio: 1, ratioLabel: '1:1', width: 280, height: 280 },
+    { ratio: 4 / 5, ratioLabel: '4:5', width: 280, height: 350 },
+    { ratio: 3 / 4, ratioLabel: '3:4', width: 240, height: 320 },
+    { ratio: 2 / 3, ratioLabel: '2:3', width: 280, height: 420 },
+    { ratio: 9 / 16, ratioLabel: '9:16', width: 270, height: 480 },
+    { ratio: 1 / 2, ratioLabel: '1:2', width: 280, height: 560 },
+  ];
+
+  return (
+    <div className="grid max-w-5xl min-w-[400px] grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+      {tiles.map(tile => (
+        <RatioTile
+          key={tile.ratioLabel}
+          ratio={tile.ratio}
+          ratioLabel={tile.ratioLabel}
+          orientationLabel="Portrait"
+          width={tile.width}
+          height={tile.height}
+          className="w-full"
+        />
+      ))}
+    </div>
+  );
+}
+
+export const examples: DemoExample[] = [
+  {
+    name: 'AspectRatioDemo',
+    title: 'Default',
+    description: 'Image clipped to a 16:9 frame with object-cover.',
+  },
+  {
+    name: 'AspectRatioLandscapeRatios',
+    title: 'Landscape ratios',
+    description:
+      'QBDS landscape proportions — useful for hero images, cards, and video.',
+  },
+  {
+    name: 'AspectRatioPortraitRatios',
+    title: 'Portrait ratios',
+    description:
+      'Taller frames for vertical photography and mobile-first layouts.',
+  },
+];
+
+export const aspectRatio = createLegacyDemo('aspect-ratio', examples, {
+  AspectRatioDemo: <AspectRatioDemo />,
+  AspectRatioLandscapeRatios: <AspectRatioLandscapeRatios />,
+  AspectRatioPortraitRatios: <AspectRatioPortraitRatios />,
+});

--- a/src/components/registry/registry-sidebar.tsx
+++ b/src/components/registry/registry-sidebar.tsx
@@ -27,6 +27,7 @@ import { getUIPrimitives } from '@/lib/registry';
 const uiItems = getUIPrimitives();
 
 const COMPONENT_GROUPS: { label: string; names: string[] }[] = [
+  { label: 'Layout', names: ['aspect-ratio'] },
   { label: 'Buttons & Toggle', names: ['button', 'toggle'] },
   {
     label: 'Date & Time',

--- a/src/components/ui/aspect-ratio.tsx
+++ b/src/components/ui/aspect-ratio.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import * as AspectRatioPrimitive from '@radix-ui/react-aspect-ratio';
+import type * as React from 'react';
+
+function AspectRatio({
+  ...props
+}: React.ComponentProps<typeof AspectRatioPrimitive.Root>) {
+  return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {...props} />;
+}
+
+export { AspectRatio };


### PR DESCRIPTION
- Introduced a new aspect-ratio component with a description and dependencies in registry.json.
- Added aspect-ratio to the registry sidebar under the Layout category.

<img width="1579" height="950" alt="Screenshot 2026-05-10 at 20 05 55" src="https://github.com/user-attachments/assets/6a217639-a46c-4ff4-89b8-f8a4f9395c3d" />
<img width="1710" height="937" alt="Screenshot 2026-05-10 at 20 05 49" src="https://github.com/user-attachments/assets/daee3eec-26a9-476c-b610-5868e19e6a90" />
