### PR TITLE
InputGroup: delete icon on focus (demo)

### DIFF
--- a/src/app/demo/[name]/index.tsx
+++ b/src/app/demo/[name]/index.tsx
@@ -155,6 +155,7 @@ import {
 } from '@/app/demo/[name]/ui/input';
 import {
   InputGroupBothSides,
+  InputGroupClearableSearch,
   InputGroupDemo,
   InputGroupLeadingIcon,
   InputGroupSizes,
@@ -457,6 +458,7 @@ export const exampleComponentMaps: Record<
     InputGroupBothSides,
     InputGroupSizes,
     InputGroupStatusStates,
+    InputGroupClearableSearch,
     InputGroupStepperSizes,
     InputGroupStepperStates,
   },

--- a/src/app/demo/[name]/index.tsx
+++ b/src/app/demo/[name]/index.tsx
@@ -155,7 +155,7 @@ import {
 } from '@/app/demo/[name]/ui/input';
 import {
   InputGroupBothSides,
-  InputGroupClearableSearch,
+  InputGroupDeleteOnFocus,
   InputGroupDemo,
   InputGroupLeadingIcon,
   InputGroupSizes,
@@ -458,7 +458,7 @@ export const exampleComponentMaps: Record<
     InputGroupBothSides,
     InputGroupSizes,
     InputGroupStatusStates,
-    InputGroupClearableSearch,
+    InputGroupDeleteOnFocus,
     InputGroupStepperSizes,
     InputGroupStepperStates,
   },

--- a/src/app/demo/[name]/ui/input-group-examples.tsx
+++ b/src/app/demo/[name]/ui/input-group-examples.tsx
@@ -264,7 +264,7 @@ export function InputGroupStepperStates() {
   );
 }
 
