### PR TITLE
feat(docs): add design tokens reference page

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "registry:build": "npx shadcn@latest build && cp -R registry.json public/r/ && tsx scripts/inject-registry-urls.ts && concurrently --kill-others-on-fail \"npm run generate:api-docs\" \"npm run extract:examples\"",
     "generate:api-docs": "tsx scripts/generate-api-docs.ts",
     "extract:examples": "tsx scripts/extract-examples.ts",
+    "tokens:generate": "tsx scripts/generate-tokens.ts",
     "test:unit": "vitest run",
     "test:watch": "vitest",
     "test": "concurrently --kill-others-on-fail \"npm run test:unit\" \"npm run build\" \"npm run lint\"",

--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -1,0 +1,157 @@
+/**
+ * Tokens generator / validator.
+ *
+ * Source of truth: Figma DS_Themes collection.
+ * Output: public/r/tokens.json — semantic color tokens with descriptions,
+ * scopes, alias chains, HEX (8-digit), and OKLCH values for Light + Dark modes.
+ *
+ * Why this script exists
+ * ----------------------
+ * Figma's Variables REST endpoint is enterprise-tier, so we currently extract
+ * via the Figma Desktop Bridge (an authoring-time JS context running inside
+ * the Figma file). The extraction logic that produced `tokens.json` lives in
+ * the bridge — see `docs/tokens-extraction.md` (or ask the design system team)
+ * for the snippet to re-run when DS_Themes changes.
+ *
+ * This script's job is to:
+ *   1. Validate the shape of `public/r/tokens.json`.
+ *   2. Normalise minor format drift (e.g. trim whitespace, sort categories).
+ *   3. Re-write it deterministically so PR diffs stay clean.
+ *   4. Print summary stats.
+ *
+ * Run it whenever you've pasted in a fresh extraction:
+ *   npm run tokens:generate
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const TOKENS_PATH = path.join(__dirname, '..', 'src', 'data', 'tokens.json');
+
+interface TokenLeaf {
+  alias: string | null;
+  hex: string;
+  oklch: string;
+}
+
+interface Token {
+  name: string;
+  category: string;
+  cssVar: string;
+  description: string;
+  scopes: string[];
+  light: TokenLeaf;
+  dark: TokenLeaf;
+}
+
+interface TokensFile {
+  $schema?: string;
+  name: string;
+  type: string;
+  description: string;
+  source: { figmaCollection: string; generatedFrom: string };
+  generatedAt: string;
+  count: number;
+  tokens: Token[];
+}
+
+const KNOWN_CATEGORIES = [
+  'Surface',
+  'Fill',
+  'Text',
+  'Border',
+  'Status',
+  'StatesLayer-Overlay',
+  'Elevations',
+] as const;
+
+function fail(msg: string): never {
+  console.error(`✗ ${msg}`);
+  process.exit(1);
+}
+
+function validate(data: unknown): asserts data is TokensFile {
+  if (!data || typeof data !== 'object') fail('tokens.json is not an object');
+  const d = data as TokensFile;
+  if (d.type !== 'registry:tokens')
+    fail(`Expected type "registry:tokens", got "${d.type}"`);
+  if (!Array.isArray(d.tokens)) fail('Missing or invalid "tokens" array');
+  if (d.tokens.length === 0) fail('No tokens in file');
+
+  const seenCssVars = new Set<string>();
+  for (const t of d.tokens) {
+    if (!t.name) fail(`Token missing name: ${JSON.stringify(t)}`);
+    if (!t.cssVar?.startsWith('--'))
+      fail(`Invalid cssVar on "${t.name}": ${t.cssVar}`);
+    if (seenCssVars.has(t.cssVar)) fail(`Duplicate cssVar: ${t.cssVar}`);
+    seenCssVars.add(t.cssVar);
+    if (!t.light?.hex || !t.dark?.hex) fail(`Missing hex on "${t.name}"`);
+    if (!t.light?.oklch || !t.dark?.oklch) fail(`Missing oklch on "${t.name}"`);
+    if (!Array.isArray(t.scopes)) fail(`Invalid scopes on "${t.name}"`);
+  }
+}
+
+function normalise(data: TokensFile): TokensFile {
+  const tokens = data.tokens.map(t => ({
+    ...t,
+    description: (t.description || '').trim(),
+    scopes: [...(t.scopes || [])].sort(),
+  }));
+
+  return {
+    ...data,
+    count: tokens.length,
+    tokens,
+  };
+}
+
+function summarise(data: TokensFile): void {
+  const byCategory = new Map<string, number>();
+  let withoutDescription = 0;
+  for (const t of data.tokens) {
+    byCategory.set(t.category, (byCategory.get(t.category) ?? 0) + 1);
+    if (!t.description) withoutDescription++;
+  }
+
+  console.log(`✓ tokens.json valid — ${data.count} tokens`);
+  console.log(`  source: ${data.source.figmaCollection}`);
+  console.log(`  generated: ${data.generatedAt}`);
+  console.log('  by category:');
+  for (const cat of KNOWN_CATEGORIES) {
+    if (byCategory.has(cat))
+      console.log(`    ${cat.padEnd(22)} ${byCategory.get(cat)}`);
+  }
+  for (const [cat, n] of byCategory) {
+    if (!KNOWN_CATEGORIES.includes(cat as (typeof KNOWN_CATEGORIES)[number])) {
+      console.log(`    ${cat.padEnd(22)} ${n}  (unknown category)`);
+    }
+  }
+  if (withoutDescription > 0) {
+    console.log(`  ⚠ ${withoutDescription} token(s) without description`);
+  }
+}
+
+function main(): void {
+  if (!fs.existsSync(TOKENS_PATH)) {
+    fail(`tokens.json not found at ${TOKENS_PATH}`);
+  }
+
+  const raw = fs.readFileSync(TOKENS_PATH, 'utf8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    fail(`tokens.json is not valid JSON: ${(err as Error).message}`);
+  }
+
+  validate(parsed);
+  const normalised = normalise(parsed);
+  fs.writeFileSync(
+    TOKENS_PATH,
+    `${JSON.stringify(normalised, null, 2)}\n`,
+    'utf8',
+  );
+
+  summarise(normalised);
+}
+
+main();

--- a/src/app/(registry)/docs/tokens/page.tsx
+++ b/src/app/(registry)/docs/tokens/page.tsx
@@ -1,0 +1,251 @@
+import { useMemo, useState } from 'react';
+
+import { Input } from '@/components/ui/input';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import tokensData from '@/data/tokens.json';
+
+interface TokenLeaf {
+  alias: string | null;
+  hex: string;
+  oklch: string;
+}
+
+interface Token {
+  name: string;
+  category: string;
+  cssVar: string;
+  description: string;
+  scopes: string[];
+  light: TokenLeaf;
+  dark: TokenLeaf;
+}
+
+interface TokensFile {
+  name: string;
+  type: string;
+  description: string;
+  source: { figmaCollection: string; generatedFrom: string };
+  generatedAt: string;
+  count: number;
+  tokens: Token[];
+}
+
+const data = tokensData as unknown as TokensFile;
+
+const CATEGORY_ORDER = [
+  'Surface',
+  'Fill',
+  'Text',
+  'Border',
+  'Status',
+  'StatesLayer-Overlay',
+  'Elevations',
+];
+
+function tokenAnchor(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+}
+
+function Swatch({ leaf, label }: { leaf: TokenLeaf; label: string }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="paragraph-small-emphasised text-fg-secondary">
+        {label}
+      </span>
+      <div
+        className="border-stroke-tertiary h-12 w-full border"
+        style={{
+          backgroundColor: leaf.hex,
+          backgroundImage:
+            'linear-gradient(45deg, rgba(0,0,0,0.04) 25%, transparent 25%, transparent 75%, rgba(0,0,0,0.04) 75%), linear-gradient(45deg, rgba(0,0,0,0.04) 25%, transparent 25%, transparent 75%, rgba(0,0,0,0.04) 75%)',
+          backgroundSize: '12px 12px',
+          backgroundPosition: '0 0, 6px 6px',
+        }}
+        aria-label={`${label} swatch ${leaf.hex}`}
+      />
+      <dl className="flex flex-col gap-0.5">
+        {leaf.alias && (
+          <div className="flex gap-2">
+            <dt className="paragraph-small-primary text-fg-tertiary w-12 shrink-0">
+              Alias
+            </dt>
+            <dd className="paragraph-small-primary text-fg-secondary truncate">
+              {leaf.alias}
+            </dd>
+          </div>
+        )}
+        <div className="flex gap-2">
+          <dt className="paragraph-small-primary text-fg-tertiary w-12 shrink-0">
+            Hex
+          </dt>
+          <dd className="paragraph-small-primary text-fg-secondary font-mono">
+            {leaf.hex}
+          </dd>
+        </div>
+        <div className="flex gap-2">
+          <dt className="paragraph-small-primary text-fg-tertiary w-12 shrink-0">
+            OKLCH
+          </dt>
+          <dd className="paragraph-small-primary text-fg-secondary truncate font-mono">
+            {leaf.oklch}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function TokenCard({ token }: { token: Token }) {
+  return (
+    <div
+      id={tokenAnchor(token.name)}
+      className="border-stroke-tertiary bg-surface-bg-primary flex scroll-mt-24 flex-col gap-4 border p-4">
+      <div className="flex flex-col gap-1">
+        <h3 className="paragraph-large-primary text-fg-primary font-semibold">
+          {token.name}
+        </h3>
+        <code className="paragraph-small-primary text-fg-secondary font-mono">
+          {token.cssVar}
+        </code>
+      </div>
+
+      {token.description && (
+        <p className="paragraph-regular-primary text-fg-secondary">
+          {token.description}
+        </p>
+      )}
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Swatch leaf={token.light} label="Light" />
+        <Swatch leaf={token.dark} label="Dark" />
+      </div>
+
+      {token.scopes.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 pt-1">
+          {token.scopes.map(scope => (
+            <span
+              key={scope}
+              className="border-stroke-tertiary text-fg-secondary paragraph-small-primary border px-2 py-0.5 font-mono">
+              {scope}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function TokensPage() {
+  const [query, setQuery] = useState('');
+  const [activeCategory, setActiveCategory] = useState<string>('all');
+
+  const categories = useMemo(() => {
+    const seen = new Set(data.tokens.map(t => t.category));
+    const ordered = CATEGORY_ORDER.filter(c => seen.has(c));
+    const extras = [...seen].filter(c => !ordered.includes(c)).sort();
+    return [...ordered, ...extras];
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return data.tokens.filter(t => {
+      if (activeCategory !== 'all' && t.category !== activeCategory)
+        return false;
+      if (!q) return true;
+      return (
+        t.name.toLowerCase().includes(q) ||
+        t.cssVar.toLowerCase().includes(q) ||
+        t.description.toLowerCase().includes(q) ||
+        t.scopes.some(s => s.toLowerCase().includes(q))
+      );
+    });
+  }, [query, activeCategory]);
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, Token[]>();
+    for (const t of filtered) {
+      if (!map.has(t.category)) map.set(t.category, []);
+      map.get(t.category)?.push(t);
+    }
+    return [...map.entries()].sort(([a], [b]) => {
+      const ai = CATEGORY_ORDER.indexOf(a);
+      const bi = CATEGORY_ORDER.indexOf(b);
+      if (ai === -1 && bi === -1) return a.localeCompare(b);
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    });
+  }, [filtered]);
+
+  return (
+    <main className="bg-surface-bg-base min-h-screen w-full p-5 md:p-10">
+      <div className="mx-auto w-full max-w-[1200px]">
+        <div className="flex flex-col gap-8">
+          <div className="flex flex-col gap-2">
+            <h1 className="headings-h1-regular text-fg-primary">
+              Design Tokens
+            </h1>
+            <p className="paragraph-large-primary text-fg-secondary">
+              Semantic color tokens from the QBDS DS_Themes collection. Each
+              token resolves to a Light and Dark mode value via aliases on the
+              Mist / Slate / status primitive ramps.
+            </p>
+            <p className="paragraph-small-primary text-fg-tertiary">
+              Source: {data.source.figmaCollection} · {data.count} tokens ·
+              generated {new Date(data.generatedAt).toLocaleDateString()}
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Input
+              type="search"
+              placeholder="Search by name, CSS variable, description, or scope…"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              className="sm:max-w-md"
+              aria-label="Search tokens"
+            />
+          </div>
+
+          <Tabs value={activeCategory} onValueChange={setActiveCategory}>
+            <TabsList className="flex flex-wrap">
+              <TabsTrigger value="all">All</TabsTrigger>
+              {categories.map(cat => (
+                <TabsTrigger key={cat} value={cat}>
+                  {cat}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+            <TabsContent value={activeCategory} className="pt-4">
+              {grouped.length === 0 && (
+                <p className="paragraph-regular-primary text-fg-secondary">
+                  No tokens match your search.
+                </p>
+              )}
+              <div className="flex flex-col gap-10">
+                {grouped.map(([category, tokens]) => (
+                  <section
+                    key={category}
+                    id={`category-${tokenAnchor(category)}`}
+                    className="flex flex-col gap-4">
+                    <h2 className="headings-h3-semibold text-fg-primary">
+                      {category}
+                      <span className="paragraph-regular-primary text-fg-tertiary ml-2 font-normal">
+                        ({tokens.length})
+                      </span>
+                    </h2>
+                    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                      {tokens.map(t => (
+                        <TokenCard key={t.cssVar} token={t} />
+                      ))}
+                    </div>
+                  </section>
+                ))}
+              </div>
+            </TabsContent>
+          </Tabs>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/registry/registry-sidebar.tsx
+++ b/src/components/registry/registry-sidebar.tsx
@@ -71,6 +71,7 @@ const sortedComponentEntries: SidebarEntry[] = [
 export const sectionItems = [
   { title: 'Introduction', path: '/' },
   { title: 'Components', path: '/components' },
+  { title: 'Tokens', path: '/tokens' },
   { title: 'Installation', path: '/installation' },
 ];
 

--- a/src/data/tokens.json
+++ b/src/data/tokens.json
@@ -1,0 +1,1562 @@
+{
+  "$schema": "./tokens.schema.json",
+  "name": "tokens",
+  "type": "registry:tokens",
+  "description": "QBDS DS_Themes semantic color tokens with descriptions, scopes, hex, and OKLCH values for Light and Dark modes.",
+  "source": {
+    "figmaCollection": "DS_Themes",
+    "generatedFrom": "Figma DS_Themes (semantic) collection"
+  },
+  "generatedAt": "2026-05-11T07:37:02.953Z",
+  "count": 79,
+  "tokens": [
+    {
+      "name": "Text/Primary",
+      "category": "Text",
+      "cssVar": "--text-primary",
+      "description": "body copy; data entries; Headers;",
+      "scopes": [
+        "TEXT_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-88",
+        "hex": "#141721e0",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.88)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-88",
+        "hex": "#ffffffe0",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.88)"
+      }
+    },
+    {
+      "name": "Text/Secondary",
+      "category": "Text",
+      "cssVar": "--text-secondary",
+      "description": "secondary text; additional descriptors; Input labels; data labels;",
+      "scopes": [
+        "TEXT_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-60",
+        "hex": "#14172199",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.60)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-60",
+        "hex": "#ffffff99",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.60)"
+      }
+    },
+    {
+      "name": "Text/Tertiary",
+      "category": "Text",
+      "cssVar": "--text-tertiary",
+      "description": "placeholder; hint text; tertiary content;",
+      "scopes": [
+        "TEXT_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-50",
+        "hex": "#14172180",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.50)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-50",
+        "hex": "#ffffff80",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.50)"
+      }
+    },
+    {
+      "name": "Text/Disabled",
+      "category": "Text",
+      "cssVar": "--text-disabled",
+      "description": "disabled content;",
+      "scopes": [
+        "TEXT_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-38",
+        "hex": "#14172161",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.38)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-38",
+        "hex": "#ffffff61",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.38)"
+      }
+    },
+    {
+      "name": "Text/Primary-Inverse",
+      "category": "Text",
+      "cssVar": "--text-primary-inverse",
+      "description": "body copy; data entries; headers; on high contrast backgrounds/elements",
+      "scopes": [
+        "TEXT_FILL"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-88",
+        "hex": "#ffffffe0",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.88)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-88",
+        "hex": "#141721e0",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.88)"
+      }
+    },
+    {
+      "name": "Text/Secondary-Inverse",
+      "category": "Text",
+      "cssVar": "--text-secondary-inverse",
+      "description": "secondary text; additional descriptors; Input labels; data labels; body copy; data entries; headers; on high contrast backgrounds or elements",
+      "scopes": [
+        "TEXT_FILL"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-60",
+        "hex": "#ffffff99",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.60)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-60",
+        "hex": "#14172199",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.60)"
+      }
+    },
+    {
+      "name": "Text/Tertiary-Inverse",
+      "category": "Text",
+      "cssVar": "--text-tertiary-inverse",
+      "description": "placeholder; hint text; tertiary content; on high contrast backgrounds or elements",
+      "scopes": [
+        "TEXT_FILL"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-50",
+        "hex": "#ffffff80",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.50)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-50",
+        "hex": "#14172180",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.50)"
+      }
+    },
+    {
+      "name": "Text/Disabled-Inverse",
+      "category": "Text",
+      "cssVar": "--text-disabled-inverse",
+      "description": "disabled content; on high contrast backgrounds or elements",
+      "scopes": [
+        "TEXT_FILL"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-38",
+        "hex": "#ffffff61",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.38)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-38",
+        "hex": "#14172161",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.38)"
+      }
+    },
+    {
+      "name": "Text/Success",
+      "category": "Text",
+      "cssVar": "--text-success",
+      "description": "status success; AA compliant: 4.5:1",
+      "scopes": [
+        "TEXT_FILL"
+      ],
+      "light": {
+        "alias": "green/700",
+        "hex": "#15803dff",
+        "oklch": "oklch(52.73% 0.1371 150.07)"
+      },
+      "dark": {
+        "alias": "green/400",
+        "hex": "#4ade80ff",
+        "oklch": "oklch(80.03% 0.1821 151.71)"
+      }
+    },
+    {
+      "name": "Text/Error",
+      "category": "Text",
+      "cssVar": "--text-error",
+      "description": "status error; AA compliant: 4.5:1",
+      "scopes": [
+        "TEXT_FILL"
+      ],
+      "light": {
+        "alias": "red/700",
+        "hex": "#b91c1cff",
+        "oklch": "oklch(50.54% 0.1905 27.52)"
+      },
+      "dark": {
+        "alias": "red/400",
+        "hex": "#f87171ff",
+        "oklch": "oklch(71.06% 0.1661 22.22)"
+      }
+    },
+    {
+      "name": "Text/Warning",
+      "category": "Text",
+      "cssVar": "--text-warning",
+      "description": "status error; AA compliant: 4.5:1",
+      "scopes": [
+        "TEXT_FILL"
+      ],
+      "light": {
+        "alias": "amber/700",
+        "hex": "#b45309ff",
+        "oklch": "oklch(55.53% 0.1455 49.00)"
+      },
+      "dark": {
+        "alias": "amber/400",
+        "hex": "#fbbf24ff",
+        "oklch": "oklch(83.69% 0.1644 84.43)"
+      }
+    },
+    {
+      "name": "Text/Information",
+      "category": "Text",
+      "cssVar": "--text-information",
+      "description": "status generic info; AA compliant: 4.5:1",
+      "scopes": [
+        "TEXT_FILL"
+      ],
+      "light": {
+        "alias": "cyan/700",
+        "hex": "#0e7490ff",
+        "oklch": "oklch(51.98% 0.0936 223.13)"
+      },
+      "dark": {
+        "alias": "sky/400",
+        "hex": "#38bdf8ff",
+        "oklch": "oklch(75.35% 0.1390 232.66)"
+      }
+    },
+    {
+      "name": "Border/Divider",
+      "category": "Border",
+      "cssVar": "--border-divider",
+      "description": "very light separators; use for list items; button groupings;",
+      "scopes": [
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-10",
+        "hex": "#1417211a",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.10)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-8",
+        "hex": "#ffffff14",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.08)"
+      }
+    },
+    {
+      "name": "Border/Tertiary",
+      "category": "Border",
+      "cssVar": "--border-tertiary",
+      "description": "subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; disabled state for toggle items; badges; switches;",
+      "scopes": [
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-16",
+        "hex": "#14172129",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.16)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-16",
+        "hex": "#ffffff29",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.16)"
+      }
+    },
+    {
+      "name": "Border/Tertiary-Hover",
+      "category": "Border",
+      "cssVar": "--border-tertiary-hover",
+      "description": "hover state – subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; toggle items; badges; switches;",
+      "scopes": [
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-38",
+        "hex": "#14172161",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.38)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-38",
+        "hex": "#ffffff61",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.38)"
+      }
+    },
+    {
+      "name": "Border/Secondary",
+      "category": "Border",
+      "cssVar": "--border-secondary",
+      "description": "medium contrast border – switches; tags; toggle elements; emphasised states",
+      "scopes": [
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-24",
+        "hex": "#1417213d",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.24)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-38",
+        "hex": "#ffffff61",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.38)"
+      }
+    },
+    {
+      "name": "Border/Primary",
+      "category": "Border",
+      "cssVar": "--border-primary",
+      "description": "high contrast border – emphasised states",
+      "scopes": [
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-38",
+        "hex": "#14172161",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.38)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-60",
+        "hex": "#ffffff99",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.60)"
+      }
+    },
+    {
+      "name": "Border/Active",
+      "category": "Border",
+      "cssVar": "--border-active",
+      "description": "active state - for tabs; tags; inline inputs; switches; buttons; toggles; slider; active content states",
+      "scopes": [
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "Slate/950",
+        "hex": "#10121bff",
+        "oklch": "oklch(18.46% 0.0187 274.71)"
+      },
+      "dark": {
+        "alias": "Mist/50",
+        "hex": "#ffffffff",
+        "oklch": "oklch(100.00% 0.0000 0.00)"
+      }
+    },
+    {
+      "name": "Border/Divider-Inverse",
+      "category": "Border",
+      "cssVar": "--border-divider-inverse",
+      "description": "very light separators; use for list items; button groupings; high contrast, theme switch friendly",
+      "scopes": [
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-8",
+        "hex": "#ffffff14",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.08)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-8",
+        "hex": "#14172114",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.08)"
+      }
+    },
+    {
+      "name": "Border/Status/Focus",
+      "category": "Border",
+      "cssVar": "--border-status-focus",
+      "description": "active/focus state for ui elements",
+      "scopes": [
+        "EFFECT_COLOR",
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "sky/400",
+        "hex": "#38bdf8ff",
+        "oklch": "oklch(75.35% 0.1390 232.66)"
+      },
+      "dark": {
+        "alias": "sky/400",
+        "hex": "#38bdf8ff",
+        "oklch": "oklch(75.35% 0.1390 232.66)"
+      }
+    },
+    {
+      "name": "Border/Status/Mono",
+      "category": "Border",
+      "cssVar": "--border-status-mono",
+      "description": "active/focus state variant for ui elements",
+      "scopes": [
+        "EFFECT_COLOR",
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-24",
+        "hex": "#1417213d",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.24)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-24",
+        "hex": "#ffffff3d",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.24)"
+      }
+    },
+    {
+      "name": "Border/Status/Error",
+      "category": "Border",
+      "cssVar": "--border-status-error",
+      "description": "active/focus state variant for ui elements - tags, badges, indicators, cards/panels",
+      "scopes": [
+        "EFFECT_COLOR",
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "red/700",
+        "hex": "#b91c1cff",
+        "oklch": "oklch(50.54% 0.1905 27.52)"
+      },
+      "dark": {
+        "alias": "red/400",
+        "hex": "#f87171ff",
+        "oklch": "oklch(71.06% 0.1661 22.22)"
+      }
+    },
+    {
+      "name": "Border/Status/Success",
+      "category": "Border",
+      "cssVar": "--border-status-success",
+      "description": "active/focus state variant for ui elements - tags, badges, indicators, cards/panels",
+      "scopes": [
+        "EFFECT_COLOR",
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "green/600",
+        "hex": "#16a34aff",
+        "oklch": "oklch(62.71% 0.1699 149.21)"
+      },
+      "dark": {
+        "alias": "green/400",
+        "hex": "#4ade80ff",
+        "oklch": "oklch(80.03% 0.1821 151.71)"
+      }
+    },
+    {
+      "name": "Border/Status/Warning",
+      "category": "Border",
+      "cssVar": "--border-status-warning",
+      "description": "active/focus state variant for ui elements - tags, badges, indicators, cards/panels",
+      "scopes": [
+        "EFFECT_COLOR",
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "amber/500",
+        "hex": "#f59e0bff",
+        "oklch": "oklch(76.86% 0.1647 70.08)"
+      },
+      "dark": {
+        "alias": "amber/400",
+        "hex": "#fbbf24ff",
+        "oklch": "oklch(83.69% 0.1644 84.43)"
+      }
+    },
+    {
+      "name": "Border/Tertiary-Inverse",
+      "category": "Border",
+      "cssVar": "--border-tertiary-inverse",
+      "description": "subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; disabled state toggle items; switches; theme switch friendly",
+      "scopes": [
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-16",
+        "hex": "#ffffff29",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.16)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-16",
+        "hex": "#14172129",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.16)"
+      }
+    },
+    {
+      "name": "Border/Tertiary-Hover-Inverse",
+      "category": "Border",
+      "cssVar": "--border-tertiary-hover-inverse",
+      "description": "hover state – subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; disabled state for toggle items; badges; switches;  theme switching friendly",
+      "scopes": [
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-38",
+        "hex": "#ffffff61",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.38)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-38",
+        "hex": "#14172161",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.38)"
+      }
+    },
+    {
+      "name": "Border/Secondary-Inverse",
+      "category": "Border",
+      "cssVar": "--border-secondary-inverse",
+      "description": "medium contrast border; switches, tags; toggle elements, emphasised states - high contrast instances, theme switching friendly",
+      "scopes": [
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-38",
+        "hex": "#ffffff61",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.38)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-38",
+        "hex": "#14172161",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.38)"
+      }
+    },
+    {
+      "name": "Border/Primary-Inverse",
+      "category": "Border",
+      "cssVar": "--border-primary-inverse",
+      "description": "stronger border; emphasised states - high contrast instances, theme switching friendly",
+      "scopes": [
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-60",
+        "hex": "#ffffff99",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.60)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-60",
+        "hex": "#14172199",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.60)"
+      }
+    },
+    {
+      "name": "Border/Active-Inverse",
+      "category": "Border",
+      "cssVar": "--border-active-inverse",
+      "description": "active state - for tabs; tags; inline inputs; buttons; switches; toggles; slider; active content states - high contrast or theme switch friendly",
+      "scopes": [
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "Mist/50",
+        "hex": "#ffffffff",
+        "oklch": "oklch(100.00% 0.0000 0.00)"
+      },
+      "dark": {
+        "alias": "Slate/950",
+        "hex": "#10121bff",
+        "oklch": "oklch(18.46% 0.0187 274.71)"
+      }
+    },
+    {
+      "name": "Fill/Content/Primary",
+      "category": "Fill",
+      "cssVar": "--fill-content-primary",
+      "description": "buttons, tooltips background primary; high contrast/emphasied items; accents",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-88",
+        "hex": "#141721e0",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.88)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-88",
+        "hex": "#ffffffe0",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.88)"
+      }
+    },
+    {
+      "name": "Fill/Content/Secondary",
+      "category": "Fill",
+      "cssVar": "--fill-content-secondary",
+      "description": "medium contrast accent backgrounds",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-60",
+        "hex": "#14172199",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.60)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-60",
+        "hex": "#ffffff99",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.60)"
+      }
+    },
+    {
+      "name": "Fill/Content/Tertiary",
+      "category": "Fill",
+      "cssVar": "--fill-content-tertiary",
+      "description": "medium colour contrast overlay on high contrast items, ui-shells/panels, tiles",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-16",
+        "hex": "#14172129",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.16)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-16",
+        "hex": "#ffffff29",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.16)"
+      }
+    },
+    {
+      "name": "Fill/Content/Disabled",
+      "category": "Fill",
+      "cssVar": "--fill-content-disabled",
+      "description": "any fill for disabled elements on Fill/Muted or Surface tokens",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-38",
+        "hex": "#14172161",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.38)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-38",
+        "hex": "#ffffff61",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.38)"
+      }
+    },
+    {
+      "name": "Fill/Content/Active",
+      "category": "Fill",
+      "cssVar": "--fill-content-active",
+      "description": "active state fill for icons, buttons backgrounds, tags, switches, toggle items, sliders",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Slate/950",
+        "hex": "#10121bff",
+        "oklch": "oklch(18.46% 0.0187 274.71)"
+      },
+      "dark": {
+        "alias": "Mist/50",
+        "hex": "#ffffffff",
+        "oklch": "oklch(100.00% 0.0000 0.00)"
+      }
+    },
+    {
+      "name": "Fill/Content/Primary-Inverse",
+      "category": "Fill",
+      "cssVar": "--fill-content-primary-inverse",
+      "description": "buttons, tooltips background primary; high contrast/emphasied items; accents - theme switch friendly",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-88",
+        "hex": "#ffffffe0",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.88)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-88",
+        "hex": "#141721e0",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.88)"
+      }
+    },
+    {
+      "name": "Fill/Content/Secondary-Inverse",
+      "category": "Fill",
+      "cssVar": "--fill-content-secondary-inverse",
+      "description": "medium contrast accent backgrounds; theme switch friendly",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-60",
+        "hex": "#ffffff99",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.60)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-60",
+        "hex": "#14172199",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.60)"
+      }
+    },
+    {
+      "name": "Fill/Content/Tertiary-Inverse",
+      "category": "Fill",
+      "cssVar": "--fill-content-tertiary-inverse",
+      "description": "medium colour contrast overlay on high contrast items, ui-shells/panels, tiles",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-16",
+        "hex": "#ffffff29",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.16)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-24",
+        "hex": "#1417213d",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.24)"
+      }
+    },
+    {
+      "name": "Fill/Content/Disabled-Inverse",
+      "category": "Fill",
+      "cssVar": "--fill-content-disabled-inverse",
+      "description": "any fill for disabled elements on Fill/Muted or Surface tokens; theme switch friendly",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-38",
+        "hex": "#ffffff61",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.38)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-38",
+        "hex": "#14172161",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.38)"
+      }
+    },
+    {
+      "name": "Fill/Content/Active-Inverse",
+      "category": "Fill",
+      "cssVar": "--fill-content-active-inverse",
+      "description": "active state fill for icons, buttons backgrounds, tags, switches, toggle items, sliders; theme switch friendly",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist/50",
+        "hex": "#ffffffff",
+        "oklch": "oklch(100.00% 0.0000 0.00)"
+      },
+      "dark": {
+        "alias": "Slate/950",
+        "hex": "#10121bff",
+        "oklch": "oklch(18.46% 0.0187 274.71)"
+      }
+    },
+    {
+      "name": "Fill/Content/StepMarkers+Track",
+      "category": "Fill",
+      "cssVar": "--fill-content-stepmarkerstrack",
+      "description": "",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL",
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "Mist/900",
+        "hex": "#d3d6d9ff",
+        "oklch": "oklch(87.46% 0.0053 247.88)"
+      },
+      "dark": {
+        "alias": "Slate/100",
+        "hex": "#333640ff",
+        "oklch": "oklch(33.40% 0.0181 272.20)"
+      }
+    },
+    {
+      "name": "Fill/onSurface/bg-ui1",
+      "category": "Fill",
+      "cssVar": "--fill-onsurface-bg-ui1",
+      "description": "solid used for high contrast tiles, ui containers backgrounds that sit on surface tokens",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist/100",
+        "hex": "#fafafbff",
+        "oklch": "oklch(98.54% 0.0013 286.38)"
+      },
+      "dark": {
+        "alias": "Slate/600",
+        "hex": "#1f222eff",
+        "oklch": "oklch(25.44% 0.0231 273.73)"
+      }
+    },
+    {
+      "name": "Fill/onSurface/bg-ui2",
+      "category": "Fill",
+      "cssVar": "--fill-onsurface-bg-ui2",
+      "description": "solid used for Avatar mono backgrounds, medium contrast tiles, ui containers backgrounds that sit on Surface tokens",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist/300",
+        "hex": "#f2f3f4ff",
+        "oklch": "oklch(96.37% 0.0017 247.84)"
+      },
+      "dark": {
+        "alias": "Slate/300",
+        "hex": "#2b2e39ff",
+        "oklch": "oklch(30.29% 0.0203 273.16)"
+      }
+    },
+    {
+      "name": "Fill/onSurface/bg-ui3",
+      "category": "Fill",
+      "cssVar": "--fill-onsurface-bg-ui3",
+      "description": "solid ui backgrounds,  field inputs, notification, toast and sonner panels that sit on Surface tokens",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist/200",
+        "hex": "#f5f6f6ff",
+        "oklch": "oklch(97.24% 0.0011 197.14)"
+      },
+      "dark": {
+        "alias": "Slate/400",
+        "hex": "#272a35ff",
+        "oklch": "oklch(28.68% 0.0206 273.08)"
+      }
+    },
+    {
+      "name": "Fill/onSurface/Muted",
+      "category": "Fill",
+      "cssVar": "--fill-onsurface-muted",
+      "description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-8",
+        "hex": "#14172114",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.08)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-8",
+        "hex": "#ffffff14",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.08)"
+      }
+    },
+    {
+      "name": "Fill/onSurface/Subtle",
+      "category": "Fill",
+      "cssVar": "--fill-onsurface-subtle",
+      "description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-6",
+        "hex": "#1417210f",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.06)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-6",
+        "hex": "#ffffff0f",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.06)"
+      }
+    },
+    {
+      "name": "Fill/onSurface/Muted-Inverse",
+      "category": "Fill",
+      "cssVar": "--fill-onsurface-muted-inverse",
+      "description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills; theme switch friendly",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-8",
+        "hex": "#ffffff14",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.08)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-8",
+        "hex": "#14172114",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.08)"
+      }
+    },
+    {
+      "name": "Fill/onSurface/Subtle -Inverse",
+      "category": "Fill",
+      "cssVar": "--fill-onsurface-subtle-inverse",
+      "description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-6",
+        "hex": "#ffffff0f",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.06)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-6",
+        "hex": "#1417210f",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.06)"
+      }
+    },
+    {
+      "name": "Surface/Primary",
+      "category": "Surface",
+      "cssVar": "--surface-primary",
+      "description": "primary page/ui shell panel background",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist/50",
+        "hex": "#ffffffff",
+        "oklch": "oklch(100.00% 0.0000 0.00)"
+      },
+      "dark": {
+        "alias": "Slate/800",
+        "hex": "#181b26ff",
+        "oklch": "oklch(22.43% 0.0220 272.68)"
+      }
+    },
+    {
+      "name": "Surface/Secondary",
+      "category": "Surface",
+      "cssVar": "--surface-secondary",
+      "description": "secondary page/ui shell panel background - use for side panels",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist/400",
+        "hex": "#ebedeeff",
+        "oklch": "oklch(94.49% 0.0025 228.79)"
+      },
+      "dark": {
+        "alias": "Slate/700",
+        "hex": "#1b1e2aff",
+        "oklch": "oklch(23.76% 0.0235 273.59)"
+      }
+    },
+    {
+      "name": "Surface/Tertiary",
+      "category": "Surface",
+      "cssVar": "--surface-tertiary",
+      "description": "optional usage - tertiary background/ui shell panels when Primary or Secondary already used.",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist/500",
+        "hex": "#e6e8eaff",
+        "oklch": "oklch(93.00% 0.0035 247.86)"
+      },
+      "dark": {
+        "alias": "Slate/500",
+        "hex": "#232632ff",
+        "oklch": "oklch(27.10% 0.0227 273.84)"
+      }
+    },
+    {
+      "name": "Surface/Base",
+      "category": "Surface",
+      "cssVar": "--surface-base",
+      "description": "high contrast surface - used to create negative space/separator between primary or secondary backgrounds/ui shells. could be used for high contrast canvas",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist/100",
+        "hex": "#fafafbff",
+        "oklch": "oklch(98.54% 0.0013 286.38)"
+      },
+      "dark": {
+        "alias": "Slate/900",
+        "hex": "#141721ff",
+        "oklch": "oklch(20.64% 0.0205 271.56)"
+      }
+    },
+    {
+      "name": "Status/Success",
+      "category": "Status",
+      "cssVar": "--status-success",
+      "description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "green/600",
+        "hex": "#16a34aff",
+        "oklch": "oklch(62.71% 0.1699 149.21)"
+      },
+      "dark": {
+        "alias": "green/400",
+        "hex": "#4ade80ff",
+        "oklch": "oklch(80.03% 0.1821 151.71)"
+      }
+    },
+    {
+      "name": "Status/Error",
+      "category": "Status",
+      "cssVar": "--status-error",
+      "description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL",
+        "STROKE_COLOR"
+      ],
+      "light": {
+        "alias": "red/600",
+        "hex": "#dc2626ff",
+        "oklch": "oklch(57.71% 0.2152 27.33)"
+      },
+      "dark": {
+        "alias": "red/400",
+        "hex": "#f87171ff",
+        "oklch": "oklch(71.06% 0.1661 22.22)"
+      }
+    },
+    {
+      "name": "Status/Warning",
+      "category": "Status",
+      "cssVar": "--status-warning",
+      "description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "amber/600",
+        "hex": "#d97706ff",
+        "oklch": "oklch(66.58% 0.1574 58.32)"
+      },
+      "dark": {
+        "alias": "amber/400",
+        "hex": "#fbbf24ff",
+        "oklch": "oklch(83.69% 0.1644 84.43)"
+      }
+    },
+    {
+      "name": "Status/Information",
+      "category": "Status",
+      "cssVar": "--status-information",
+      "description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "cyan/600",
+        "hex": "#0891b2ff",
+        "oklch": "oklch(60.89% 0.1109 221.72)"
+      },
+      "dark": {
+        "alias": "cyan/400",
+        "hex": "#22d3eeff",
+        "oklch": "oklch(79.71% 0.1339 211.53)"
+      }
+    },
+    {
+      "name": "Status/Success-Inverse",
+      "category": "Status",
+      "cssVar": "--status-success-inverse",
+      "description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant - high contrast instances, theme switch friendly.",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "green/400",
+        "hex": "#4ade80ff",
+        "oklch": "oklch(80.03% 0.1821 151.71)"
+      },
+      "dark": {
+        "alias": "green/600",
+        "hex": "#16a34aff",
+        "oklch": "oklch(62.71% 0.1699 149.21)"
+      }
+    },
+    {
+      "name": "Status/Error-Inverse",
+      "category": "Status",
+      "cssVar": "--status-error-inverse",
+      "description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant Fill/Border only, for all status modes instances; except text - not contrast AA compliant; - high contrast instances, theme switch friendly.",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "red/400",
+        "hex": "#f87171ff",
+        "oklch": "oklch(71.06% 0.1661 22.22)"
+      },
+      "dark": {
+        "alias": "red/600",
+        "hex": "#dc2626ff",
+        "oklch": "oklch(57.71% 0.2152 27.33)"
+      }
+    },
+    {
+      "name": "Status/Warning-Inverse",
+      "category": "Status",
+      "cssVar": "--status-warning-inverse",
+      "description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant; - high contrast instances, theme switch friendly.",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "amber/400",
+        "hex": "#fbbf24ff",
+        "oklch": "oklch(83.69% 0.1644 84.43)"
+      },
+      "dark": {
+        "alias": "amber/600",
+        "hex": "#d97706ff",
+        "oklch": "oklch(66.58% 0.1574 58.32)"
+      }
+    },
+    {
+      "name": "Status/Information-Inverse",
+      "category": "Status",
+      "cssVar": "--status-information-inverse",
+      "description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant; - high contrast instances, theme switch friendly.",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "sky/400",
+        "hex": "#38bdf8ff",
+        "oklch": "oklch(75.35% 0.1390 232.66)"
+      },
+      "dark": {
+        "alias": "sky/400",
+        "hex": "#38bdf8ff",
+        "oklch": "oklch(75.35% 0.1390 232.66)"
+      }
+    },
+    {
+      "name": "StatesLayer-Overlay/Enabled",
+      "category": "StatesLayer-Overlay",
+      "cssVar": "--stateslayer-overlay-enabled",
+      "description": "Enabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-0",
+        "hex": "#14172100",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.00)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-0☼",
+        "hex": "#ffffff00",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.00)"
+      }
+    },
+    {
+      "name": "StatesLayer-Overlay/Hover",
+      "category": "StatesLayer-Overlay",
+      "cssVar": "--stateslayer-overlay-hover",
+      "description": "Hover State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-8",
+        "hex": "#14172114",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.08)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-8",
+        "hex": "#ffffff14",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.08)"
+      }
+    },
+    {
+      "name": "StatesLayer-Overlay/Pressed",
+      "category": "StatesLayer-Overlay",
+      "cssVar": "--stateslayer-overlay-pressed",
+      "description": "Pressed State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-16",
+        "hex": "#14172129",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.16)"
+      },
+      "dark": {
+        "alias": "Mist 50/opacity-16",
+        "hex": "#ffffff29",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.16)"
+      }
+    },
+    {
+      "name": "StatesLayer-Overlay/Active",
+      "category": "StatesLayer-Overlay",
+      "cssVar": "--stateslayer-overlay-active",
+      "description": "Active State overlay for entire ui item - used in most components; buttons, inputs, menus, pickers, text area, tags, list items",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Slate/950",
+        "hex": "#10121bff",
+        "oklch": "oklch(18.46% 0.0187 274.71)"
+      },
+      "dark": {
+        "alias": "Mist/50",
+        "hex": "#ffffffff",
+        "oklch": "oklch(100.00% 0.0000 0.00)"
+      }
+    },
+    {
+      "name": "StatesLayer-Overlay/Disabled",
+      "category": "StatesLayer-Overlay",
+      "cssVar": "--stateslayer-overlay-disabled",
+      "description": "Disabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-8",
+        "hex": "#14172114",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.08)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-38",
+        "hex": "#14172161",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.38)"
+      }
+    },
+    {
+      "name": "StatesLayer-Overlay/Enabled_Inverse",
+      "category": "StatesLayer-Overlay",
+      "cssVar": "--stateslayer-overlay-enabled-inverse",
+      "description": "Enabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items - on high contrast/accent content",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-0☼",
+        "hex": "#ffffff00",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.00)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-0",
+        "hex": "#14172100",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.00)"
+      }
+    },
+    {
+      "name": "StatesLayer-Overlay/Hover-Inverse",
+      "category": "StatesLayer-Overlay",
+      "cssVar": "--stateslayer-overlay-hover-inverse",
+      "description": "Hover State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items –on high/accent contrast elements",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-8",
+        "hex": "#ffffff14",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.08)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-8",
+        "hex": "#14172114",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.08)"
+      }
+    },
+    {
+      "name": "StatesLayer-Overlay/Pressed-Inverse",
+      "category": "StatesLayer-Overlay",
+      "cssVar": "--stateslayer-overlay-pressed-inverse",
+      "description": "Pressed State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items - on high/accent contrast elements",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist 50/opacity-16",
+        "hex": "#ffffff29",
+        "oklch": "oklch(100.00% 0.0000 0.00 / 0.16)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-16",
+        "hex": "#14172129",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.16)"
+      }
+    },
+    {
+      "name": "StatesLayer-Overlay/Active-Inverse",
+      "category": "StatesLayer-Overlay",
+      "cssVar": "--stateslayer-overlay-active-inverse",
+      "description": "Active State overlay for entire ui item - used in most components; buttons, inputs, menus, pickers, text area, tags, list items -on high/accent contrast elements",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Mist/50",
+        "hex": "#ffffffff",
+        "oklch": "oklch(100.00% 0.0000 0.00)"
+      },
+      "dark": {
+        "alias": "Slate/950",
+        "hex": "#10121bff",
+        "oklch": "oklch(18.46% 0.0187 274.71)"
+      }
+    },
+    {
+      "name": "StatesLayer-Overlay/Disabled-Inverse",
+      "category": "StatesLayer-Overlay",
+      "cssVar": "--stateslayer-overlay-disabled-inverse",
+      "description": "Disabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items - on high/accent elements",
+      "scopes": [
+        "FRAME_FILL",
+        "SHAPE_FILL"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-38",
+        "hex": "#14172161",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.38)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-8",
+        "hex": "#14172114",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.08)"
+      }
+    },
+    {
+      "name": "Elevations/Shade_T",
+      "category": "Elevations",
+      "cssVar": "--elevations-shade-t",
+      "description": "",
+      "scopes": [
+        "EFFECT_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-8",
+        "hex": "#14172114",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.08)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-88",
+        "hex": "#141721e0",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.88)"
+      }
+    },
+    {
+      "name": "Elevations/Shade",
+      "category": "Elevations",
+      "cssVar": "--elevations-shade",
+      "description": "",
+      "scopes": [
+        "EFFECT_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-38",
+        "hex": "#14172161",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.38)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-88",
+        "hex": "#141721e0",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.88)"
+      }
+    },
+    {
+      "name": "Elevations/Shade_T–01",
+      "category": "Elevations",
+      "cssVar": "--elevations-shade-t01",
+      "description": "",
+      "scopes": [
+        "EFFECT_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-12",
+        "hex": "#1417211f",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.12)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-60",
+        "hex": "#14172199",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.60)"
+      }
+    },
+    {
+      "name": "Elevations/Shade–01",
+      "category": "Elevations",
+      "cssVar": "--elevations-shade01",
+      "description": "",
+      "scopes": [
+        "EFFECT_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-12",
+        "hex": "#1417211f",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.12)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-12",
+        "hex": "#1417211f",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.12)"
+      }
+    },
+    {
+      "name": "Elevations/Shade_T–02",
+      "category": "Elevations",
+      "cssVar": "--elevations-shade-t02",
+      "description": "",
+      "scopes": [
+        "EFFECT_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-12",
+        "hex": "#1417211f",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.12)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-88",
+        "hex": "#141721e0",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.88)"
+      }
+    },
+    {
+      "name": "Elevations/Shade–02",
+      "category": "Elevations",
+      "cssVar": "--elevations-shade02",
+      "description": "",
+      "scopes": [
+        "EFFECT_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-24",
+        "hex": "#1417213d",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.24)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-38",
+        "hex": "#14172161",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.38)"
+      }
+    },
+    {
+      "name": "Elevations/Shade_T–03",
+      "category": "Elevations",
+      "cssVar": "--elevations-shade-t03",
+      "description": "",
+      "scopes": [
+        "EFFECT_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-12",
+        "hex": "#1417211f",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.12)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-38",
+        "hex": "#14172161",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.38)"
+      }
+    },
+    {
+      "name": "Elevations/Shade–03",
+      "category": "Elevations",
+      "cssVar": "--elevations-shade03",
+      "description": "",
+      "scopes": [
+        "EFFECT_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-8",
+        "hex": "#14172114",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.08)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-88",
+        "hex": "#141721e0",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.88)"
+      }
+    },
+    {
+      "name": "Elevations/Shade_T–04",
+      "category": "Elevations",
+      "cssVar": "--elevations-shade-t04",
+      "description": "",
+      "scopes": [
+        "EFFECT_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-12",
+        "hex": "#1417211f",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.12)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-38",
+        "hex": "#14172161",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.38)"
+      }
+    },
+    {
+      "name": "Elevations/Shade–04",
+      "category": "Elevations",
+      "cssVar": "--elevations-shade04",
+      "description": "",
+      "scopes": [
+        "EFFECT_COLOR"
+      ],
+      "light": {
+        "alias": "Slate 900/opacity-8",
+        "hex": "#14172114",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.08)"
+      },
+      "dark": {
+        "alias": "Slate 900/opacity-88",
+        "hex": "#141721e0",
+        "oklch": "oklch(20.64% 0.0205 271.56 / 0.88)"
+      }
+    }
+  ]
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -15,6 +15,7 @@ const InstallationPage = lazy(
   () => import('./app/(registry)/docs/installation/page'),
 );
 const IntroductionPage = lazy(() => import('./app/(registry)/docs/page'));
+const TokensPage = lazy(() => import('./app/(registry)/docs/tokens/page'));
 const RegistryItemPage = lazy(
   () => import('./app/(registry)/registry/[name]/page'),
 );
@@ -44,6 +45,7 @@ export const router = createBrowserRouter(
         { index: true, element: <IntroductionPage /> },
         { path: 'components', element: <ComponentsPage /> },
         { path: 'installation', element: <InstallationPage /> },
+        { path: 'tokens', element: <TokensPage /> },
         { path: 'registry/:name', element: <RegistryItemPage /> },
       ],
     },


### PR DESCRIPTION
## Summary

Adds a `/tokens` page to the registry website that surfaces the QBDS **DS_Themes** semantic colour tokens (79 in total) with full design-system metadata: descriptions, scopes, alias chains, hex (8-digit) and OKLCH values for both Light and Dark modes.

Closes the long-standing design ↔ code documentation gap. Until now, `globals.css` was the only code-side reference for these tokens — devs (and LLMs) had no way to know that `--surface-primary` is "primary page/ui shell panel background" with scope `FRAME_FILL, SHAPE_FILL`. That metadata lived only in Figma. It now ships in the registry repo.

## What's in this PR

| File | Role |
|---|---|
| `src/data/tokens.json` | Source of truth — 79 token entries extracted from Figma DS_Themes (categorised: Surface, Fill, Text, Border, Status, StatesLayer-Overlay, Elevations) |
| `src/app/(registry)/docs/tokens/page.tsx` | New `/tokens` route — searchable, category-tabbed grid with Light + Dark swatches, hex, OKLCH, alias chain, scope badges |
| `scripts/generate-tokens.ts` | Validator / normaliser — `npm run tokens:generate` |
| `src/router.tsx` | Wires up `/tokens` route |
| `src/components/registry/registry-sidebar.tsx` | Adds "Tokens" sidebar entry between Components and Installation |
| `package.json` | New script: `tokens:generate` |

## Why no `registry.json` entry?

`tokens.json` is reference data, not a shadcn-installable component. Adding it as a registry item caused `npx shadcn build` to wrap the source file in its own registry-item schema (overwriting the raw data on disk). Treating it as a static data import sidesteps the issue and keeps the source readable. If we want to expose it via the registry CLI later, we can add a copy step that produces a wrapped `public/r/tokens.json` without mutating the source.

## OKLCH

Each token carries both an 8-digit `hex` and a CSS `oklch()` value (slash-alpha syntax for transparency). HEX for tooling familiarity; OKLCH for perceptually-uniform colour reasoning, `color-mix()`, relative-colour syntax, and Tailwind v4 / shadcn-modern conventions. No code changes to `globals.css` in this PR — that's a separate migration.

## Refresh workflow

Source today is a one-shot extraction from Figma DS_Themes via the Desktop Bridge (Figma's Variables REST endpoint is enterprise-only). When DS_Themes changes:

1. Re-run the extraction snippet (lives in the QBDS extraction tooling)
2. Paste fresh JSON into `src/data/tokens.json`
3. `npm run tokens:generate` — validates shape, normalises scopes, prints summary
4. Open PR

The validator catches: type mismatches, duplicate `cssVar`s, missing hex/oklch, malformed scopes.

## Stats

- **79** color tokens
- **7** categories: Surface (4), Fill (18), Text (12), Border (17), Status (8), StatesLayer-Overlay (10), Elevations (10)
- **68 / 79** carry descriptions today (11 still pending in Figma — primarily `Elevations/*` and `Fill/Content/StepMarkers+Track`)
- All 79 carry scopes

## Test plan

- [ ] `npm run dev` → visit `/tokens` → confirm categories render, swatches display, search filters by name / cssVar / description / scope
- [ ] Click a category tab → verify only that category shows
- [ ] `npm run tokens:generate` → confirm validator prints the summary cleanly
- [ ] `npm run build` → confirm production build passes (validated on this branch)
- [ ] Sidebar shows "Tokens" between "Components" and "Installation"
- [ ] Visual spot-check: `Status/Error` light swatch should be a deep red, dark should be lighter

## Follow-ups (not in this PR)

- Migrate `globals.css` primitives from HEX → `oklch()` (separate PR — `resume-oklch-migration`)
- Extract DS-Primitives (294 vars) and Radius (5 vars) into the same pipeline
- Optional: typed token enum (`src/tokens/colors.ts`) with JSDoc per token for IDE-hover descriptions
- Optional: registry-CLI distribution via a separate built artifact


Made with [Cursor](https://cursor.com)