### PR TITLE
fix(registry): honor components.json aliases on shadcn install

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -4,25 +4,38 @@
   "homepage": "",
   "items": [
     {
+      "name": "utils",
+      "type": "registry:lib",
+      "title": "QBDS Utilities",
+      "description": "Tailwind class merge with QBDS typography class-group support.",
+      "dependencies": ["clsx", "tailwind-merge"],
+      "files": [
+        {
+          "path": "src/lib/utils.ts",
+          "type": "registry:lib"
+        }
+      ]
+    },
+    {
       "name": "alert",
       "type": "registry:ui",
       "title": "Alert",
       "description": "Displays contextual messages with two layouts (modal, long). Compose with AlertIcon, AlertContent, AlertTitle, AlertDescription, and optional AlertClose.",
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
         "__REGISTRY_URL__/r/button.json",
         "__REGISTRY_URL__/r/icon-shell.json"
       ],
       "files": [
         {
           "path": "src/components/ui/alert.tsx",
-          "type": "registry:file",
-          "target": "components/ui/alert.tsx"
+          "type": "registry:ui"
         },
         {
           "path": "src/components/icons/Close.tsx",
-          "type": "registry:file",
-          "target": "components/icons/Close.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/Close.tsx"
         }
       ]
     },
@@ -32,12 +45,14 @@
       "title": "Avatar",
       "description": "An avatar component with support for images and tooltips.",
       "dependencies": ["@radix-ui/react-avatar"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/avatar.tsx",
-          "type": "registry:file",
-          "target": "components/ui/avatar.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -47,12 +62,14 @@
       "title": "Badge",
       "description": "A badge component.",
       "dependencies": ["@radix-ui/react-slot"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/badge.tsx",
-          "type": "registry:file",
-          "target": "components/ui/badge.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -62,12 +79,14 @@
       "title": "Button",
       "description": "Allows users to take actions with a single click or tap.",
       "dependencies": ["@radix-ui/react-slot"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/button.tsx",
-          "type": "registry:file",
-          "target": "components/ui/button.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -79,6 +98,7 @@
       "dependencies": ["react-day-picker", "date-fns"],
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
         "__REGISTRY_URL__/r/button.json",
         "__REGISTRY_URL__/r/icon-shell.json",
         "__REGISTRY_URL__/r/input.json"
@@ -86,18 +106,17 @@
       "files": [
         {
           "path": "src/components/ui/calendar.tsx",
-          "type": "registry:file",
-          "target": "components/ui/calendar.tsx"
+          "type": "registry:ui"
         },
         {
           "path": "src/components/icons/ChevronLeft.tsx",
-          "type": "registry:file",
-          "target": "components/icons/ChevronLeft.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/ChevronLeft.tsx"
         },
         {
           "path": "src/components/icons/ChevronRight.tsx",
-          "type": "registry:file",
-          "target": "components/icons/ChevronRight.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/ChevronRight.tsx"
         }
       ]
     },
@@ -109,6 +128,7 @@
       "dependencies": ["react-day-picker", "date-fns"],
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
         "__REGISTRY_URL__/r/calendar.json",
         "__REGISTRY_URL__/r/input-group.json",
         "__REGISTRY_URL__/r/popover.json"
@@ -121,13 +141,13 @@
         },
         {
           "path": "src/components/icons/CalendarMonth.tsx",
-          "type": "registry:file",
-          "target": "components/icons/CalendarMonth.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/CalendarMonth.tsx"
         },
         {
           "path": "src/components/icons/ArrowForward.tsx",
-          "type": "registry:file",
-          "target": "components/icons/ArrowForward.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/ArrowForward.tsx"
         }
       ]
     },