-/** Trailing delete (Backspace) control while the input group has focus (demo). */
+/** Trailing delete (Backspace) control; always mounted, shown via `:focus-within` (demo). */
 export function InputGroupDeleteOnFocus() {
   const { label, description, gap, iconSize } = inputGroupFieldConfig.default;
   const inlineLabelClass = cn(label, 'mb-[-4px]');
@@ -277,7 +277,6 @@ export function InputGroupDeleteOnFocus() {
     labelClassName: string;
   }>) {
     const [value, setValue] = useState('');
-    const [hasFocusWithin, setHasFocusWithin] = useState(false);
     const groupContainerRef = useRef<HTMLDivElement>(null);
 
     const focusControl = () => {
@@ -289,20 +288,16 @@ export function InputGroupDeleteOnFocus() {
       control?.focus();
     };
 
-    const handleBlurFocusLeavingGroup = (
-      e: React.FocusEvent<HTMLInputElement | HTMLButtonElement>,
-    ) => {
-      const next = e.relatedTarget;
-
-      if (!groupContainerRef.current?.contains(next)) {
-        setHasFocusWithin(false);
-      }
-    };
+    const deleteAddonVisibility = cn(
+      'transition-[opacity,visibility] duration-150',
+      'invisible opacity-0 pointer-events-none',
+      'group-focus-within:visible group-focus-within:opacity-100 group-focus-within:pointer-events-auto',
+    );
 
     return (
       <FieldSet className={`w-[240px] ${gap}`}>
         <FieldTitle className={labelClassName}>Label</FieldTitle>
-        <div ref={groupContainerRef}>
+        <div ref={groupContainerRef} className="group">
           <InputGroup variant={variant}>
             <InputGroupAddon align="inline-start">
               <InputGroupText>
@@ -315,28 +310,25 @@ export function InputGroupDeleteOnFocus() {
               value={value}
               autoComplete="off"
               onChange={e => setValue(e.target.value)}
-              onFocus={() => setHasFocusWithin(true)}
-              onBlur={handleBlurFocusLeavingGroup}
             />
-            {hasFocusWithin ? (
-              <InputGroupAddon align="inline-end">
-                <InputGroupButton
-                  type="button"
-                  size="icon-xs"
-                  variant="ghost"
-                  aria-label="Delete entered text"
-                  className="hover:bg-transparent active:bg-transparent"
-                  onBlur={handleBlurFocusLeavingGroup}
-                  onClick={() => {
-                    setValue('');
-                    focusControl();
-                  }}>
-                  <IconShell size="sm" variant="secondary">
-                    <Backspace aria-hidden />
-                  </IconShell>
-                </InputGroupButton>
-              </InputGroupAddon>
-            ) : null}
+            <InputGroupAddon
+              align="inline-end"
+              className={deleteAddonVisibility}>
+              <InputGroupButton
+                type="button"
+                size="icon-xs"
+                variant="ghost"
+                aria-label="Delete entered text"
+                className="hover:bg-transparent active:bg-transparent"
+                onClick={() => {
+                  setValue('');
+                  focusControl();
+                }}>
+                <IconShell size="sm" variant="secondary">
+                  <Backspace aria-hidden />
+                </IconShell>
+              </InputGroupButton>
+            </InputGroupAddon>
           </InputGroup>
         </div>
         <FieldDescription className={description}>Helper text</FieldDescription>

--- a/src/app/demo/[name]/ui/input-group-examples.tsx
+++ b/src/app/demo/[name]/ui/input-group-examples.tsx
@@ -264,12 +264,12 @@ export function InputGroupStepperStates() {
   );
 }
 
-/** Clear/backspace control shown while the search field is focused (demo). */
-export function InputGroupClearableSearch() {
+/** Trailing delete (Backspace) control while the input group has focus (demo). */
+export function InputGroupDeleteOnFocus() {
   const { label, description, gap, iconSize } = inputGroupFieldConfig.default;
   const inlineLabelClass = cn(label, 'mb-[-4px]');
 
-  function ClearableField({
+  function DeleteOnFocusField({
     variant,
     labelClassName,
   }: Readonly<{
@@ -277,7 +277,7 @@ export function InputGroupClearableSearch() {
     labelClassName: string;
   }>) {
     const [value, setValue] = useState('');
-    const [isFocused, setIsFocused] = useState(false);
+    const [hasFocusWithin, setHasFocusWithin] = useState(false);
     const groupContainerRef = useRef<HTMLDivElement>(null);
 
     const focusControl = () => {
@@ -287,6 +287,16 @@ export function InputGroupClearableSearch() {
         );
 
       control?.focus();
+    };
+
+    const handleBlurFocusLeavingGroup = (
+      e: React.FocusEvent<HTMLInputElement | HTMLButtonElement>,
+    ) => {
+      const next = e.relatedTarget;
+
+      if (!groupContainerRef.current?.contains(next)) {
+        setHasFocusWithin(false);
+      }
     };
 
     return (
@@ -305,18 +315,18 @@ export function InputGroupClearableSearch() {
               value={value}
               autoComplete="off"
               onChange={e => setValue(e.target.value)}
-              onFocus={() => setIsFocused(true)}
-              onBlur={() => setIsFocused(false)}
+              onFocus={() => setHasFocusWithin(true)}
+              onBlur={handleBlurFocusLeavingGroup}
             />
-            {isFocused ? (
+            {hasFocusWithin ? (
               <InputGroupAddon align="inline-end">
                 <InputGroupButton
                   type="button"
                   size="icon-xs"
                   variant="ghost"
-                  aria-label="Clear input"
+                  aria-label="Delete entered text"
                   className="hover:bg-transparent active:bg-transparent"
-                  onMouseDown={e => e.preventDefault()}
+                  onBlur={handleBlurFocusLeavingGroup}
                   onClick={() => {
                     setValue('');
                     focusControl();
@@ -336,8 +346,8 @@ export function InputGroupClearableSearch() {
 
   return (
     <div className="flex flex-col gap-6">
-      <ClearableField variant="default" labelClassName={label} />
-      <ClearableField variant="inline" labelClassName={inlineLabelClass} />
+      <DeleteOnFocusField variant="default" labelClassName={label} />
+      <DeleteOnFocusField variant="inline" labelClassName={inlineLabelClass} />
     </div>
   );
 }

--- a/src/app/demo/[name]/ui/input-group-examples.tsx
+++ b/src/app/demo/[name]/ui/input-group-examples.tsx
@@ -107,7 +107,6 @@ export function InputGroupStepperSizes() {
       {sizes.map(({ size, width }) => (
         <div key={size} className="flex justify-center gap-[200px]">
           <StepperItem size={size} width={width} variant="default" />
-
           <StepperItem size={size} width={width} variant="inline" />
         </div>
       ))}
@@ -338,7 +337,6 @@ export function InputGroupClearableSearch() {
   return (
     <div className="flex flex-col gap-6">
       <ClearableField variant="default" labelClassName={label} />
-
       <ClearableField variant="inline" labelClassName={inlineLabelClass} />
     </div>
   );

--- a/src/app/demo/[name]/ui/input-group-examples.tsx
+++ b/src/app/demo/[name]/ui/input-group-examples.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from 'react';
 
 import { Add } from '@/components/icons/Add';
-import { Cancel } from '@/components/icons/Cancel';
+import { Backspace } from '@/components/icons/Backspace';
 import { Remove } from '@/components/icons/Remove';
 import { Search } from '@/components/icons/Search';
 import { FieldDescription, FieldSet, FieldTitle } from '@/components/ui/field';
@@ -265,10 +265,7 @@ export function InputGroupStepperStates() {
   );
 }
 
-/**
- * Search-style input group with a trailing clear control (QBDS dismiss pattern).
- * The clear icon is visible only while the field is focused and has text.
- */
+/** Clear/backspace control shown while the search field is focused (demo). */
 export function InputGroupClearableSearch() {
   const { label, description, gap, iconSize } = inputGroupFieldConfig.default;
   const inlineLabelClass = cn(label, 'mb-[-4px]');
@@ -283,8 +280,6 @@ export function InputGroupClearableSearch() {
     const [value, setValue] = useState('');
     const [isFocused, setIsFocused] = useState(false);
     const groupContainerRef = useRef<HTMLDivElement>(null);
-
-    const showClear = isFocused && value.length > 0;
 
     const focusControl = () => {
       const control =
@@ -314,35 +309,34 @@ export function InputGroupClearableSearch() {
               onFocus={() => setIsFocused(true)}
               onBlur={() => setIsFocused(false)}
             />
-            {showClear ? (
+            {isFocused ? (
               <InputGroupAddon align="inline-end">
                 <InputGroupButton
                   type="button"
                   size="icon-xs"
                   variant="ghost"
                   aria-label="Clear input"
+                  className="hover:bg-transparent active:bg-transparent"
                   onMouseDown={e => e.preventDefault()}
                   onClick={() => {
                     setValue('');
                     focusControl();
                   }}>
                   <IconShell size="sm" variant="secondary">
-                    <Cancel aria-hidden />
+                    <Backspace aria-hidden />
                   </IconShell>
                 </InputGroupButton>
               </InputGroupAddon>
             ) : null}
           </InputGroup>
         </div>
-        <FieldDescription className={description}>
-          Clear appears while the input is focused and has text.
-        </FieldDescription>
+        <FieldDescription className={description}>Helper text</FieldDescription>
       </FieldSet>
     );
   }
 
   return (
-    <div className="flex gap-6">
+    <div className="flex flex-col gap-6">
       <ClearableField variant="default" labelClassName={label} />
 
       <ClearableField variant="inline" labelClassName={inlineLabelClass} />

--- a/src/app/demo/[name]/ui/input-group-examples.tsx
+++ b/src/app/demo/[name]/ui/input-group-examples.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { Add } from '@/components/icons/Add';
+import { Cancel } from '@/components/icons/Cancel';
 import { Remove } from '@/components/icons/Remove';
+import { Search } from '@/components/icons/Search';
 import { FieldDescription, FieldSet, FieldTitle } from '@/components/ui/field';
 import { IconShell } from '@/components/ui/icon-shell';
 import {
@@ -11,6 +13,7 @@ import {
   InputGroupAddon,
   InputGroupButton,
   InputGroupInput,
+  InputGroupText,
 } from '@/components/ui/input-group';
 import { type DemoExample } from '@/lib/demo-utils';
 import { cn } from '@/lib/utils';
@@ -258,6 +261,91 @@ export function InputGroupStepperStates() {
           </div>
         ),
       )}
+    </div>
+  );
+}
+
+/**
+ * Search-style input group with a trailing clear control (QBDS dismiss pattern).
+ * The clear icon is visible only while the field is focused and has text.
+ */
+export function InputGroupClearableSearch() {
+  const { label, description, gap, iconSize } = inputGroupFieldConfig.default;
+  const inlineLabelClass = cn(label, 'mb-[-4px]');
+
+  function ClearableField({
+    variant,
+    labelClassName,
+  }: Readonly<{
+    variant: 'default' | 'inline';
+    labelClassName: string;
+  }>) {
+    const [value, setValue] = useState('');
+    const [isFocused, setIsFocused] = useState(false);
+    const groupContainerRef = useRef<HTMLDivElement>(null);
+
+    const showClear = isFocused && value.length > 0;
+
+    const focusControl = () => {
+      const control =
+        groupContainerRef.current?.querySelector<HTMLInputElement>(
+          '[data-slot=input-group-control]',
+        );
+
+      control?.focus();
+    };
+
+    return (
+      <FieldSet className={`w-[240px] ${gap}`}>
+        <FieldTitle className={labelClassName}>Label</FieldTitle>
+        <div ref={groupContainerRef}>
+          <InputGroup variant={variant}>
+            <InputGroupAddon align="inline-start">
+              <InputGroupText>
+                <Search className={`icon ${iconSize}`} aria-hidden />
+              </InputGroupText>
+            </InputGroupAddon>
+            <InputGroupInput
+              variant={variant}
+              placeholder="Search…"
+              value={value}
+              autoComplete="off"
+              onChange={e => setValue(e.target.value)}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setIsFocused(false)}
+            />
+            {showClear ? (
+              <InputGroupAddon align="inline-end">
+                <InputGroupButton
+                  type="button"
+                  size="icon-xs"
+                  variant="ghost"
+                  aria-label="Clear input"
+                  onMouseDown={e => e.preventDefault()}
+                  onClick={() => {
+                    setValue('');
+                    focusControl();
+                  }}>
+                  <IconShell size="sm" variant="secondary">
+                    <Cancel aria-hidden />
+                  </IconShell>
+                </InputGroupButton>
+              </InputGroupAddon>
+            ) : null}
+          </InputGroup>
+        </div>
+        <FieldDescription className={description}>
+          Clear appears while the input is focused and has text.
+        </FieldDescription>
+      </FieldSet>
+    );
+  }
+
+  return (
+    <div className="flex gap-6">
+      <ClearableField variant="default" labelClassName={label} />
+
+      <ClearableField variant="inline" labelClassName={inlineLabelClass} />
     </div>
   );
 }

--- a/src/app/demo/[name]/ui/input-group.tsx
+++ b/src/app/demo/[name]/ui/input-group.tsx
@@ -338,9 +338,9 @@ export const examples: DemoExample[] = [
   },
   {
     name: 'InputGroupClearableSearch',
-    title: 'Clear on focus',
+    title: 'Clear icon (focused)',
     description:
-      'Trailing clear icon while the field is focused and has text (default and inline).',
+      'Trailing clear control while the field is focused — default and inline, stacked vertically.',
   },
   {
     name: 'InputGroupStepperSizes',

--- a/src/app/demo/[name]/ui/input-group.tsx
+++ b/src/app/demo/[name]/ui/input-group.tsx
@@ -340,7 +340,7 @@ export const examples: DemoExample[] = [
     name: 'InputGroupDeleteOnFocus',
     title: 'Input with delete icon on focus',
     description:
-      'Trailing delete control (Backspace icon) while the input group is focused — default and inline, stacked vertically.',
+      'Trailing delete control (Backspace icon) shown with CSS :focus-within — control stays mounted for predictable focus; default and inline, stacked vertically.',
   },
   {
     name: 'InputGroupStepperSizes',

--- a/src/app/demo/[name]/ui/input-group.tsx
+++ b/src/app/demo/[name]/ui/input-group.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/lib/utils';
 
 import { inputGroupFieldConfig } from './input-group-config';
 import {
+  InputGroupClearableSearch,
   InputGroupStepperSizes,
   InputGroupStepperStates,
 } from './input-group-examples';
@@ -29,6 +30,7 @@ export { inputGroupFieldConfig } from './input-group-config';
 
 // Re-export client-side components
 export {
+  InputGroupClearableSearch,
   InputGroupStepperSizes,
   InputGroupStepperStates,
 } from './input-group-examples';
@@ -335,6 +337,12 @@ export const examples: DemoExample[] = [
       'Error, warning, and success states with default and inline variants side by side.',
   },
   {
+    name: 'InputGroupClearableSearch',
+    title: 'Clear on focus',
+    description:
+      'Trailing clear icon while the field is focused and has text (default and inline).',
+  },
+  {
     name: 'InputGroupStepperSizes',
     title: 'Stepper Sizes',
     description:
@@ -355,6 +363,7 @@ export const inputGroup = createLegacyDemo('input-group', examples, {
   InputGroupBothSides: <InputGroupBothSides />,
   InputGroupSizes: <InputGroupSizes />,
   InputGroupStatusStates: <InputGroupStatusStates />,
+  InputGroupClearableSearch: <InputGroupClearableSearch />,
   InputGroupStepperSizes: <InputGroupStepperSizes />,
   InputGroupStepperStates: <InputGroupStepperStates />,
 });

--- a/src/app/demo/[name]/ui/input-group.tsx
+++ b/src/app/demo/[name]/ui/input-group.tsx
@@ -19,7 +19,7 @@ import { cn } from '@/lib/utils';
 
 import { inputGroupFieldConfig } from './input-group-config';
 import {
-  InputGroupClearableSearch,
+  InputGroupDeleteOnFocus,
   InputGroupStepperSizes,
   InputGroupStepperStates,
 } from './input-group-examples';
@@ -30,7 +30,7 @@ export { inputGroupFieldConfig } from './input-group-config';
 
 // Re-export client-side components
 export {
-  InputGroupClearableSearch,
+  InputGroupDeleteOnFocus,
   InputGroupStepperSizes,
   InputGroupStepperStates,
 } from './input-group-examples';
@@ -337,10 +337,10 @@ export const examples: DemoExample[] = [
       'Error, warning, and success states with default and inline variants side by side.',
   },
   {
-    name: 'InputGroupClearableSearch',
-    title: 'Clear icon (focused)',
+    name: 'InputGroupDeleteOnFocus',
+    title: 'Input with delete icon on focus',
     description:
-      'Trailing clear control while the field is focused — default and inline, stacked vertically.',
+      'Trailing delete control (Backspace icon) while the input group is focused — default and inline, stacked vertically.',
   },
   {
     name: 'InputGroupStepperSizes',
@@ -363,7 +363,7 @@ export const inputGroup = createLegacyDemo('input-group', examples, {
   InputGroupBothSides: <InputGroupBothSides />,
   InputGroupSizes: <InputGroupSizes />,
   InputGroupStatusStates: <InputGroupStatusStates />,
-  InputGroupClearableSearch: <InputGroupClearableSearch />,
+  InputGroupDeleteOnFocus: <InputGroupDeleteOnFocus />,
   InputGroupStepperSizes: <InputGroupStepperSizes />,
   InputGroupStepperStates: <InputGroupStepperStates />,
 });

--- a/src/components/icons/Backspace.tsx
+++ b/src/components/icons/Backspace.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+interface IconProps extends React.SVGProps<SVGSVGElement> {
+  readonly className?: string;
+}
+
+export function Backspace({ className, ...props }: Readonly<IconProps>) {
+  return (
+    <svg
+      className={cn('', className)}
+      viewBox="0 -960 960 960"
+      fill="currentColor"
+      aria-hidden="true"
+      {...props}>
+      <path d="m560-438 91 91q9 9 21 9t21-9q9-9 9-21.5t-9-21.5l-91-90 90-90q9-9 9-21t-9-21q-9-9-21.5-9t-21.5 9l-89 90-91-91q-9-9-21-9t-21 9q-9 9-9 21.5t9 21.5l91 90-91 90q-9 9-9 21t9 21q9 9 21.5 9t21.5-9l90-90ZM350-160q-14.25 0-27-6.38-12.75-6.37-21-17.62L107-444q-12-15.68-12-35.84Q95-500 107-516l194-260q8.25-11.25 21-17.63 12.75-6.37 27-6.37h472q24.75 0 42.38 17.62Q881-764.75 881-740v520q0 24.75-17.62 42.37Q845.75-160 821-160H350Zm0-60h471v-520H350L155-480l195 260Zm138-260Z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
Added example for Clear icon in InputGroup

<img width="975" height="455" alt="Screenshot 2026-05-10 at 21 12 43" src="https://github.com/user-attachments/assets/e958145a-0ab9-4cd4-a5d0-1875abfe4b65" />
<img width="942" height="436" alt="Screenshot 2026-05-10 at 21 12 40" src="https://github.com/user-attachments/assets/b1c232da-2ede-48e0-9a44-a243082808ed" />
