### PR TITLE
docs: import QBDS rules cards, llm-readiness plan, figma checklist

### DIFF
--- a/docs/component-rules/_template.md
+++ b/docs/component-rules/_template.md
@@ -1,0 +1,175 @@
+---
+component: "{{kebab-name}}"            # e.g. "button", "data-table"
+display-name: "{{PascalName}}"          # the exported React symbol
+status: "stable"                        # stable | beta | deprecated
+last-updated: "YYYY-MM-DD"
+registry-name: "{{registry-id}}"        # the entry in registry.json
+figma:
+  file-key: "iuMWqCsIohoKAUB0tBS0xr"
+  page: "❖ ⎯ {{Page Name}}"             # the Figma page hosting the component
+  primary-node-id: "{{node-id}}"        # the canonical component / component-set
+code-connect:
+  mapped: false                          # true once `*.figma.tsx` exists
+  file: "src/components/ui/{{kebab-name}}.figma.tsx"  # planned path
+related:                                 # cross-links to sibling cards
+  - "{{related-component-1}}"
+  - "{{related-component-2}}"
+---
+
+# {{PascalName}}
+
+> One-line elevator pitch. The kind of sentence a designer or engineer would say when justifying the component's existence. Drop adjectives. Keep concrete.
+
+## Purpose
+
+Two to three sentences. What problem does this component solve, what's the affordance it offers, and what's its single job? If you can't say it in three sentences, the component is doing too much.
+
+## When to use
+
+- Use case 1, phrased as a concrete user goal (not a design adjective).
+- Use case 2.
+- Use case 3.
+
+## When not to use
+
+- Anti-use case 1, with a redirect: `{{wrong-pattern}} -> use {{better-component}} instead`.
+- Anti-use case 2.
+
+## Anatomy
+
+The exported sub-components and `data-slot` attributes that compose this component.
+
+| Sub-component         | data-slot        | Required? | Notes                                                      |
+| --------------------- | ---------------- | --------- | ---------------------------------------------------------- |
+| `{{ComponentName}}`   | `{{slot-name}}`  | yes       | Root wrapper.                                              |
+| `{{SubComponentA}}`   | `{{slot-name}}`  | optional  | Brief contextual note.                                     |
+
+If the component is a single primitive (e.g. `Button`), drop the table and write a one-line note instead.
+
+## API surface
+
+Use the data from `public/api/{{kebab-name}}.json` as the source of truth.
+
+| Prop       | Type                                  | Default     | Notes                                                  |
+| ---------- | ------------------------------------- | ----------- | ------------------------------------------------------ |
+| `variant`  | `"default" \| "{{...}}"`              | `"default"` | Visual treatment. Each variant maps to a Figma variant. |
+| `size`     | `"default" \| "{{...}}"`              | `"default"` | Sizing scale. Each size maps to a Figma `size=` axis.  |
+| `asChild`  | `boolean`                             | `false`     | If true, merges props into the immediate child via Radix `Slot`. |
+
+If the component does not use `cva`, document the relevant `data-*` attributes and class hooks instead.
+
+## Hard rules
+
+Numbered, imperative, testable. Each rule must be falsifiable — an LLM or a linter should be able to flag a violation.
+
+1. **{{rule-1}}** — one sentence stating the rule, then "Why: {{rationale}}".
+2. **{{rule-2}}** — ditto.
+3. **{{rule-3}}** — ditto.
+
+Aim for 4–8 hard rules. More than 10 means the component is unclear or you're padding.
+
+## Soft rules
+
+Looser preferences. Violations are a code smell, not an error.
+
+- {{soft-rule-1}}.
+- {{soft-rule-2}}.
+
+## Composition patterns
+
+Two to four named patterns that the component is designed for. Each pattern: one heading, one paragraph of context, one code block referencing real QBDS imports.
+
+### Pattern: {{descriptive-name}}
+
+Brief context. When/why this pattern applies.
+
+```tsx
+import { {{ComponentName}} } from '@/components/ui/{{kebab-name}}';
+
+<{{ComponentName}} variant="default">
+  {{example-children}}
+</{{ComponentName}}>
+```
+
+### Pattern: {{another-pattern}}
+
+...
+
+## Accessibility contract
+
+Concrete, non-negotiable a11y requirements:
+
+- **Keyboard**: which keys do what. (e.g. `ESC` closes; `Tab` moves focus; `Enter` activates.)
+- **ARIA**: which roles and attributes are applied automatically vs. what the consumer must supply.
+- **Focus**: where does focus go when the component opens / closes / changes state.
+- **Contrast**: which token guarantees AA/AAA contrast in which mode.
+- **Screen reader**: the announcement order and any `aria-label` / `sr-only` requirements.
+
+If a requirement only applies in a sub-component, scope it: `DialogTitle: ...`.
+
+## Tokens used
+
+The semantic CSS variables this component reads from. Only list tokens used in the component's own classes; do not list tokens consumed transitively.
+
+| Role                | Token                                                          |
+| ------------------- | -------------------------------------------------------------- |
+| Foreground          | `--color-fg-primary`                                           |
+| Background          | `--color-surface-bg-primary`                                   |
+| Hover state layer   | `--color-stateslayer-overlay-hover`                            |
+
+## Code Connect
+
+State the current mapping status and the planned file path.
+
+- **Status**: `not-mapped` | `partial` | `mapped`
+- **File**: `src/components/ui/{{kebab-name}}.figma.tsx`
+- **Figma node**: `https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr?node-id={{node-id}}`
+- **Mapping notes**: any quirks (e.g. "Figma `size=reg` maps to code `size='default'`").
+
+If a Figma component has multiple variants per code prop, list each one as a separate `figma.connect` block in the planned mapping file.
+
+## Anti-patterns
+
+Concrete BAD / GOOD pairs. Each pair must be runnable code, not pseudo-code.
+
+### BAD
+
+```tsx
+{{bad-example}}
+```
+
+Reason: {{why-this-breaks}}.
+
+### GOOD
+
+```tsx
+{{good-example}}
+```
+
+Reason: {{why-this-works}}.
+
+Aim for 2–4 pairs. Pick the failures most likely to occur in real code (especially: hardcoded hex, wrong `size` mapping, ignoring `asChild` for links, missing `aria-*`).
+
+## Migration notes
+
+Only when the component has changed shape recently or has a deprecated alternative. Otherwise omit this section.
+
+- `{{deprecated-name}}` -> `{{ComponentName}}` (since {{date}}). Codemod: `{{path-or-link}}`.
+
+## Related components
+
+Cross-links to siblings the consumer might confuse this with.
+
+- `{{Sibling}}` — when to reach for it instead.
+- `{{ParentPattern}}` — composition recipe that uses this component.
+
+---
+
+## Authoring notes (delete in the published card)
+
+- **Tone**: imperative for rules, descriptive for context. No marketing language.
+- **No emojis.** Anywhere. Use plain words for status (`Done`, `Open question`, `Blocked`).
+- **Token names** must match `src/styles/globals.css`. If a token doesn't exist, flag it as an open issue rather than inventing one.
+- **Code snippets** import from `@/components/ui/{{kebab-name}}` (the registry path). Avoid relative paths in examples.
+- **Length target**: 800–1500 words. Longer cards are usually a sign of a component that should be split.
+- **Update the front matter**, especially `last-updated`, `code-connect.mapped`, and `figma.primary-node-id`. The front matter is the only machine-readable contract.

