### PR TITLE
feat(ui): expose Figma SLOT properties as React seams

### DIFF
--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -85,6 +85,37 @@ function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/**
+ * Optional Form header. Maps to the `headerSlot` property in the QBDS Figma
+ * `Form` component set; use it for the form's title, description, or any
+ * leading content above the sections.
+ */
+function FormHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="form-header"
+      className={cn('flex flex-col gap-1', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * Optional Form section. Repeat as many times as needed to cover the
+ * `sectionSlot1`, `sectionSlot2`, `sectionSlot3`, and `sectionSlot4`
+ * properties in the QBDS Figma `Form` component set; in code the count is
+ * unbounded by design (Figma caps at 4 because Figma slots must be named).
+ */
+function FormSection({ className, ...props }: React.ComponentProps<'section'>) {
+  return (
+    <section
+      data-slot="form-section"
+      className={cn('flex flex-col gap-4', className)}
+      {...props}
+    />
+  );
+}
+
 function FormLabel({
   className,
   ...props
@@ -167,6 +198,8 @@ export {
   useFormField,
   Form,
   FormItem,
+  FormHeader,
+  FormSection,
   FormLabel,
   FormControl,
   FormDescription,

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -30,15 +30,52 @@ const labelVariants = cva(
 export interface LabelProps
   extends
     React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>,
-    VariantProps<typeof labelVariants> {}
+    VariantProps<typeof labelVariants> {
+  /**
+   * Optional content rendered after the label, right-aligned. Maps to the
+   * `infoCounterSlot` property in the QBDS Figma `Elements/Label` component
+   * set (e.g. `12 / 50` character counter).
+   */
+  infoCounter?: React.ReactNode;
+  /**
+   * Optional content rendered after the label, right-aligned, sitting beside
+   * `infoCounter` when both are present. Maps to the `infoMiscsSlot` property
+   * in the QBDS Figma `Elements/Label` component set (e.g. an info icon or
+   * "Optional" hint).
+   */
+  infoMiscs?: React.ReactNode;
+}
 
-function Label({ className, size, disabled, ...props }: LabelProps) {
+function Label({
+  className,
+  size,
+  disabled,
+  infoCounter,
+  infoMiscs,
+  children,
+  ...props
+}: LabelProps) {
+  const hasInfo = infoCounter !== undefined || infoMiscs !== undefined;
+
   return (
     <LabelPrimitive.Root
       className={cn(labelVariants({ size, disabled }), className)}
       data-slot="label"
-      {...props}
-    />
+      {...props}>
+      {children}
+      {hasInfo && (
+        <span
+          data-slot="label-info"
+          className="ml-auto inline-flex items-center gap-1">
+          {infoCounter !== undefined && (
+            <span data-slot="label-info-counter">{infoCounter}</span>
+          )}
+          {infoMiscs !== undefined && (
+            <span data-slot="label-info-miscs">{infoMiscs}</span>
+          )}
+        </span>
+      )}
+    </LabelPrimitive.Root>
   );
 }
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -193,11 +193,24 @@ function SelectLabel({
   );
 }
 
+/**
+ * `leading` and `trailing` map to the `leadingSlot` and `trailingSlot`
+ * properties in the QBDS Figma `MenuItem/Select` component set. Use them for
+ * an item-leading icon/avatar and an item-trailing affordance (e.g. shortcut,
+ * counter, status dot). Both are rendered alongside the item's `children`.
+ */
+type SelectItemProps = SelectPrimitive.Item.Props & {
+  leading?: React.ReactNode;
+  trailing?: React.ReactNode;
+};
+
 function SelectItem({
   className,
   children,
+  leading,
+  trailing,
   ...props
-}: SelectPrimitive.Item.Props) {
+}: SelectItemProps) {
   const sizeContext = useSelectSizeContext();
   const size = sizeContext?.size ?? 'default';
 
@@ -220,7 +233,19 @@ function SelectItem({
         className,
       )}
       {...props}>
+      {leading !== undefined && (
+        <span data-slot="select-item-leading" className="inline-flex shrink-0">
+          {leading}
+        </span>
+      )}
       {children}
+      {trailing !== undefined && (
+        <span
+          data-slot="select-item-trailing"
+          className="ml-auto inline-flex shrink-0">
+          {trailing}
+        </span>
+      )}
     </SelectPrimitive.Item>
   );
 }


### PR DESCRIPTION
## Summary

The QBDS Figma library defines SLOT component properties on several component sets, but **none of them have a corresponding React seam** in the registry today. Designers using a slot in Figma have no way to express the same composition in code, which makes Figma-to-code translation a manual interpretation step every time.

This PR adds the seams for the 7 in-scope SLOTs that genuinely needed new code. The remaining 8 in-scope SLOTs are already captured implicitly by Radix's `children` composition pattern.

## Code changes

| File | New API | Maps to Figma slot(s) |
|---|---|---|
| `label.tsx` | `LabelProps.infoCounter?: ReactNode`, `LabelProps.infoMiscs?: ReactNode` | `Elements/Label.infoCounterSlot`, `Elements/Label.infoMiscsSlot` |
| `form.tsx` | `<FormHeader>` subcomponent | `Form.headerSlot` |
| `form.tsx` | `<FormSection>` subcomponent (used N times) | `Form.sectionSlot1`, `sectionSlot2`, `sectionSlot3`, `sectionSlot4` |
| `select.tsx` | `SelectItemProps.leading?: ReactNode`, `SelectItemProps.trailing?: ReactNode` | `MenuItem/Select.leadingSlot`, `MenuItem/Select.trailingSlot` |

All additions are optional and backward-compatible — components called without the new props render identically to before.

### Worked example

```tsx
<Form {...form}>
  <FormHeader>
    <h2>Profile</h2>
    <p>Update your account details.</p>
  </FormHeader>

  <FormSection>
    <FormField name=\"email\" ... />
    <FormField name=\"phone\" ... />
  </FormSection>

  <FormSection>
    <FormField name=\"company\" ... />
  </FormSection>
</Form>
```

```tsx
<Label infoCounter=\"12 / 50\" infoMiscs={<InfoIcon />}>Bio</Label>

<SelectItem value=\"acme\" leading={<Avatar />} trailing={<Badge>NEW</Badge>}>
  Acme Inc.
</SelectItem>
```

## What was already covered (no change needed)

8 of the 15 in-scope Figma SLOTs are already satisfied by Radix's `children` composition:

| Figma slot | Code equivalent |
|---|---|
| `Tab-Group.tabsSlot` | `<TabsList><TabsTrigger>...</TabsTrigger></TabsList>` |
| `Menu/Select.itemsSlot` | `<SelectContent><SelectItem>...</SelectItem></SelectContent>` |
| `RadioGroup/List Horizontal.itemsSlot`, `RadioGroup/List Vertical.itemsSlot` | `<RadioGroup><RadioGroupItem>...</RadioGroupItem></RadioGroup>` |
| `ScrollBar.scrubberSlot` | `<ScrollBar>` already renders the thumb internally via Radix |
| `GroupStacked.avatarsSlot` | `<AvatarGroup><Avatar>...</Avatar></AvatarGroup>` |
| `Tags-Avatar.tagSlot`, `Tags-Dismissable.tagSlot`, `Tags-Toggle.tagSlot` | `<Tag>` / `<TagToggle>` accept arbitrary `children` (and `<Tag>` exposes `onRemove` for the dismissable variant) |

The slot audit script (`npm run audit:slots`) doesn't recognise children-composition as a captured seam — its current heuristic looks for prop names, subcomponent names, or `asChild` + Radix Slot. Improving the audit to understand children-composition is a separate workstream and intentionally out of scope here.

## Out of scope (4 components have no code yet)

These Figma component sets account for 18 of the 33 total SLOTs and need the component itself built first:

- `.base/CellContent-Text` (5 slots)
- `.ListItem` (3 slots)
- `ToolBar-Button` (2 slots)
- `CheckboxGroup` (2 slots)
- `SegmentedControls` (1 slot)
- `Menu/Avatar` (1 slot) - no avatar-menu component
- `Menu/Context` (1 slot) - no context-menu component

Each will need its own implementation PR (and at that point, exposing the Figma SLOTs is part of building the component, not retrofitting it).

## Audit before/after

Running `npm run audit:slots` against the QBDS Figma library (file key `iuMWqCsIohoKAUB0tBS0xr`):

- **Before:** 33 slots, **0 captured**, 7 missing, 26 no-file.
- **After:** 33 slots, **5 captured** (all Form slots), 2 missing (RadioGroup - false negatives, see above), 26 no-file (out-of-scope components + audit heuristic limitations on label/select/etc.).

The audit's heuristic doesn't yet map every Figma component-set name to its code file (e.g. `Elements/Label` → `label.tsx`, `MenuItem/Select` → `select.tsx`), so the rows for Label/SelectItem still show as no-file even though the seams have been added. That's a separate audit-improvement workstream.

## Test plan

- [x] `npm run lint` passes on all changed files.
- [x] `npm run build` passes.
- [x] `npm run audit:slots` returns 5 captured (all five Form slots flip from missing to captured).
- [ ] Reviewer compiles a sample Form using `<FormHeader>` + multiple `<FormSection>` children and confirms layout matches the Figma `Form` component set.
- [ ] Reviewer renders `<Label infoCounter=\"...\" infoMiscs={...}>` and confirms the right-aligned info area visually matches the Figma `Elements/Label` info group.
- [ ] Reviewer renders `<SelectItem leading={...} trailing={...}>` and confirms placement matches `MenuItem/Select`.

## Follow-up PRs (not blocking this one)

1. Improve `scripts/audit-slots.ts` to read a `figma-component-set → src/components/ui/<file>` mapping so it accurately attributes slots to files (turns most "no-file" rows into real signal) and recognises children-composition as a captured seam.
2. Build the missing components (`cell-content`, `list-item`, `toolbar-button`, `checkbox-group`, `segmented-controls`, `avatar-menu`, `context-menu`) and expose their SLOTs at the same time.
3. Add demos in `src/app/demo/` showing the new seams for Label, Form, and SelectItem.

Made with [Cursor](https://cursor.com)