@@ -138,14 +158,19 @@
       "description": "Custom time input with composable segment-based hh:mm entry, keyboard navigation, and clock icon trigger. Exports TimeInputRoot, TimeSegmentInput, TimeSeparator, TimeInputTrigger, and TimeInput convenience wrapper.",
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
         "__REGISTRY_URL__/r/input.json",
         "__REGISTRY_URL__/r/icon-shell.json"
       ],
       "files": [
         {
           "path": "src/components/ui/time-input.tsx",
-          "type": "registry:file",
-          "target": "components/ui/time-input.tsx"
+          "type": "registry:ui"
+        },
+        {
+          "path": "src/components/icons/Schedule.tsx",
+          "type": "registry:component",
+          "target": "@components/icons/Schedule.tsx"
         },
         {
           "path": "src/app/demo/[name]/ui/time-input.tsx",
@@ -161,6 +186,7 @@
       "description": "Individual components for building time picker interfaces. Includes TimePickerItem (radio list item) and TimePickerList (scrollable list) with size support (sm, default, lg).",
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
         "__REGISTRY_URL__/r/dropdown-menu.json",
         "__REGISTRY_URL__/r/scroll-area.json",
         "__REGISTRY_URL__/r/time-input.json"
@@ -168,8 +194,7 @@
       "files": [
         {
           "path": "src/components/ui/time-picker.tsx",
-          "type": "registry:file",
-          "target": "components/ui/time-picker.tsx"
+          "type": "registry:ui"
         },
         {
           "path": "src/app/demo/[name]/ui/time-picker.tsx",
@@ -183,12 +208,14 @@
       "type": "registry:ui",
       "title": "Card",
       "description": "A card component.",
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/card.tsx",
-          "type": "registry:file",
-          "target": "components/ui/card.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -198,12 +225,14 @@
       "title": "Checkbox",
       "description": "Allows users to select multiple items from a list of options.",
       "dependencies": ["@radix-ui/react-checkbox"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/checkbox.tsx",
-          "type": "registry:file",
-          "target": "components/ui/checkbox.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -213,12 +242,14 @@
       "title": "Dialog",
       "description": "A dialog component.",
       "dependencies": ["@radix-ui/react-dialog"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/dialog.tsx",
-          "type": "registry:file",
-          "target": "components/ui/dialog.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -230,13 +261,13 @@
       "dependencies": ["@radix-ui/react-dropdown-menu"],
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
         "__REGISTRY_URL__/r/button.json"
       ],
       "files": [
         {
           "path": "src/components/ui/dropdown-menu.tsx",
-          "type": "registry:file",
-          "target": "components/ui/dropdown-menu.tsx"
+          "type": "registry:ui"
         },
         {
           "path": "src/app/demo/[name]/ui/dropdown-menu.tsx",
@@ -250,12 +281,14 @@
       "type": "registry:ui",
       "title": "Empty",
       "description": "Displays empty states with support for icons, titles, descriptions, and custom content. Compose with EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription, and EmptyContent.",
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/empty.tsx",
-          "type": "registry:file",
-          "target": "components/ui/empty.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -266,14 +299,14 @@
       "description": "Composable field layout and structure for forms. Use FieldSet, FieldLegend, FieldGroup, Field, FieldLabel, FieldContent, FieldTitle, and FieldDescription.",
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
         "__REGISTRY_URL__/r/label.json",
         "__REGISTRY_URL__/r/separator.json"
       ],
       "files": [
         {
           "path": "src/components/ui/field.tsx",
-          "type": "registry:file",
-          "target": "components/ui/field.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -290,13 +323,13 @@
       ],
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
         "__REGISTRY_URL__/r/label.json"
       ],
       "files": [
         {
           "path": "src/components/ui/form.tsx",
-          "type": "registry:file",
-          "target": "components/ui/form.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -306,12 +339,14 @@
       "title": "Icon Shell",
       "description": "An icon component.",
       "dependencies": ["@radix-ui/react-slot"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/icon-shell.tsx",
-          "type": "registry:file",
-          "target": "components/ui/icon-shell.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -320,12 +355,14 @@
       "type": "registry:ui",
       "title": "Input",
       "description": "A text input field with support for variants (default, inline) and sizes (small, default, large).",
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/input.tsx",
-          "type": "registry:file",
-          "target": "components/ui/input.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -336,6 +373,7 @@
       "description": "A composite input component with support for icons, buttons, and text addons.",
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
         "__REGISTRY_URL__/r/input.json",
         "__REGISTRY_URL__/r/button.json",
         "__REGISTRY_URL__/r/textarea.json"
@@ -343,8 +381,7 @@
       "files": [
         {
           "path": "src/components/ui/input-group.tsx",
-          "type": "registry:file",
-          "target": "components/ui/input-group.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -356,29 +393,29 @@
       "dependencies": ["@base-ui/react"],
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
         "__REGISTRY_URL__/r/input-group.json",
         "__REGISTRY_URL__/r/button.json"
       ],
       "files": [
         {
           "path": "src/components/ui/combobox.tsx",
-          "type": "registry:file",
-          "target": "components/ui/combobox.tsx"
+          "type": "registry:ui"
         },
         {
           "path": "src/components/icons/Check.tsx",
-          "type": "registry:file",
-          "target": "components/icons/Check.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/Check.tsx"
         },
         {
           "path": "src/components/icons/ChevronDown.tsx",
-          "type": "registry:file",
-          "target": "components/icons/ChevronDown.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/ChevronDown.tsx"
         },
         {
           "path": "src/components/icons/Close.tsx",
-          "type": "registry:file",
-          "target": "components/icons/Close.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/Close.tsx"
         }
       ]
     },
@@ -388,12 +425,14 @@
       "title": "Label",
       "description": "A component that displays a label for form elements.",
       "dependencies": ["@radix-ui/react-label"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/label.tsx",
-          "type": "registry:file",
-          "target": "components/ui/label.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -403,12 +442,14 @@
       "title": "Popover",
       "description": "A popover component.",
       "dependencies": ["@radix-ui/react-popover"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/popover.tsx",
-          "type": "registry:file",
-          "target": "components/ui/popover.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -418,12 +459,14 @@
       "title": "Radio Group",
       "description": "A radio group component.",
       "dependencies": ["@radix-ui/react-radio-group"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/radio-group.tsx",
-          "type": "registry:file",
-          "target": "components/ui/radio-group.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -433,22 +476,24 @@
       "title": "Select",
       "description": "A select component with single and multiple selection support.",
       "dependencies": ["@base-ui/react"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/select.tsx",
-          "type": "registry:file",
-          "target": "components/ui/select.tsx"
+          "type": "registry:ui"
         },
         {
           "path": "src/components/icons/Check.tsx",
-          "type": "registry:file",
-          "target": "components/icons/Check.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/Check.tsx"
         },
         {
           "path": "src/components/icons/ChevronDown.tsx",
-          "type": "registry:file",
-          "target": "components/icons/ChevronDown.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/ChevronDown.tsx"
         }
       ]
     },
@@ -458,12 +503,14 @@
       "title": "Scroll Area",
       "description": "A scrollable viewport with custom scrollbars, built on Radix Scroll Area primitives.",
       "dependencies": ["@radix-ui/react-scroll-area"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/scroll-area.tsx",
-          "type": "registry:file",
-          "target": "components/ui/scroll-area.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -473,12 +520,14 @@
       "title": "Separator",
       "description": "A visual divider that separates content. Supports horizontal and vertical orientation.",
       "dependencies": ["@radix-ui/react-separator"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/separator.tsx",
-          "type": "registry:file",
-          "target": "components/ui/separator.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -490,13 +539,13 @@
       "dependencies": ["@radix-ui/react-slider"],
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
         "__REGISTRY_URL__/r/tooltip.json"
       ],
       "files": [
         {
           "path": "src/components/ui/slider.tsx",
-          "type": "registry:file",
-          "target": "components/ui/slider.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -505,43 +554,45 @@
       "type": "registry:ui",
       "title": "Sonner",
       "description": "A toast notification component.",
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "dependencies": ["sonner", "next-themes"],
       "files": [
         {
           "path": "src/components/ui/sonner.tsx",
-          "type": "registry:file",
-          "target": "components/ui/sonner.tsx"
+          "type": "registry:ui"
         },
         {
           "path": "src/components/icons/CheckCircle.tsx",
-          "type": "registry:file",
-          "target": "components/icons/CheckCircle.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/CheckCircle.tsx"
         },
         {
           "path": "src/components/icons/Cancel.tsx",
-          "type": "registry:file",
-          "target": "components/icons/Cancel.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/Cancel.tsx"
         },
         {
           "path": "src/components/icons/ErrorIcon.tsx",
-          "type": "registry:file",
-          "target": "components/icons/ErrorIcon.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/ErrorIcon.tsx"
         },
         {
           "path": "src/components/icons/Info.tsx",
-          "type": "registry:file",
-          "target": "components/icons/Info.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/Info.tsx"
         },
         {
           "path": "src/components/icons/PlaylistAddCheck.tsx",
-          "type": "registry:file",
-          "target": "components/icons/PlaylistAddCheck.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/PlaylistAddCheck.tsx"
         },
         {
           "path": "src/components/icons/Close.tsx",
-          "type": "registry:file",
-          "target": "components/icons/Close.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/Close.tsx"
         }
       ]
     },
@@ -551,12 +602,14 @@
       "title": "Switch",
       "description": "A switch component.",
       "dependencies": ["@radix-ui/react-switch", "class-variance-authority"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/switch.tsx",
-          "type": "registry:file",
-          "target": "components/ui/switch.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -565,12 +618,14 @@
       "type": "registry:ui",
       "title": "Table",
       "description": "A responsive table component.",
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/table.tsx",
-          "type": "registry:file",
-          "target": "components/ui/table.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -582,6 +637,7 @@
       "dependencies": ["@tanstack/react-table"],
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
         "__REGISTRY_URL__/r/table.json",
         "__REGISTRY_URL__/r/checkbox.json",
         "__REGISTRY_URL__/r/select.json",
@@ -595,18 +651,18 @@
         },
         {
           "path": "src/components/icons/SwapVert.tsx",
-          "type": "registry:file",
-          "target": "components/icons/SwapVert.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/SwapVert.tsx"
         },
         {
           "path": "src/components/icons/ArrowDownwardAlt.tsx",
-          "type": "registry:file",
-          "target": "components/icons/ArrowDownwardAlt.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/ArrowDownwardAlt.tsx"
         },
         {
           "path": "src/components/icons/ArrowUpwardAlt.tsx",
-          "type": "registry:file",
-          "target": "components/icons/ArrowUpwardAlt.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/ArrowUpwardAlt.tsx"
         }
       ]
     },
@@ -616,12 +672,14 @@
       "title": "Tabs",
       "description": "A responsive tabs component.",
       "dependencies": ["@radix-ui/react-tabs"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/tabs.tsx",
-          "type": "registry:file",
-          "target": "components/ui/tabs.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -630,12 +688,14 @@
       "type": "registry:ui",
       "title": "Textarea",
       "description": "Displays a form textarea or a component that looks like a textarea.",
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/textarea.tsx",
-          "type": "registry:file",
-          "target": "components/ui/textarea.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -658,12 +718,14 @@
       "title": "Tooltip",
       "description": "A component that displays informative text when users hover over an element.",
       "dependencies": ["@radix-ui/react-tooltip"],
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/tooltip.tsx",
-          "type": "registry:file",
-          "target": "components/ui/tooltip.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -672,17 +734,19 @@
       "type": "registry:ui",
       "title": "Tag",
       "description": "A dismissable tag component with support for icons, variants (default, secondary, accent, outline, accent-outline), pill shape, and sizes.",
-      "registryDependencies": ["__REGISTRY_URL__/r/theme.json"],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
       "files": [
         {
           "path": "src/components/ui/tag.tsx",
-          "type": "registry:file",
-          "target": "components/ui/tag.tsx"
+          "type": "registry:ui"
         },
         {
           "path": "src/components/icons/Close.tsx",
-          "type": "registry:file",
-          "target": "components/icons/Close.tsx"
+          "type": "registry:component",
+          "target": "@components/icons/Close.tsx"
         }
       ]
     },
@@ -694,14 +758,14 @@
       "dependencies": ["@radix-ui/react-toggle"],
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
         "__REGISTRY_URL__/r/button.json",
         "__REGISTRY_URL__/r/tag.json"
       ],
       "files": [
         {
           "path": "src/components/ui/tag-toggle.tsx",
-          "type": "registry:file",
-          "target": "components/ui/tag-toggle.tsx"
+          "type": "registry:ui"
         }
       ]
     },
@@ -713,13 +777,13 @@
       "dependencies": ["@radix-ui/react-toggle"],
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
         "__REGISTRY_URL__/r/button.json"
       ],
       "files": [
         {
           "path": "src/components/ui/toggle.tsx",
-          "type": "registry:file",
-          "target": "components/ui/toggle.tsx"
+          "type": "registry:ui"
         }
       ]
     }

--- a/src/components/icons/Add.tsx
+++ b/src/components/icons/Add.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/ArrowDownwardAlt.tsx
+++ b/src/components/icons/ArrowDownwardAlt.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/ArrowForward.tsx
+++ b/src/components/icons/ArrowForward.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/ArrowUpwardAlt.tsx
+++ b/src/components/icons/ArrowUpwardAlt.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/AttachMoney.tsx
+++ b/src/components/icons/AttachMoney.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Backspace.tsx
+++ b/src/components/icons/Backspace.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/CalendarMonth.tsx
+++ b/src/components/icons/CalendarMonth.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Cancel.tsx
+++ b/src/components/icons/Cancel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Check.tsx
+++ b/src/components/icons/Check.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/CheckCircle.tsx
+++ b/src/components/icons/CheckCircle.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/ChevronDown.tsx
+++ b/src/components/icons/ChevronDown.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/ChevronLeft.tsx
+++ b/src/components/icons/ChevronLeft.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/ChevronRight.tsx
+++ b/src/components/icons/ChevronRight.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/ChevronUp.tsx
+++ b/src/components/icons/ChevronUp.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Close.tsx
+++ b/src/components/icons/Close.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/CropFree.tsx
+++ b/src/components/icons/CropFree.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Delete.tsx
+++ b/src/components/icons/Delete.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Description.tsx
+++ b/src/components/icons/Description.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/DisabledByDefault.tsx
+++ b/src/components/icons/DisabledByDefault.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Edit.tsx
+++ b/src/components/icons/Edit.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/ErrorIcon.tsx
+++ b/src/components/icons/ErrorIcon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Event.tsx
+++ b/src/components/icons/Event.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Info.tsx
+++ b/src/components/icons/Info.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Key.tsx
+++ b/src/components/icons/Key.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Layers.tsx
+++ b/src/components/icons/Layers.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Link.tsx
+++ b/src/components/icons/Link.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Lock.tsx
+++ b/src/components/icons/Lock.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Mail.tsx
+++ b/src/components/icons/Mail.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/MoreVert.tsx
+++ b/src/components/icons/MoreVert.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/PageInfo.tsx
+++ b/src/components/icons/PageInfo.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Person.tsx
+++ b/src/components/icons/Person.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/PlaylistAddCheck.tsx
+++ b/src/components/icons/PlaylistAddCheck.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/ProgressActivity.tsx
+++ b/src/components/icons/ProgressActivity.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Remove.tsx
+++ b/src/components/icons/Remove.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Schedule.tsx
+++ b/src/components/icons/Schedule.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Search.tsx
+++ b/src/components/icons/Search.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Send.tsx
+++ b/src/components/icons/Send.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Style.tsx
+++ b/src/components/icons/Style.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/SwapVert.tsx
+++ b/src/components/icons/SwapVert.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/TrendingUp.tsx
+++ b/src/components/icons/TrendingUp.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/VolumeDown.tsx
+++ b/src/components/icons/VolumeDown.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/VolumeUp.tsx
+++ b/src/components/icons/VolumeUp.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/icons/Warning.tsx
+++ b/src/components/icons/Warning.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   readonly className?: string;

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,10 +1,10 @@
 import { type VariantProps, cva } from 'class-variance-authority';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
-import { Close } from '../icons/Close';
-import { Button } from './button';
-import { IconShell } from './icon-shell';
+import { Close } from '@/components/icons/Close';
+import { Button } from '@/components/ui/button';
+import { IconShell } from '@/components/ui/icon-shell';
+import { cn } from '@/lib/utils';
 
 const alertVariants = cva(
   'group/alert relative w-full bg-fill-onsurface-ui-3 shadow-elevation-2 flex items-center rounded-lg',

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -4,7 +4,7 @@ import * as AvatarPrimitive from '@radix-ui/react-avatar';
 import { type VariantProps, cva } from 'class-variance-authority';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 // Context to share size and disabled state with children
 type AvatarContextValue = {

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -2,7 +2,7 @@ import { Slot } from '@radix-ui/react-slot';
 import { type VariantProps, cva } from 'class-variance-authority';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 /**
  * Padding lookup, keyed by content mode → size.

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import { Slot } from '@radix-ui/react-slot';
 import { type VariantProps, cva } from 'class-variance-authority';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 // State overlay gradients
 /**

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -27,12 +27,12 @@ import {
   useDayPicker,
 } from 'react-day-picker';
 
-import { cn } from '../../lib/utils';
-import { ChevronLeft } from '../icons/ChevronLeft';
-import { ChevronRight } from '../icons/ChevronRight';
-import { Button } from './button';
-import { IconShell } from './icon-shell';
-import { Input } from './input';
+import { ChevronLeft } from '@/components/icons/ChevronLeft';
+import { ChevronRight } from '@/components/icons/ChevronRight';
+import { Button } from '@/components/ui/button';
+import { IconShell } from '@/components/ui/icon-shell';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
 
 // Constants
 const MONTH_NAMES = [

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
 import type * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 function Card({ className, ...props }: React.ComponentProps<'div'>) {
   return (

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -3,7 +3,7 @@
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 function CheckmarkIcon({ size }: { size: 'default' | 'lg' }) {
   const isRegular = size === 'default';

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
+import * as React from 'react';
 
 function Collapsible({
   ...props

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
-import * as React from 'react';
+import type * as React from 'react';
 
 function Collapsible({
   ...props

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -4,7 +4,7 @@ import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { XIcon } from 'lucide-react';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 function Dialog({
   ...props

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -4,7 +4,7 @@ import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { CheckIcon, ChevronRightIcon, Circle } from 'lucide-react';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 function DropdownMenu({
   ...props

--- a/src/components/ui/empty.tsx
+++ b/src/components/ui/empty.tsx
@@ -1,5 +1,5 @@
 import { type VariantProps, cva } from 'class-variance-authority';
-import * as React from 'react';
+import type * as React from 'react';
 
 import { cn } from '@/lib/utils';
 

--- a/src/components/ui/empty.tsx
+++ b/src/components/ui/empty.tsx
@@ -1,6 +1,6 @@
 import { type VariantProps, cva } from 'class-variance-authority';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 function Empty({ className, ...props }: React.ComponentProps<'div'>) {
   return (

--- a/src/components/ui/empty.tsx
+++ b/src/components/ui/empty.tsx
@@ -1,4 +1,5 @@
 import { type VariantProps, cva } from 'class-variance-authority';
+import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -11,8 +11,8 @@ import {
 } from 'react-hook-form';
 import type { ControllerProps, FieldPath, FieldValues } from 'react-hook-form';
 
-import { cn } from '../../lib/utils';
-import { Label } from './label';
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
 
 const Form = FormProvider;
 

--- a/src/components/ui/icon-shell.tsx
+++ b/src/components/ui/icon-shell.tsx
@@ -2,7 +2,7 @@ import { Slot } from '@radix-ui/react-slot';
 import { type VariantProps, cva } from 'class-variance-authority';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 const iconVariants = cva(
   // Base styles

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -3,15 +3,15 @@
 import { type VariantProps, cva } from 'class-variance-authority';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
-import { Button } from './button';
+import { Button } from '@/components/ui/button';
 import {
   Input,
   type InputProps,
   inputSizeDefinitions,
   inputVariantStyles,
-} from './input';
-import { Textarea } from './textarea';
+} from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
 
 // Focus state wrapper styles for default variant
 // Triggered by child input focus-visible OR data-open="true" on the wrapper

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,7 +1,7 @@
 import { type VariantProps, cva } from 'class-variance-authority';
 import type * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 // Edge case when type=search for input, there is a cancel button (X) that is styled to match the design system colors.
 const searchCancelButtonIcon =

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -4,7 +4,7 @@ import * as LabelPrimitive from '@radix-ui/react-label';
 import { type VariantProps, cva } from 'class-variance-authority';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 const labelVariants = cva(
   'flex items-center font-normal gap-1 select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed',

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -4,7 +4,7 @@ import * as MenubarPrimitive from '@radix-ui/react-menubar';
 import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
 import type * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 function Menubar({
   className,

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -3,7 +3,7 @@
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 function Popover({
   ...props

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -3,7 +3,7 @@
 import * as ProgressPrimitive from '@radix-ui/react-progress';
 import type * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 function Progress({
   className,

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -3,7 +3,7 @@
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 function RadioGroup({
   className,

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -3,7 +3,7 @@
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 import type * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 function ScrollArea({
   className,

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -3,7 +3,7 @@
 import * as SeparatorPrimitive from '@radix-ui/react-separator';
 import type * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 function Separator({
   className,

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -5,18 +5,18 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import { PanelLeftIcon } from 'lucide-react';
 import * as React from 'react';
 
-import { useIsMobile } from '../../hooks/use-mobile';
-import { cn } from '../../lib/utils';
-import { Button } from './button';
-import { Input } from './input';
-import { Separator } from './separator';
-import { Skeleton } from './skeleton';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
+import { Skeleton } from '@/components/ui/skeleton';
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from './tooltip';
+} from '@/components/ui/tooltip';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cn } from '@/lib/utils';
 
 const SIDEBAR_COOKIE_NAME = 'sidebar_state';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type * as React from 'react';
 
 import { cn } from '@/lib/utils';
 

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { cn } from '@/lib/utils';
 
 function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -3,8 +3,12 @@
 import * as SliderPrimitive from '@radix-ui/react-slider';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
-import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
 
 // Types
 

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -9,14 +9,14 @@ import {
   toast as sonnerToast,
 } from 'sonner';
 
-import { cn } from '../../lib/utils';
-import { Cancel } from '../icons/Cancel';
-import { CheckCircle } from '../icons/CheckCircle';
-import { Close } from '../icons/Close';
-import { ErrorIcon } from '../icons/ErrorIcon';
-import { Info } from '../icons/Info';
-import { PlaylistAddCheck } from '../icons/PlaylistAddCheck';
-import { Button } from './button';
+import { Cancel } from '@/components/icons/Cancel';
+import { CheckCircle } from '@/components/icons/CheckCircle';
+import { Close } from '@/components/icons/Close';
+import { ErrorIcon } from '@/components/icons/ErrorIcon';
+import { Info } from '@/components/icons/Info';
+import { PlaylistAddCheck } from '@/components/icons/PlaylistAddCheck';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 type ToastType = NonNullable<ToastT['type']>;
 

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -4,7 +4,7 @@ import * as SwitchPrimitive from '@radix-ui/react-switch';
 import { type VariantProps, cva } from 'class-variance-authority';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 const switchVariants = cva(
   [

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -2,7 +2,7 @@
 
 import type * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 function Table({ className, ...props }: React.ComponentProps<'table'>) {
   return (

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -3,7 +3,7 @@
 import * as TabsPrimitive from '@radix-ui/react-tabs';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 // Types
 export type TabSize = 'sm' | 'default' | 'lg';

--- a/src/components/ui/tag-toggle.tsx
+++ b/src/components/ui/tag-toggle.tsx
@@ -4,8 +4,8 @@ import * as TogglePrimitive from '@radix-ui/react-toggle';
 import type { VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
-import { tagBaseStyles, tagSizeVariants } from './tag';
+import { tagBaseStyles, tagSizeVariants } from '@/components/ui/tag';
+import { cn } from '@/lib/utils';
 
 type TagToggleVariant = 'default' | 'outline';
 

--- a/src/components/ui/tag.tsx
+++ b/src/components/ui/tag.tsx
@@ -1,8 +1,8 @@
 import { type VariantProps, cva } from 'class-variance-authority';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
-import { Close } from '../icons/Close';
+import { Close } from '@/components/icons/Close';
+import { cn } from '@/lib/utils';
 
 const hoverOverlay = {
   normal:

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -3,8 +3,8 @@
 import { type VariantProps, cva } from 'class-variance-authority';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
-import { inputVariantStyles } from './input';
+import { inputVariantStyles } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
 
 const textareaVariants = cva(
   'flex w-full rounded-none outline-none transition-[border-color,box-shadow,background-color] font-normal min-h-16 selection:bg-fill-active selection:text-fg-primary-inverse',

--- a/src/components/ui/time-input.tsx
+++ b/src/components/ui/time-input.tsx
@@ -3,10 +3,10 @@
 import { type VariantProps, cva } from 'class-variance-authority';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
-import { Schedule } from '../icons';
-import { IconShell } from './icon-shell';
-import { inputVariantStyles } from './input';
+import { Schedule } from '@/components/icons/Schedule';
+import { IconShell } from '@/components/ui/icon-shell';
+import { inputVariantStyles } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
 
 // ============================================================================
 // TYPES

--- a/src/components/ui/time-picker.tsx
+++ b/src/components/ui/time-picker.tsx
@@ -2,6 +2,7 @@
 
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { cva } from 'class-variance-authority';
+import * as React from 'react';
 
 import { DropdownMenuRadioGroup } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';

--- a/src/components/ui/time-picker.tsx
+++ b/src/components/ui/time-picker.tsx
@@ -3,8 +3,8 @@
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { cva } from 'class-variance-authority';
 
-import { cn } from '../../lib/utils';
-import { DropdownMenuRadioGroup } from './dropdown-menu';
+import { DropdownMenuRadioGroup } from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
 
 // ============================================================================
 // TYPES & INTERFACES

--- a/src/components/ui/time-picker.tsx
+++ b/src/components/ui/time-picker.tsx
@@ -2,7 +2,7 @@
 
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { cva } from 'class-variance-authority';
-import * as React from 'react';
+import type * as React from 'react';
 
 import { DropdownMenuRadioGroup } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -3,8 +3,8 @@
 import * as TogglePrimitive from '@radix-ui/react-toggle';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
-import { buttonVariants } from './button';
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 // Toggle reuses button variants (secondary, outline, ghost) and sizes
 // with the addition of data-[state=on]:bg-fill-active for the on state

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -3,7 +3,7 @@
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 function TooltipProvider({
   delayDuration = 0,


### PR DESCRIPTION
## Issue

`npx shadcn@latest add @qbds/<component>` ignored the consumer's `components.json` `aliases`. Files landed at hardcoded paths regardless of consumer config.

Causes:
1. Every file was `registry:file` with a hardcoded `target` — shadcn bypasses `aliases` for that type.
2. Internal imports were relative (`../../lib/utils`, `../icons/Close`) — shadcn only rewrites `@/` imports.
3. `src/lib/utils.ts` (QBDS `cn` with typography class-group merge) was never shipped — consumers fell back to stock `cn`.

## Fix

- Re-typed files:
  - `components/ui/*.tsx` → `registry:ui`, no `target`.
  - `components/icons/*.tsx` → `registry:component`, `target: "@components/icons/<Name>.tsx"`.
- Added `utils` registry item shipping `src/lib/utils.ts`. Wired into every UI item's `registryDependencies`.
- Converted all internal imports to `@/` aliases.
- Added missing `Schedule.tsx` to `time-input`.

## Verified

Smoke-tested with consumer aliases pointing into `@/vendor/...`:

```
✔ Created 3 files:
  - src/vendor/components/ui/icon-shell.tsx
  - src/vendor/components/ui/alert.tsx
  - src/vendor/components/icons/Close.tsx
```

Imports rewritten to `@/vendor/...`. `lint` and `build` green.

Made with [Cursor](https://cursor.com)