--- a/docs/component-rules/button.md
+++ b/docs/component-rules/button.md
@@ -1,0 +1,262 @@
+---
+component: "button"
+display-name: "Button"
+status: "stable"
+last-updated: "2026-05-10"
+registry-name: "button"
+figma:
+  file-key: "iuMWqCsIohoKAUB0tBS0xr"
+  page: "❖ ⎯ Buttons"
+  primary-node-id: "2175:28524"
+code-connect:
+  mapped: false
+  file: "src/components/ui/button.figma.tsx"
+related:
+  - "buttons-group"
+  - "icon-shell"
+  - "tooltip"
+---
+
+# Button
+
+> The single-action affordance. Anything the user can click that does one thing — submitting, opening, dismissing, navigating — is a `Button`.
+
+## Purpose
+
+`Button` is the primary call-to-action primitive in QBDS. It enforces consistent sizing, focus rings, disabled treatment, hover/pressed state-layers, and inverted text contrast across light and dark modes. All other interactive primitives (link, segmented control, icon button) either compose `Button` or follow its hard rules.
+
+## When to use
+
+- Submitting a form (`type="submit"` inside `<Form>`).
+- Triggering an action: `Save`, `Delete`, `Apply filter`, `Add row`.
+- Opening overlays: `Dialog`, `Sheet`, `Popover`, `DropdownMenu` (always via the overlay's own `Trigger` slot, not a bare `<Button onClick>`).
+- Navigating between routes — but only when paired with `asChild` to render an `<a>` underneath.
+
+## When not to use
+
+- Plain text links inline in body copy → use a real `<a>` styled as a link, not a `ghost` Button.
+- Toggle on/off → use `Switch` (binary) or `Toggle` (segmented), not two-state Buttons.
+- Pure decorative containers → never put `<Button>` around non-clickable content; if it does nothing on `onClick`, it is not a Button.
+- Submitting AND navigating at once → split into two Buttons or a `DropdownMenu`.
+
+## Anatomy
+
+`Button` is a single primitive with two notable internals:
+
+- The element itself (`<button>` by default, or any tag if `asChild` is true).
+- An automatic text wrapper (`wrapTextNodes`) that wraps every string/number child in a `<span>`. This guarantees that hover/focus underlines apply to text only, never to icons or other inline children.
+
+`data-slot="button"` is set on the root for selector-based theming and Code Connect identity.
+
+## API surface
+
+Source of truth: `public/api/button.json`.
+
+| Prop       | Type                                                                                                                | Default     | Notes                                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------- |
+| `variant`  | `"default" \| "accent" \| "secondary" \| "outline" \| "ghost"`                                                       | `"default"` | Visual treatment. `default` is the high-emphasis dark-on-light primary action.         |
+| `size`     | `"xxs" \| "xs" \| "sm" \| "default" \| "lg" \| "icon-xs" \| "icon-sm" \| "icon" \| "icon-lg"`                        | `"default"` | Text sizes use `cta-button-01..03`. Icon sizes are square (no padding) for `IconShell`. |
+| `asChild`  | `boolean`                                                                                                            | `false`     | Render as the immediate child via Radix `Slot`. Use for link buttons.                  |
+| `disabled` | `boolean`                                                                                                            | `false`     | Standard HTML; combined with `disabled:` Tailwind classes for the disabled state layer. |
+| `type`     | `"button" \| "submit" \| "reset"`                                                                                    | `"button"`  | Native HTML. Always set explicitly inside forms — never rely on the browser default.    |
+
+The component also accepts every native `<button>` prop (`onClick`, `aria-*`, `name`, `value`, `form`, etc.) via `React.ComponentProps<'button'>`.
+
+### Variant matrix (what each combo means)
+
+- `default` — primary action; `bg-fill-primary` / `text-fg-primary-inverse`. Used for the dominant action in a dialog footer, form submit, or toolbar.
+- `accent` — brand-accented primary; `bg-brand-accents-qb-accent`. Reserved for marquee CTAs and brand surfaces. Do not use as a generic alternative to `default`.
+- `secondary` — companion to `default`; `bg-fill-muted` / `text-fg-primary`. Use for secondary actions like `Cancel` next to `Save`.
+- `outline` — bordered, low-emphasis; `border-stroke-secondary`. Use when surface needs a contour but the action is non-critical.
+- `ghost` — transparent until hovered. Use inside dense surfaces (toolbars, table cells, menu items) where chrome would compete with content.
+
+## Hard rules
+
+1. **Always set `type` explicitly inside a `<form>`.** Default browser behaviour is `type="submit"`; an unmarked button inside a form will submit unintentionally. Why: prevents accidental submissions.
+2. **Use `asChild` for navigation, never `onClick={() => router.push(...)}`.** Pair with `<a>` or your router's `<Link>`. Why: preserves middle-click, ctrl-click, right-click "open in new tab", and screen reader link semantics.
+3. **Never compose `<Button>` inside `<Button>`.** Radix `Slot` will collide and the inner element will lose accessibility props. If you need nested actions, use a `DropdownMenu` or split actions.
+4. **Use the `icon-*` sizes only with `IconShell` as the sole child.** Mixing text + icon at icon sizes breaks the square footprint and the focus ring offset.
+5. **Disabled buttons must remain in the DOM, not be removed.** Removing a button on disable shifts focus unpredictably. Why: keeps tab order stable; lets screen readers announce the disabled state.
+6. **Use semantic `aria-label` on `icon-*` buttons.** An icon without a visible label is meaningless to AT users. Why: WCAG 2.1 Success Criterion 4.1.2.
+7. **Bind colors only via QBDS tokens — never hardcoded hex.** All Button classes resolve to `--color-*` semantic variables. Why: ensures dark-mode and brand-theme parity.
+8. **Wrap action text in normal children, not in a nested `<span>`.** The component already injects a span via `wrapTextNodes` for the underline behaviour. Adding your own breaks the underline scoping.
+
+## Soft rules
+
+- Prefer text + icon over icon-only when space allows. Icon-only is harder for first-time users.
+- Place the primary `Button` on the trailing side of footers and toolbars (right on LTR locales).
+- Pair `default` with `secondary` in two-button layouts. Two `default` buttons confuse the eye.
+- Use `lg` only for landing-page hero CTAs. Inside dense product UIs, `default` is correct.
+
+## Composition patterns
+
+### Pattern: Submit + Cancel in a Dialog footer
+
+The default action and its escape hatch.
+
+```tsx
+import { Button } from '@/components/ui/button';
+import { DialogFooter, DialogClose } from '@/components/ui/dialog';
+
+<DialogFooter>
+  <DialogClose asChild>
+    <Button variant="secondary">Cancel</Button>
+  </DialogClose>
+  <Button type="submit" form="invite-form">Send invite</Button>
+</DialogFooter>;
+```
+
+### Pattern: Link button (navigation)
+
+When the affordance looks like a button but is actually a link.
+
+```tsx
+import { Button } from '@/components/ui/button';
+import { Link } from 'react-router-dom';
+
+<Button asChild variant="outline">
+  <Link to="/billing">Manage billing</Link>
+</Button>;
+```
+
+### Pattern: Icon-only button with tooltip
+
+Icon-only must always carry an accessible name. Pair with `Tooltip` for sighted users.
+
+```tsx
+import { Button } from '@/components/ui/button';
+import { IconShell } from '@/components/ui/icon-shell';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Trash2 } from 'lucide-react';
+
+<Tooltip>
+  <TooltipTrigger asChild>
+    <Button size="icon" variant="ghost" aria-label="Delete row">
+      <IconShell icon={Trash2} />
+    </Button>
+  </TooltipTrigger>
+  <TooltipContent>Delete row</TooltipContent>
+</Tooltip>;
+```
+
+### Pattern: Loading state
+
+While an async action is in flight, disable the button and swap the label. Avoid replacing the entire button — keep the same width to prevent layout shift.
+
+```tsx
+<Button type="submit" disabled={isSaving} aria-busy={isSaving}>
+  {isSaving ? 'Saving…' : 'Save changes'}
+</Button>;
+```
+
+## Accessibility contract
+
+- **Keyboard**: `Enter` and `Space` activate. `Tab` moves focus. Disabled buttons are skipped by `Tab` (this is the browser default for `<button disabled>`).
+- **ARIA**: native `<button>` is implicit role="button". Add `aria-label` for icon-only. Add `aria-pressed` only if the button is a toggle (rare — prefer `Toggle`).
+- **Focus**: focus ring uses `--color-stroke-status-focus` with a `ring-offset` that swaps to the inverse stroke for `default`/`accent` so the ring stays visible on dark fills. Smaller sizes use `ring-1`, default/large use `ring-2`.
+- **Contrast**: `default` text on `default` fill exceeds 7:1 AAA. `ghost` over `surface-bg-primary` exceeds 4.5:1 AA.
+- **Screen reader**: visible text is the accessible name unless `aria-label` overrides it. Loading state should announce via `aria-busy="true"` on the button.
+
+## Tokens used
+
+| Role                              | Token                                                                  |
+| --------------------------------- | ---------------------------------------------------------------------- |
+| Foreground (text, default fill)   | `--color-fg-primary-inverse`                                           |
+| Foreground (text, light fills)    | `--color-fg-primary`                                                   |
+| Foreground (disabled)             | `--color-fg-disabled`                                                  |
+| Fill (default)                    | `--color-fill-primary`                                                 |
+| Fill (secondary)                  | `--color-fill-muted`                                                   |
+| Fill (outline / ghost / disabled) | `--color-fill-muted-inverse`, `transparent`, `--color-fill-muted`      |
+| Brand accent                      | `--color-brand-accents-qb-accent` + `--color-mist-50-opacity-88` (text) |
+| Border (outline)                  | `--color-stroke-secondary`, focus -> `--color-stroke-active`           |
+| Focus ring                        | `--color-stroke-status-focus`                                          |
+| Hover state layer                 | `--color-stateslayer-overlay-hover`, `-hover-inverse`                  |
+| Pressed state layer               | `--color-stateslayer-overlay-pressed`, `-pressed-inverse`              |
+| Disabled state layer              | `--color-stateslayer-overlay-disabled`                                 |
+| Active state layer (focus-visible)| `--color-stateslayer-overlay-active`, `-active-inverse`                |
+
+State layers are applied via `background-image: linear-gradient(token, token)` so they composite over the existing fill. **The class names must appear literally in source** — Tailwind's JIT cannot see template-string interpolation. See the `hoverGradient`/`activeGradient` constants in `button.tsx`.
+
+## Code Connect
+
+- **Status**: `not-mapped`.
+- **File** (planned): `src/components/ui/button.figma.tsx`.
+- **Figma node**: <https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr?node-id=2175-28524>.
+- **Mapping notes**:
+  - Figma `size=` axis values map 1:1 to code `size` values when the names match. The Figma `reg` value (if present) maps to code `'default'`. Verify against the live `❖ ⎯ Buttons` page before authoring.
+  - Figma `type=` (variant) is expected to align with code `variant`. Confirm: `default`, `accent`, `secondary`, `outline`, `ghost`.
+  - Figma icon-only sets are typically separate component sets; expect 4 distinct `figma.connect` blocks (text + icon-leading + icon-trailing + icon-only).
+  - `asChild` cannot be expressed in Figma. Always render the example as a plain `<Button>`; document the `asChild` route in the card, not in Code Connect.
+
+## Anti-patterns
+
+### BAD: hardcoded color
+
+```tsx
+<Button style={{ backgroundColor: '#0F62FE' }}>Save</Button>
+```
+
+Reason: bypasses the QBDS token system. Will not adapt to dark mode; will not pick up brand-theme overrides; cannot be audited by `figma_lint_design`.
+
+### GOOD: variant-driven color
+
+```tsx
+<Button variant="accent">Save</Button>
+```
+
+Reason: every fill / text / state-layer routes through `--color-*` tokens, so dark mode and brand themes are automatic.
+
+### BAD: Button-wrapped link missing `asChild`
+
+```tsx
+<Button onClick={() => navigate('/billing')}>Manage billing</Button>
+```
+
+Reason: breaks middle-click, right-click "Open in new tab", screen reader link semantics, and SSR-friendly prefetch.
+
+### GOOD: link-as-button via `asChild`
+
+```tsx
+<Button asChild variant="outline">
+  <Link to="/billing">Manage billing</Link>
+</Button>
+```
+
+### BAD: icon-only without an accessible name
+
+```tsx
+<Button size="icon" variant="ghost">
+  <IconShell icon={Trash2} />
+</Button>
+```
+
+Reason: screen readers announce "button" with no name; fails WCAG 4.1.2.
+
+### GOOD: icon-only with `aria-label`
+
+```tsx
+<Button size="icon" variant="ghost" aria-label="Delete row">
+  <IconShell icon={Trash2} />
+</Button>
+```
+
+### BAD: nested Buttons
+
+```tsx
+<Button asChild>
+  <Button variant="ghost">Open</Button>
+</Button>
+```
+
+Reason: `Slot` collides with the inner button's props; focus, disabled, and ARIA all break in subtle ways.
+
+## Migration notes
+
+None. Button has been API-stable since v1.
+
+## Related components
+
+- `ButtonsGroup` — segmented multi-button container (`❖ ⎯ Buttons Group` page in Figma).
+- `IconShell` — the icon primitive used inside `icon-*` button sizes. Always pair them.
+- `Tooltip` — required companion for icon-only Buttons.
+- `DropdownMenu` — when a Button needs to expose multiple actions, prefer this over chaining Buttons.

--- a/docs/component-rules/dialog.md
+++ b/docs/component-rules/dialog.md
@@ -1,0 +1,297 @@
+---
+component: "dialog"
+display-name: "Dialog"
+status: "stable"
+last-updated: "2026-05-10"
+registry-name: "dialog"
+figma:
+  file-key: "iuMWqCsIohoKAUB0tBS0xr"
+  page: "❖ ⎯ Dialog"                # OPEN ISSUE: no dedicated Dialog page in QBDS v2.0.0 yet
+  primary-node-id: "tbd"
+code-connect:
+  mapped: false
+  file: "src/components/ui/dialog.figma.tsx"
+related:
+  - "button"
+  - "form"
+  - "sheet"
+  - "alert-dialog"
+---
+
+# Dialog
+
+> A modal surface that interrupts the main flow. Use it when the user must finish or dismiss a discrete task before continuing.
+
+## Purpose
+
+`Dialog` is QBDS's modal primitive, built on Radix UI's accessible Dialog. It traps focus, restores it on close, renders into a portal, dims the page with an overlay, and exposes a compositional API (`Trigger`, `Content`, `Header`, `Title`, `Description`, `Footer`, `Close`). It is the right surface for short, focused interactions — confirmations, single-form submissions, detail edits — when the user must commit or cancel before doing anything else.
+
+## When to use
+
+- The user is committing to a discrete action (`Delete invoice?`, `Invite teammate`).
+- A form's complexity is small enough to fit on one screen and finishing it is mandatory.
+- The user is editing a single record where context outside the dialog is useful (preview behind the overlay).
+
+## When not to use
+
+- Multi-step wizards or long forms → use a full page or a `Sheet` (slide-over) so users can defer.
+- Destructive irreversible actions where the user needs a stronger interrupt → use `AlertDialog` (when added to QBDS) or a confirmation pattern with explicit consequence text.
+- Non-blocking notifications → use `Toast` or `Snackbar`.
+- Nested dialogs → never. If a sub-task requires interruption, replace the current `Dialog`; do not stack.
+
+## Anatomy
+
+| Sub-component       | data-slot           | Required? | Notes                                                                                |
+| ------------------- | ------------------- | --------- | ------------------------------------------------------------------------------------ |
+| `Dialog`            | `dialog`            | yes       | Root state container. Wraps `DialogPrimitive.Root`.                                  |
+| `DialogTrigger`     | `dialog-trigger`    | usually   | The control that opens the dialog. Use `asChild` to wrap a `<Button>`.               |
+| `DialogPortal`      | `dialog-portal`     | implicit  | Rendered automatically by `DialogContent`. Do not include manually.                  |
+| `DialogOverlay`     | `dialog-overlay`    | implicit  | Rendered automatically by `DialogContent`. Do not include manually.                  |
+| `DialogContent`     | `dialog-content`    | yes       | The modal surface. Holds the layout (`bg-surface-bg-primary`, centered, `max-w-lg`). |
+| `DialogHeader`      | `dialog-header`     | yes       | Vertical group containing `DialogTitle` + `DialogDescription`.                       |
+| `DialogTitle`       | `dialog-title`      | yes       | Required for screen reader announcement. Radix throws a dev-only error if missing.   |
+| `DialogDescription` | `dialog-description`| yes       | Required for screen reader announcement. Pair with `DialogTitle`.                    |
+| `DialogFooter`      | `dialog-footer`     | usually   | Action buttons. Stacks on mobile (`flex-col-reverse`), inlines on `sm:` breakpoint.  |
+| `DialogClose`       | `dialog-close`      | usually   | Programmatic close trigger. Use `asChild` for the cancel button.                     |
+
+The built-in close affordance (the `X` in the top-right) is rendered by `DialogContent` when `showCloseButton={true}` (the default). Set it to `false` only when you also provide an explicit `Close` action in the body.
+
+## API surface
+
+Sub-components forward all props to the underlying Radix primitive. The only QBDS-added prop is on `DialogContent`:
+
+| Component       | Prop              | Type      | Default | Notes                                                                                |
+| --------------- | ----------------- | --------- | ------- | ------------------------------------------------------------------------------------ |
+| `DialogContent` | `showCloseButton` | `boolean` | `true`  | Renders the top-right `X` icon + `sr-only` "Close" label. Disable only if you supply an alternative dismiss control. |
+
+For Radix-supplied props (controlled `open`, `onOpenChange`, `modal`, `defaultOpen`), follow [the Radix Dialog docs](https://www.radix-ui.com/primitives/docs/components/dialog). The most important ones:
+
+- `open` / `onOpenChange` — for controlled state (necessary if dismiss should be confirmed first).
+- `modal={false}` — disables focus trap and overlay click-to-close. Almost never the right choice for QBDS surfaces.
+
+## Hard rules
+
+1. **Always render `DialogTitle` and `DialogDescription`.** Both are required for accessible naming and description. Radix dev mode warns when missing; production silently fails AT users. Why: WCAG 4.1.2 (Name, Role, Value).
+2. **Use `DialogTrigger` with `asChild` to wrap a `<Button>`.** Do not put `onClick` on a Button to flip controlled state if Radix's uncontrolled state is enough. Why: keeps focus return logic intact and avoids double-state.
+3. **Never nest a `Dialog` inside another `Dialog`.** Replace the current dialog instead. Why: focus trap stacks become ambiguous, and Radix does not document a guarantee for nested dialogs.
+4. **Submit-style buttons in `DialogFooter` must be `type="submit"` and reference the form by `form="..."`.** The body's form must have `id="..."` matching. Why: the dialog's footer is outside the form element by convention; the `form=` attribute reconnects them.
+5. **`DialogContent` must remain centered and max `sm:max-w-lg`.** Do not override `max-width` for "more breathing room" — that is a sign the content belongs in a page or `Sheet`, not a dialog.
+6. **Do not put a scroll container inside `DialogContent` without explicit overflow handling.** Long content should either move to a `Sheet`, or `DialogContent` should be allowed to grow with `max-h` + an inner scroll region. Avoid sticky headers/footers inside the dialog.
+7. **Always provide an explicit cancel/dismiss path.** Either keep `showCloseButton`, or include a `Cancel` button in `DialogFooter` via `<DialogClose asChild><Button variant="secondary">Cancel</Button></DialogClose>`.
+8. **The destructive action's button must use the destructive variant.** Until QBDS ships a destructive variant, use `default` and prepend an explicit consequence sentence in `DialogDescription` ("This will permanently delete 17 records.").
+
+## Soft rules
+
+- Keep `DialogTitle` to one line — about 6 words.
+- Keep `DialogDescription` to one short sentence; if you need more, the action probably belongs on a full page.
+- Footer order, LTR: `Cancel` (left, `secondary`), primary action (right, `default` or `accent`).
+- Avoid putting more than two actions in `DialogFooter`. A third action is usually a sign of feature creep.
+- Do not animate content into the dialog — Radix already animates the overlay and content. Extra animation feels jittery.
+
+## Composition patterns
+
+### Pattern: Confirm a destructive action
+
+The most common Dialog use case. Note the explicit consequence sentence in the description.
+
+```tsx
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+<Dialog>
+  <DialogTrigger asChild>
+    <Button variant="ghost">Delete invoice</Button>
+  </DialogTrigger>
+  <DialogContent>
+    <DialogHeader>
+      <DialogTitle>Delete invoice INV-7821?</DialogTitle>
+      <DialogDescription>
+        This permanently removes the invoice and its line items. This action cannot be undone.
+      </DialogDescription>
+    </DialogHeader>
+    <DialogFooter>
+      <DialogClose asChild>
+        <Button variant="secondary">Cancel</Button>
+      </DialogClose>
+      <Button onClick={onConfirmDelete}>Delete</Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>;
+```
+
+### Pattern: Form submission
+
+Form lives inside `DialogContent`; submit button lives in `DialogFooter` and binds via `form="..."`.
+
+```tsx
+<Dialog>
+  <DialogTrigger asChild>
+    <Button>Invite teammate</Button>
+  </DialogTrigger>
+  <DialogContent>
+    <DialogHeader>
+      <DialogTitle>Invite a teammate</DialogTitle>
+      <DialogDescription>They will receive an email with a join link.</DialogDescription>
+    </DialogHeader>
+    <Form {...form}>
+      <form id="invite-form" onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4">
+        {/* FormField items */}
+      </form>
+    </Form>
+    <DialogFooter>
+      <DialogClose asChild>
+        <Button variant="secondary">Cancel</Button>
+      </DialogClose>
+      <Button type="submit" form="invite-form">Send invite</Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>;
+```
+
+### Pattern: Controlled open with a custom dismiss guard
+
+When closing requires a confirmation (e.g. unsaved changes).
+
+```tsx
+const [open, setOpen] = React.useState(false);
+
+const handleOpenChange = (next: boolean) => {
+  if (!next && form.formState.isDirty) {
+    if (!window.confirm('Discard unsaved changes?')) return;
+  }
+  setOpen(next);
+};
+
+<Dialog open={open} onOpenChange={handleOpenChange}>
+  {/* ... */}
+</Dialog>;
+```
+
+## Accessibility contract
+
+- **Keyboard**: `ESC` closes (overrideable via `onOpenChange`). `Tab` cycles focus inside the dialog only. The first focusable element receives focus on open; focus returns to the trigger on close (Radix default).
+- **ARIA**: Radix sets `role="dialog"`, `aria-modal="true"`, `aria-labelledby={title-id}`, `aria-describedby={description-id}` automatically. The `DialogTitle` and `DialogDescription` IDs are wired via Radix context — you do not set them manually.
+- **Focus**: a focus trap is active while the dialog is open. The overlay click and `ESC` both dismiss unless `onOpenChange` returns false.
+- **Contrast**: `bg-surface-bg-primary` against the `bg-black/50` overlay exceeds AA in both modes. Title (`text-fg-primary`) over surface exceeds AAA.
+- **Screen reader**: the announcement is "{Title}. {Description}. Dialog." in this order. Avoid putting essential consequence text in the body — it will be skipped by AT users on first focus.
+- **Reduced motion**: the fade/zoom animations are CSS-driven (`data-[state=open]:animate-in`) and respect `prefers-reduced-motion` via Tailwind's `motion-safe`/`motion-reduce` utilities. Add `motion-reduce:animate-none` on `DialogContent` if you observe issues.
+
+## Tokens used
+
+| Role                | Token                                                 |
+| ------------------- | ----------------------------------------------------- |
+| Surface             | `--color-surface-bg-primary` (DialogContent fill)     |
+| Foreground (title)  | `--color-fg-primary` (via DialogHeader)               |
+| Foreground (close)  | `--color-fg-secondary`                                |
+| Overlay             | `bg-black/50` (Tailwind utility — not a QBDS token)   |
+| Border              | default `border` (1px) — currently relies on the user-agent default border-color |
+| Shadow              | `shadow-lg` (Tailwind utility — not yet bound to a QBDS effect style) |
+
+**Open issues**:
+
+- The overlay (`bg-black/50`) and shadow (`shadow-lg`) are Tailwind defaults, not QBDS tokens. When QBDS exposes `--color-overlay-scrim` and a QBDS effect style for elevation, swap them in.
+- The default `border` on `DialogContent` has no explicit color binding — it falls back to Tailwind's default border color. Should bind to `--color-stroke-tertiary` or similar.
+
+## Code Connect
+
+- **Status**: `not-mapped`.
+- **File** (planned): `src/components/ui/dialog.figma.tsx`.
+- **Figma node**: not yet known. There is no `❖ ⎯ Dialog` page in QBDS v2.0.0 (verified against the page list).
+- **Mapping notes**:
+  - **Open issue**: dialog needs a Figma component set before Code Connect can be authored. The likely approach is one component set with variants for `header`, `description`, `footer-actions`, and `closable` axes.
+  - When the Figma component is shipped, expect `figma.connect` blocks per major composition (confirmation vs. form).
+  - Compound components (`DialogTitle`, `DialogDescription` etc.) generally do not get individual Code Connect blocks — only the parent does.
+
+## Anti-patterns
+
+### BAD: missing accessible name
+
+```tsx
+<DialogContent>
+  <p>Are you sure?</p>
+  <Button>Delete</Button>
+</DialogContent>
+```
+
+Reason: no `DialogTitle`, no `DialogDescription`. Radix warns in dev; AT users get a dialog announcement with no context.
+
+### GOOD: explicit Title + Description
+
+```tsx
+<DialogContent>
+  <DialogHeader>
+    <DialogTitle>Delete this row?</DialogTitle>
+    <DialogDescription>This action cannot be undone.</DialogDescription>
+  </DialogHeader>
+  {/* ... */}
+</DialogContent>
+```
+
+### BAD: nested dialog
+
+```tsx
+<Dialog>
+  <DialogContent>
+    <Dialog>
+      <DialogContent>...</DialogContent>
+    </Dialog>
+  </DialogContent>
+</Dialog>
+```
+
+Reason: focus trap and ARIA modal stacking is undefined. Replace the parent dialog content instead.
+
+### BAD: footer button outside the form's reach
+
+```tsx
+<DialogContent>
+  <form onSubmit={onSubmit}>
+    <Input name="email" />
+  </form>
+  <DialogFooter>
+    <Button type="submit">Save</Button> {/* this is NOT inside the form */}
+  </DialogFooter>
+</DialogContent>
+```
+
+Reason: the submit button isn't a descendant of the form, so clicking it does nothing.
+
+### GOOD: link the button to the form by id
+
+```tsx
+<form id="invite-form" onSubmit={onSubmit}>
+  <Input name="email" />
+</form>
+<DialogFooter>
+  <Button type="submit" form="invite-form">Save</Button>
+</DialogFooter>
+```
+
+### BAD: oversized dialog
+
+```tsx
+<DialogContent className="max-w-4xl">{/* multi-step form */}</DialogContent>
+```
+
+Reason: a multi-step form belongs on a page or in a `Sheet`, not in a dialog. Increasing `max-w` masks the design problem.
+
+## Migration notes
+
+None. Dialog has been API-stable since shadcn integration.
+
+## Related components
+
+- `Button` — `DialogTrigger asChild` and `DialogClose asChild` always wrap a Button.
+- `Form` — the body of a Dialog form. Always set `id` on the form so the footer's submit button can reference it.
+- `Sheet` (slide-over panel) — for longer interactions or wizards.
+- `AlertDialog` (planned) — when QBDS ships it, use it for destructive irreversible actions.
+- `Toast` / `Snackbar` — for non-blocking notifications.

--- a/docs/component-rules/form.md
+++ b/docs/component-rules/form.md
@@ -1,0 +1,340 @@
+---
+component: "form"
+display-name: "Form"
+status: "stable"
+last-updated: "2026-05-10"
+registry-name: "form"
+figma:
+  file-key: "iuMWqCsIohoKAUB0tBS0xr"
+  page: "❖ ⎯ Form"
+  primary-node-id: "40809:80577"
+code-connect:
+  mapped: false
+  file: "n/a"     # Form has no visual representation; Code Connect does not apply
+related:
+  - "input"
+  - "label"
+  - "button"
+  - "dialog"
+  - "form-elements"
+---
+
+# Form
+
+> The contract that ties react-hook-form, QBDS field primitives, and accessible labelling into one composable shape. Every QBDS form on every page goes through this.
+
+## Purpose
+
+`Form` is QBDS's form orchestration layer. It is a thin wrapper over `react-hook-form`'s `FormProvider`, plus four context-aware sub-components (`FormItem`, `FormLabel`, `FormControl`, `FormDescription`, `FormMessage`) and a typed `FormField` controller. Together they wire a single field's `id`, `aria-describedby`, `aria-invalid`, error state, and label association — automatically. Consumers write field code without thinking about IDs or ARIA strings.
+
+Validation is **not** included; pair `Form` with a schema validator (recommended: `zod` + `@hookform/resolvers/zod`) supplied at the call site.
+
+## When to use
+
+- Any user-editable form longer than one field. Below that, a single `<input>` with a label is fine.
+- Any form that needs validation feedback bound to a field (the `aria-describedby` chain is the whole point).
+- Forms inside `Dialog`, `Sheet`, or full pages — the API is identical regardless of host.
+
+## When not to use
+
+- Read-only display of values → use `<dl>` / `Card` / a definition list, not a Form.
+- One-shot inputs where validation is trivial and there's no submit step (e.g. a search box) → a controlled `<Input>` is enough.
+- File uploads as the only field → use a dedicated upload component; Form's API doesn't help here.
+
+## Anatomy
+
+`Form` is a compound component built around two React contexts (`FormFieldContext`, `FormItemContext`) plus the hook `useFormField()` that ties them together.
+
+| Sub-component       | data-slot          | Required? | Notes                                                                                                  |
+| ------------------- | ------------------ | --------- | ------------------------------------------------------------------------------------------------------ |
+| `Form`              | (none — provider)  | yes       | Re-export of `FormProvider` from react-hook-form. Spread the `useForm()` return into it.                |
+| `FormField`         | (none — controller)| yes       | Typed wrapper over RHF's `Controller`. Sets `FormFieldContext.name` so descendants know their field.    |
+| `FormItem`          | `form-item`        | yes       | Layout container for a single field. Generates the field's `id` via `React.useId()`.                    |
+| `FormLabel`         | `form-label`       | usually   | Wraps `<Label>`; sets `htmlFor` to the auto-generated `formItemId`. Toggles error styling via `data-error`. |
+| `FormControl`       | `form-control`     | yes       | Radix `Slot` that injects `id`, `aria-describedby`, and `aria-invalid` into its single child.           |
+| `FormDescription`   | `form-description` | optional  | Hint text. Receives `id={formDescriptionId}` so it joins the `aria-describedby` chain.                  |
+| `FormMessage`       | `form-message`     | yes¹     | Renders the error string for the field. Returns `null` when there is no error and no fallback child.    |
+
+¹ `FormMessage` is required *if* the field validates; if the field cannot fail, you may omit it.
+
+`useFormField()` exposes `{ id, name, formItemId, formDescriptionId, formMessageId, error, ...fieldState }` — useful only for advanced compositions (e.g. building a custom `FormControl` for a non-input control).
+
+## API surface
+
+`Form` itself takes no QBDS-specific props — it is `FormProvider` and forwards every RHF prop. The interesting surface lives in `FormField`'s `ControllerProps` (from react-hook-form):
+
+| Prop          | Type                                                    | Notes                                                                  |
+| ------------- | ------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `name`        | `FieldPath<TFieldValues>`                               | Path into the form's value shape. Typed against your `useForm` schema. |
+| `control`     | `Control<TFieldValues>`                                 | From `useForm()`. Optional if `FormProvider` is in scope.              |
+| `defaultValue`| `TFieldValues[name]`                                    | Initial value for the field.                                           |
+| `rules`       | `RegisterOptions`                                       | Avoid — prefer schema-based validation (zod) at `useForm` time.        |
+| `render`      | `({ field, fieldState, formState }) => ReactElement`     | Required. Render the field UI here.                                    |
+
+`FormField` uses `Controller`, so a field's value flows via `field.value`, `field.onChange`, `field.onBlur`, `field.ref`. Spread these into the input.
+
+## Hard rules
+
+1. **Wrap the whole form in `<Form {...form}>` where `form = useForm({...})`.** The provider is what makes `useFormField()` work. Why: every sub-component depends on `FormProvider`'s context.
+2. **Every field is `<FormField name="..." render={...}>`, not a raw `<input>`.** Why: `Controller` registers the field with RHF, manages its lifecycle, and exposes `field.onChange` for non-native inputs (Combobox, Calendar, etc.).
+3. **Inside `render`, the structure is exactly: `FormItem > FormLabel + FormControl + FormDescription? + FormMessage`.** In that order. Why: `FormControl` slots its props into the immediate child, so the wrapping element of the input must be `FormControl`. The order matters for screen reader announcement (label first, then field, then description, then error).
+4. **`FormControl` must wrap the actual input element.** It is a Radix `Slot`; it injects `id`, `aria-describedby`, `aria-invalid` into its single child. If you wrap a `<div>` around the input inside `FormControl`, the IDs land on the wrong node.
+5. **Use `FormMessage` for errors — never render `fieldState.error.message` manually.** Why: `FormMessage` already wires `id={formMessageId}`, which `FormControl` includes in `aria-describedby` only when there's an error. Manual rendering breaks the AT chain.
+6. **Validation lives on `useForm`, not on `<input required>`.** Pair with a `zodResolver`. Why: HTML validation cannot be styled consistently and bypasses RHF's error state.
+7. **Never set `id` manually on a Form input.** `FormItem` generates a stable id via `React.useId()` and `FormControl` propagates it. Setting `id` yourself collides with the generated one.
+8. **Submit via `form.handleSubmit(onSubmit)` on the `<form>` element, not via a button click handler.** Why: `handleSubmit` runs validation and only invokes `onSubmit` on success. Bypassing it skips validation.
+
+## Soft rules
+
+- Place `FormDescription` between the label and the input only when the hint clarifies *what* the input expects. Place it after the input when the hint clarifies *how* the input is used.
+- Keep field labels short (1–3 words). Use `FormDescription` for the long version.
+- Group related fields visually with a heading + a `flex flex-col gap-4` wrapper, not a `<fieldset>` with default browser styling — but do use `<fieldset>` + `<legend>` if you need true semantic grouping for AT.
+- Show inline `FormMessage` errors only after the user has interacted (`onBlur` or after first submit). RHF's `mode: 'onBlur'` or `'onTouched'` does this for you.
+
+## Composition patterns
+
+### Pattern: Single-field form (with zod)
+
+```tsx
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+const schema = z.object({
+  email: z.string().email('Enter a valid email.'),
+});
+
+type Values = z.infer<typeof schema>;
+
+export function InviteForm({ onSubmit }: { onSubmit: (v: Values) => void }) {
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: '' },
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4">
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" autoComplete="email" {...field} />
+              </FormControl>
+              <FormDescription>We will send a join link.</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit">Send invite</Button>
+      </form>
+    </Form>
+  );
+}
+```
+
+### Pattern: Form inside a Dialog
+
+The form lives inside `DialogContent`; the submit button lives in `DialogFooter` and references the form by id (see also `dialog.md`).
+
+```tsx
+<DialogContent>
+  <DialogHeader>
+    <DialogTitle>Invite a teammate</DialogTitle>
+    <DialogDescription>They will receive an email with a join link.</DialogDescription>
+  </DialogHeader>
+  <Form {...form}>
+    <form id="invite-form" onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4">
+      <FormField {/* ... */} />
+    </form>
+  </Form>
+  <DialogFooter>
+    <DialogClose asChild>
+      <Button variant="secondary">Cancel</Button>
+    </DialogClose>
+    <Button type="submit" form="invite-form">Send invite</Button>
+  </DialogFooter>
+</DialogContent>;
+```
+
+### Pattern: Custom non-input control (Combobox)
+
+`FormControl` works with any single child that accepts `id`, `aria-describedby`, `aria-invalid`. For QBDS components like `Combobox` or `Calendar`, hand `field.value` and `field.onChange` through.
+
+```tsx
+<FormField
+  control={form.control}
+  name="vendor"
+  render={({ field }) => (
+    <FormItem>
+      <FormLabel>Vendor</FormLabel>
+      <FormControl>
+        <Combobox
+          options={vendors}
+          value={field.value}
+          onValueChange={field.onChange}
+        />
+      </FormControl>
+      <FormMessage />
+    </FormItem>
+  )}
+/>;
+```
+
+### Pattern: Dependent fields
+
+Use `form.watch(...)` outside the field render, or `useWatch({ control, name })` inside.
+
+```tsx
+const region = form.watch('region');
+
+<FormField
+  control={form.control}
+  name="state"
+  render={({ field }) => (
+    <FormItem>
+      <FormLabel>State</FormLabel>
+      <FormControl>
+        <Select disabled={!region} {/* ... */} />
+      </FormControl>
+      <FormMessage />
+    </FormItem>
+  )}
+/>;
+```
+
+## Accessibility contract
+
+- **Label association**: `FormLabel` sets `htmlFor={formItemId}`. `FormControl` sets `id={formItemId}` on the input. The two are linked; clicking the label focuses the input.
+- **`aria-describedby`**: `FormControl` sets `aria-describedby` to `${formDescriptionId}` when there is no error, or `${formDescriptionId} ${formMessageId}` when there is. The chain is rebuilt on every render based on `error` from `useFormField()`.
+- **`aria-invalid`**: `FormControl` sets `aria-invalid={!!error}` so AT can announce the field state.
+- **Error styling**: `FormLabel` toggles `data-error="true"` when the field has an error, switching its color to `--color-status-error`. `FormMessage` always uses `--color-status-error` for the error text.
+- **Focus management**: RHF does not move focus on validation by default. To focus the first invalid field on submit, pass `shouldFocusError: true` (the default) when calling `useForm`.
+- **Live announcements**: error messages are statically rendered; they are not in an `aria-live` region. AT users hear them when they Tab back into the field. If you need immediate announcement, wrap the form in `<div role="status" aria-live="polite">` (rare — discuss with design first).
+
+## Tokens used
+
+| Role                  | Token                                                          |
+| --------------------- | -------------------------------------------------------------- |
+| Label foreground      | `--color-fg-secondary`                                         |
+| Label foreground (error) | `--color-status-error`                                       |
+| Description foreground| `--color-fg-secondary`                                         |
+| Message foreground    | `--color-status-error`                                         |
+
+Form-level surface, borders, and field backgrounds live on the input components themselves (`Input`, `Select`, etc.); see those cards for their token usage.
+
+## Code Connect
+
+- **Status**: `n/a`. `Form` has no visual representation in Figma — it is a logical wrapper. Code Connect targets visual components.
+- **Field-level mapping**: each individual input (`Input`, `Select`, `Combobox`, `Checkbox`, `Calendar`, `DatePicker`, etc.) gets its own `*.figma.tsx`. Those mappings stand alone and do not need to know about `Form`.
+- **Composition guidance**: when an LLM generates a Figma form layout, it should produce real `Input` / `Select` / `Combobox` instances bound to QBDS variables; the surrounding `<Form>` wrapper is a code-only concern.
+
+## Anti-patterns
+
+### BAD: raw input with manual id
+
+```tsx
+<form onSubmit={form.handleSubmit(onSubmit)}>
+  <label htmlFor="email">Email</label>
+  <input id="email" {...form.register('email')} aria-invalid={!!form.formState.errors.email} />
+  {form.formState.errors.email && <p>{form.formState.errors.email.message}</p>}
+</form>
+```
+
+Reason: rebuilds everything `FormItem` / `FormControl` / `FormMessage` already do; misses `aria-describedby`; will drift across consumers.
+
+### GOOD: idiomatic FormField
+
+```tsx
+<FormField
+  control={form.control}
+  name="email"
+  render={({ field }) => (
+    <FormItem>
+      <FormLabel>Email</FormLabel>
+      <FormControl>
+        <Input type="email" {...field} />
+      </FormControl>
+      <FormMessage />
+    </FormItem>
+  )}
+/>;
+```
+
+### BAD: wrapping FormControl around a non-input
+
+```tsx
+<FormControl>
+  <div>
+    <Input {...field} />
+  </div>
+</FormControl>
+```
+
+Reason: `FormControl` is a Radix `Slot`; it injects `id` / `aria-describedby` into its single child. The `<div>` swallows them and the underlying `<input>` ends up unlabelled and unreachable from the description chain.
+
+### GOOD: input is the direct child of FormControl
+
+```tsx
+<FormControl>
+  <Input {...field} />
+</FormControl>
+```
+
+### BAD: rendering errors manually
+
+```tsx
+{form.formState.errors.email && (
+  <span className="text-red-500">{form.formState.errors.email.message}</span>
+)}
+```
+
+Reason: hardcodes a colour, breaks the `aria-describedby` chain, and re-implements `FormMessage` poorly.
+
+### GOOD: FormMessage handles it
+
+```tsx
+<FormMessage />
+```
+
+### BAD: submit via onClick
+
+```tsx
+<Button onClick={() => onSubmit(form.getValues())}>Save</Button>
+```
+
+Reason: bypasses `form.handleSubmit`, skipping validation. Invalid data reaches the handler.
+
+### GOOD: type="submit" on a button inside the form
+
+```tsx
+<Button type="submit">Save</Button>
+```
+
+(Or `<Button type="submit" form="form-id">` if the button lives outside the `<form>` element, e.g. in a Dialog footer.)
+
+## Migration notes
+
+None. The Form API is stable since shadcn integration. The internal sub-component file structure (single `form.tsx` exporting all sub-components) matches the upstream convention.
+
+## Related components
+
+- `Input` / `Textarea` / `Select` / `Checkbox` / `RadioGroup` / `Switch` / `Combobox` / `Calendar` / `DatePicker` / `Slider` — the controls that go inside `FormControl`. Each has its own rules card.
+- `Label` — used internally by `FormLabel`. Reach for it directly only when you have a label *outside* a Form (rare).
+- `Button` — every form needs at least a submit button; see `button.md` for the `type="submit"` rules.
+- `Dialog` — the most common host for a Form. See `dialog.md` for the `form` attribute pattern.
+- `FormElements` (registry composition recipe) — when QBDS ships pre-composed field templates (e.g. `EmailField`, `PasswordField`), they will live there, not in `form.tsx`.

--- a/docs/qbds-figma-component-checklist.md
+++ b/docs/qbds-figma-component-checklist.md
@@ -1,0 +1,248 @@
+# QBDS v2.0.0 — Figma Component Checklist
+
+Canonical reference of every published component in the QBDS Figma library, cross-referenced against code exports in `src/components/ui/`.
+
+## Source of truth
+
+| | |
+|---|---|
+| Figma file | `QBDS v2.0.0` |
+| Figma file key | `iuMWqCsIohoKAUB0tBS0xr` |
+| Figma URL | https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr/QBDS-v2.0.0 |
+| Registry root | `src/components/ui/` |
+| Code Connect config | `figma.config.json` |
+
+## Publish state
+
+| | Count |
+|---|---|
+| Public (visible in Assets panel) | 78 |
+| Hidden internals (`.base/*`) | 8 |
+| Total component sets in file | 86 |
+
+## Naming conventions
+
+- **Singular PascalCase** for single-concept components (`Avatar`, `Button`, `IconShell`, `AlertBanner`, `RangeSlider`).
+- **Hyphen** for variant pairs and group wrappers (`Button-Icon`, `Tag-Toggle`, `Tags-Dismissable`, `InputGroup-Horizontal`).
+- **Slash** for category trees in Figma (`Badge/Numeric`, `Field/Text-Filled`, `Tooltip/OneLine`).
+- **Leading dot** `.base/*` for hidden internals (not shown in Assets panel).
+
+## Public components
+
+Each row shows the Figma component name, the matching React export in `src/components/ui/`, and Code Connect mapping status.
+
+### Alerts and feedback
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `AlertBanner` | `Alert` | unmapped |
+| `Snackbars` | `Toaster` / `toast` | unmapped |
+
+### Layout and media
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `AspectRatio` | *(none — candidate for new code component)* | n/a |
+| `DataTable-Starter` | `Table` | unmapped |
+
+### Avatars
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `Avatar` | `Avatar` | unmapped |
+| `GroupStacked` | `AvatarGroup` | unmapped |
+
+### Badges
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `Badge/Dot+Label` | `StatusBadge` | unmapped |
+| `Badge/Hint-Dot` | *(dot-only, no code yet)* | n/a |
+| `Badge/Icon+Label` | `Badge` *(with icon prop)* | unmapped |
+| `Badge/Label-Only` | `Badge` | unmapped |
+| `Badge/Numeric` | `NumericBadge` | unmapped |
+
+### Buttons
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `Button` | `Button` | unmapped |
+| `Button-Icon` | `Button` *(iconOnly prop)* | unmapped |
+| `Button-Split` | *(none — candidate)* | n/a |
+| `ButtonsGroup/CTAs` | *(composition pattern, no single code component)* | n/a |
+| `IconButton-Split` | *(none — candidate)* | n/a |
+| `ToolBar-Button` | *(none — candidate)* | n/a |
+
+### Selection controls
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `Checkbox` | `Checkbox` | unmapped |
+| `CheckboxGroup/Item` | `Checkbox` + `Label` | unmapped |
+| `CheckboxGroup/List Horizontal` | *(composition)* | n/a |
+| `CheckboxGroup/List Vertical` | *(composition)* | n/a |
+| `RadioButton` | `RadioGroupItem` *(primitive)* | unmapped |
+| `RadioGroup/Item` | `RadioGroupItem` | unmapped |
+| `RadioGroup/List Horizontal` | `RadioGroup` | unmapped |
+| `RadioGroup/List Vertical` | `RadioGroup` | unmapped |
+| `Switch` | `Switch` | unmapped |
+
+### Fields (inputs)
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `Field/DateRange-Filled` | *(Calendar + custom input)* | n/a |
+| `Field/DateRange-Ghost` | *(Calendar + custom input)* | n/a |
+| `Field/DateSingle-Filled` | *(Calendar + custom input)* | n/a |
+| `Field/DateSingle-Ghost` | *(Calendar + custom input)* | n/a |
+| `Field/MultiSelect-Filled` | `Combobox` | unmapped |
+| `Field/MultiSelect-Ghost` | `Combobox` | unmapped |
+| `Field/SingleSelect-Filled` | `Select` | unmapped |
+| `Field/SingleSelect-Ghost` | `Select` | unmapped |
+| `Field/Stepper-Filled` | *(none — candidate)* | n/a |
+| `Field/Stepper-Ghost` | *(none — candidate)* | n/a |
+| `Field/Text-Filled` | `Input` *(variant=filled)* | unmapped |
+| `Field/Text-Ghost` | `Input` *(variant=ghost)* | unmapped |
+| `Field/TextVariant-Filled` | `Input` *(variant)* | unmapped |
+| `Field/TextVariant-Ghost` | `Input` *(variant)* | unmapped |
+| `Field/Time-Filled` | `TimeInput` | unmapped |
+| `Field/Time-Ghost` | `TimeInput` | unmapped |
+
+### Field elements
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `Elements/Characters-Counter` | `TextareaCounter` | unmapped |
+| `Elements/Help-Text` | `FieldDescription` / `FieldError` | unmapped |
+| `Elements/Label` | `Label` / `FieldLabel` | unmapped |
+| `Elements/Status-Messages` | *(covered by Field components)* | n/a |
+
+### Input groups
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `InputGroup-Horizontal` | `InputGroup` | unmapped |
+| `InputGroup-Vertical` | `InputGroup` | unmapped |
+| `DropdownGroup/Horizontal` | *(composition)* | n/a |
+| `DropdownGroup/Vertical` | *(composition)* | n/a |
+| `PickerGroup/Horizontal` | *(composition)* | n/a |
+| `PickerGroup/Vertical` | *(composition)* | n/a |
+
+### Text area
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `Textarea-Input` | `Textarea` / `TextareaRoot` | unmapped |
+
+### Forms
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `Form` | `Form` | unmapped |
+
+### Icons
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `IconShell` | `IconShell` | **mapped** (`src/components/ui/icon-shell.figma.tsx`) |
+
+### Menus
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `Menu/Avatar` | *(composition)* | n/a |
+| `Menu/Context` | `DropdownMenuContent` | unmapped |
+| `Menu/Select` | *(composition)* | n/a |
+| `MenuItem/Avatar` | `DropdownMenuItem` *(custom)* | unmapped |
+| `MenuItem/Context` | `DropdownMenuItem` | unmapped |
+| `MenuItem/Divider` | `DropdownMenuSeparator` | unmapped |
+| `MenuItem/Header` | `DropdownMenuLabel` | unmapped |
+| `MenuItem/Select` | `DropdownMenuCheckboxItem` / `DropdownMenuRadioItem` | unmapped |
+| `MenuItem/Subtrigger` | `DropdownMenuSubTrigger` | unmapped |
+
+### Sliders
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `RangeSlider` | `Slider` *(range mode)* | unmapped |
+| `SingleValueSlider` | `Slider` | unmapped |
+
+### Navigation and layout
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `Tab-Group` | `Tabs` | unmapped |
+| `SegmentedControls` | *(none — candidate)* | n/a |
+| `ScrollBar` | `ScrollBar` | unmapped |
+
+### Tags
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `Tag-Avatar-Dismissable` | `Tag` + `Avatar` | unmapped |
+| `Tag-Dismissable` | `Tag` | unmapped |
+| `Tag-Toggle` | `TagToggle` | unmapped |
+| `Tags-Avatar` | *(group wrapper)* | n/a |
+| `Tags-Dismissable` | *(group wrapper)* | n/a |
+| `Tags-Toggle` | *(group wrapper)* | n/a |
+
+### Tooltips
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `Tooltip/OneLine` | `Tooltip` | unmapped |
+| `Tooltip/MultipleLines` | `Tooltip` | unmapped |
+
+### Time
+
+| Figma | Code | Code Connect |
+|---|---|---|
+| `Overflow-TimePicker` | `TimePicker` components | unmapped |
+
+## Hidden internals (`.base/*`)
+
+Not shown in the Assets panel. Used internally by other components; instances keep working.
+
+| Figma | Purpose |
+|---|---|
+| `.base/ActiveTrack` | Slider internal |
+| `.base/BadgeDotRing` | Badge hint-dot internal |
+| `.base/CellContent` | Table cell internal |
+| `.base/EmptyTrack` | Slider internal |
+| `.base/Header` | Table header internal |
+| `.base/RangeSlider` | Range slider primitive |
+| `.base/SingleSlider` | Single slider primitive |
+| `.base/Tab` | Tab item primitive |
+
+## Code components with no Figma counterpart
+
+Candidates for adding to the library if you want full parity:
+
+- `Calendar`, `CalendarDayButton`
+- `Card` (+ `CardHeader`, `CardFooter`, `CardTitle`, `CardAction`, `CardDescription`, `CardContent`)
+- `Collapsible` (+ `CollapsibleTrigger`, `CollapsibleContent`)
+- `Dialog` (+ `DialogClose`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogOverlay`, `DialogPortal`, `DialogTitle`, `DialogTrigger`)
+- `Empty` (+ `EmptyHeader`, `EmptyTitle`, `EmptyDescription`, `EmptyContent`, `EmptyMedia`)
+- `Field` (+ `FieldLabel`, `FieldDescription`, `FieldError`, `FieldGroup`, `FieldLegend`, `FieldSeparator`, `FieldSet`, `FieldContent`, `FieldTitle`)
+- `Label` *(partial — `Elements/Label` covers input-label use only, not the standalone label)*
+- `Menubar` (+ 15 sub-parts)
+- `Popover` (+ `PopoverTrigger`, `PopoverContent`, `PopoverAnchor`)
+- `Progress`
+- `ScrollArea`
+- `Separator`
+- `Sidebar` (+ 22 sub-parts)
+- `Skeleton`
+- `Toggle`
+
+## Code Connect scorecard
+
+| | Count |
+|---|---|
+| Figma components with Code Connect mapping | 1 (`IconShell`) |
+| Figma components mappable to existing code | 52 |
+| Figma components without code equivalent | 25 (mostly composition patterns, sliders/pickers, date fields, split buttons, segmented controls) |
+| Code components without Figma equivalent | 15 families |
+
+## Changelog
+
+- 2026-05-02 — Rename pass to enforce consistent PascalCase/hyphen/slash conventions and hide internal primitives under `.base/*`. 4 typo fixes (`ChecboxGroup/List Vertical`, `Taggs Toggle`, `Scrollbar`, `TextArea-Input`) and 22 consistency renames applied and published. File renamed from `QBDS_(v2.0.0)` to `QBDS v2.0.0`.

--- a/docs/qbds-llm-readiness-plan.md
+++ b/docs/qbds-llm-readiness-plan.md
@@ -1,0 +1,217 @@
+# QBDS — LLM-Readiness Plan
+
+> A 10-week plan to take QBDS from a clean component library to a system that powers near-shippable application code via AI agents (Cursor, Figma MCP, Code Connect).
+
+---
+
+## TL;DR
+
+Today, "build me a dashboard" prompts using QBDS hit ~65–70% quality. The plan moves that to ~98–99% in 10 weeks of focused work, run as two parallel tracks (Design + Code) joining at three milestones.
+
+The biggest single multiplier is a **pattern library** (canonical compositions of atoms). Most of the remaining lift comes from **Code Connect** for atoms and **per-property descriptions** that make Figma metadata machine-readable.
+
+---
+
+## Three audiences we're building for
+
+| User | What they need | Today | After plan |
+|---|---|---|---|
+| **Designer** in Figma — customising a starter pack | Strong atoms with clear documentation | ~85% (recent slot/variant work) | 100% |
+| **Claude / LLM** generating code from Figma URLs or screengrabs | Deterministic mapping from Figma to React | ~50% | ~95% |
+| **Generic prompts** — "build me a dashboard" | Patterns to compose, project conventions to follow | ~40% | ~95% |
+
+---
+
+## Where we are today
+
+```
+Foundations:    ████████████░░  ~85% — variant/slot/naming audits done
+Atom coverage:  █████████░░░░░  ~70% — 24/34 atoms in Figma+code parity
+Code Connect:   █░░░░░░░░░░░░░  ~5%  — icons only, no atoms yet
+Patterns:       ░░░░░░░░░░░░░░  0%
+Rules / tokens: ████░░░░░░░░░░  ~30% — globals.css mature, not exposed to LLM
+LLM quality:    ~65–70% across all three audiences
+```
+
+---
+
+## The plan — 8 phases, 2 parallel tracks
+
+```
+Week:                 1   2   3   4   5   6   7   8   9   10
+                      |   |   |   |   |   |   |   |   |   |
+DESIGN  P1 atoms ────────────────●
+        P3 prop desc       ──────────●
+        P5 patterns                     ──────────────●
+                                        |             |
+JOIN POINTS              ●─────────────●  publish     ● ship #2
+                                        |
+CODE    P2 Code Connect ──────────────●
+        P4 token bridge       ────●
+        P6 cursor rules       ───●
+        P7 validation                       ────●
+        P8 visual regression                       ────●
+```
+
+| # | Phase | Owner | Time | LLM Quality |
+|---|---|---|---|---|
+| **1** | **Atom gap close + library publish** | Design | 2–3 wk | 70 → 78% |
+| **2** | **Code Connect for atoms** (parallel after Wk 3) | Dev | 2–3 wk | 78 → 88% |
+| **3** | **Per-property descriptions** (variants, booleans, text) | Design | 1 wk | 88 → 91% |
+| **4** | **Token bridge clarity** | Dev | 2–3 d | 91 → 92% |
+| **5** | **Pattern library (8–12 patterns)** ⭐ | Design + Dev | 2–3 wk | 92 → 96% |
+| **6** | **Cursor rules (4 short docs)** | Dev | 2–3 d | 96 → 97% |
+| **7** | **Type / lint enforcement + fixtures** | Dev | 1 wk | 97 → 98% |
+| **8** | **Visual regression in CI** | Dev | 1 wk | safety net |
+
+---
+
+## Phase detail
+
+### Phase 1 — Atom gap close + library publish
+
+Five atoms missing entirely; three need promotion from drafts; library not yet published.
+
+| Build new in Figma | Promote / fix | Add code-side too |
+|---|---|---|
+| Card | Dialog (from `playground/.Modal`) | Skeleton |
+| Empty | Calendar (top-level atom) | Progress |
+| Popover | Time-Input (top-level atom) | Collapsible |
+| Separator | Sonner / Snackbars name align | AspectRatio |
+| Toggle | | Scroll-Area (register existing) |
+
+Apply the slot/naming conventions (`figma-slot-properties` skill) on every new atom from day one.
+
+**Exit:** 34/34 atoms in parity, library published.
+
+### Phase 2 — Code Connect for atoms
+
+| Sub-phase | Atoms | Time |
+|---|---|---|
+| 2a — Top 10 | Button, Field/Text-*, SingleSelect, MultiSelect, Tabs, Tag, Tooltip, Badge, Checkbox, Radio | 1 wk |
+| 2b — Remainder | All other atoms in registry | 1.5 wk |
+| 2c — Phase 1 atoms | Card, Empty, Popover, Separator, Toggle, etc. | 0.5 wk |
+
+**Exit:** running `npx figma connect publish` covers every registry atom.
+
+### Phase 3 — Per-property descriptions
+
+Apply the same audit pattern as slots, for **variants**, **booleans**, **text props**, and **instance-swap props**. Becomes the v2 of the `figma-slot-properties` skill.
+
+**Exit:** 100% of properties on the top 20 atoms have inline descriptions.
+
+### Phase 4 — Token bridge clarity
+
+| Task |
+|---|
+| Document the QBDS token list (output `docs/tokens.md`) |
+| Add cursor rule: "use semantic tokens, never raw colour or px values" |
+| Verify Figma variable names match code variables |
+| ESLint rule flagging hardcoded colours/spacing |
+
+**Exit:** generated code uses `bg-surface-bg-accent` rather than `bg-gray-50`.
+
+### Phase 5 — Pattern library (the multiplier)
+
+Suggested 8 patterns:
+
+1. Page header (title + breadcrumb + actions)
+2. Empty state (illustration + message + CTA)
+3. Filter bar (search + chips + sort)
+4. Login form
+5. Settings panel (sectioned form)
+6. Dashboard shell (sidebar + topbar + content)
+7. Search-with-results (search + list + pagination)
+8. Confirmation dialog
+
+Each pattern ships in **Figma + `registry:example` + Code Connect mapping**.
+
+**Exit:** designer can drop any pattern in Figma; dev can `npx shadcn add <pattern>` to scaffold.
+
+### Phase 6 — Cursor rules
+
+Four short rule files at `.cursor/rules/`:
+
+| File | Codifies |
+|---|---|
+| `components.md` | Atom selection guidance (use Field over Input directly, etc.) |
+| `data-fetching.md` | TanStack Query patterns, error/loading shapes |
+| `styling.md` | Token-only, density rules |
+| `accessibility.md` | Required ARIA, focus management, keyboard flow |
+
+### Phase 7 — Validation + fixtures
+
+| Task |
+|---|
+| Tighten component prop types (no `any`; explicit unions) |
+| ESLint custom rule: forbid hardcoded colour / spacing |
+| Public fixture data: `public/fixtures/users.json`, `transactions.json` etc. |
+
+**Exit:** LLM-generated code passes `npm run lint && tsc` first try in 90% of cases.
+
+### Phase 8 — Visual regression in CI
+
+Storybook stories for every atom + pattern; Chromatic or Playwright visual snapshots in CI.
+
+---
+
+## Outcomes by milestone
+
+| End of week | "Build me X" prompts can produce |
+|---|---|
+| Wk 3 | Single screens with the right atoms, slightly off layouts |
+| Wk 5 | Production-quality individual screens |
+| Wk 8 | Multi-screen flows with proper composition |
+| Wk 10 | Near-shippable application skeletons |
+
+---
+
+## Faster path (if 4 weeks > 10 weeks matters)
+
+```
+Wk 1–2: Phase 1 — atoms + publish (priority Card, Dialog, Empty)
+Wk 1–2: Phase 2a — Code Connect top 10 atoms (parallel)
+Wk 3:   Phase 6 (cursor rules) + Phase 4 (token bridge)
+Wk 4:   Phase 5 — first 4 patterns (Page header, Empty state, Filter bar, Login)
+```
+
+Result: **~92% LLM quality after 4 weeks**. The remaining 7% takes the full plan but each percentage point gets harder to win.
+
+---
+
+## Resource model
+
+- **1 designer** + **1 developer** in parallel — fits in 8 calendar weeks.
+- **1 of each, sequential** — closer to 12 calendar weeks.
+- **Solo (one person across both)** — 14–16 weeks; parallelisation lost.
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| New atoms accumulate the same naming/slot debt | Apply `figma-slot-properties` skill from day 1 on every new atom |
+| Code Connect mappings drift as Figma changes | Make Code Connect publish part of the library publish flow |
+| Patterns become brittle to atom changes | Patterns reuse atoms via component instances, not copies |
+| LLM still hallucinates because rules aren't read | Keep rules ≤ 100 lines each; prefer concrete examples over prose |
+| Visual regression CI runs flaky | Bring in only after atoms + patterns stabilise (Phase 8 last) |
+
+---
+
+## Definition of done
+
+The whole programme is "done" when:
+
+1. A designer in Figma can build a screen using only QBDS components and patterns.
+2. A developer can run `npx shadcn add <pattern>` to scaffold any of the 8 patterns.
+3. Claude given a Figma URL or natural-language brief produces React code that:
+   - Imports correct atoms by exact name
+   - Uses semantic design tokens (no raw values)
+   - Composes atoms via documented patterns
+   - Passes type checks and lint rules first try in ≥ 90% of attempts
+4. Visual regression CI catches drift before merge.
+
+---
+
+*Generated alongside the QBDS slot-properties cleanup work. Last updated alongside this plan.*


### PR DESCRIPTION
## Summary

Brings into the repo the Phase 0 reference docs that were drafted in earlier sessions and parked in local branches/Downloads, but never pushed. These are the written foundation that the proposed agent-skills slate (`~/.cursor/plans/qbds_skills_clean_slate_80f30375.plan.md`) depends on — skills are supposed to *link* to these, not restate them.

This PR is purely additive: six new files under `docs/`, 1,539 lines, zero deletions. `docs/` doesn't exist on `main` today.

## What lands

| File | Purpose |
|---|---|
| `docs/qbds-llm-readiness-plan.md` | 10-week, 8-phase strategic plan to take QBDS from a component library to a system that powers near-shippable application code via AI agents. Frames three audiences (designer ~85% to 100%, LLM-from-Figma ~50% to ~95%, generic prompts ~40% to ~95%) and the canonical 8 patterns. |
| `docs/qbds-figma-component-checklist.md` | Figma to code reconciliation across the published QBDS v2.0.0 library (file key `iuMWqCsIohoKAUB0tBS0xr`). |
| `docs/component-rules/_template.md` | Schema (YAML front matter + 14 fixed sections) for component rules cards. |
| `docs/component-rules/button.md` | 5 variants, 9 sizes, state-layer rationale, 5 anti-pattern pairs. |
| `docs/component-rules/dialog.md` | 10 sub-components, Radix integration, open issues flagged. |
| `docs/component-rules/form.md` | react-hook-form integration, aria chain, 4 composition patterns. |

## Why these belong together

The readiness plan defines the strategy; the rules cards are the per-component reference data the skills (and LLMs) read; the Figma checklist is the design-side bookkeeping that closes the loop. Splitting them across PRs would require cross-referencing between in-flight branches, which is more friction than it's worth for purely additive reference docs.

## Out of scope (explicitly)

- Actual skills authoring. The agent-skills slate (5 skills, 3 personas, token-efficient) is staged at `~/.cursor/plans/qbds_skills_clean_slate_80f30375.plan.md` and follows once Code Connect lands for all 40 components.
- Rules cards beyond the three already drafted (Button, Dialog, Form). The remaining 37 are scaffolded via the template and authored phase-by-phase per the readiness plan.

## Test plan

- [x] `npm run lint` passes (docs/ is in ESLint's `globalIgnores`).
- [ ] Reviewer renders `docs/qbds-llm-readiness-plan.md` on GitHub and confirms the phase table + ASCII timeline + audience matrix render correctly.
- [ ] Reviewer skims one rules card (e.g. `button.md`) end-to-end to confirm the 14-section schema is followed and the inline anti-pattern pairs are useful for an agent reader.

Made with [Cursor](https://cursor.com)