### PR TITLE
feat(tokens): Sync Figma tokens to `globals.css`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:watch": "vitest",
     "test": "concurrently --kill-others-on-fail \"npm run test:unit\" \"npm run build\" \"npm run lint\"",
     "lint": "eslint . --cache --cache-location .eslintcache",
+    "sync:tokens": "tsx scripts/sync-tokens.ts",
     "secretscan": "scripts/secret-scan.sh",
     "precommit": "concurrently --kill-others-on-fail -n lint,test,secrets \"npm run lint\" \"npm run test:unit\" \"npm run secretscan\"",
     "start": "vite preview --host 0.0.0.0 --port 3000",

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
   "name": "Quantumblack Design System Registry",
-  "homepage": "",
+  "homepage": "https://github.com/mckinsey/quantumblack-design-system",
   "items": [
     {
       "name": "utils",

--- a/scripts/sync-tokens.ts
+++ b/scripts/sync-tokens.ts
@@ -7,40 +7,39 @@
  *
  * Run: npm run sync:tokens
  */
-import { readFileSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
+  type TokensSyncConfig,
   generateAllSections,
   parseCssCustomProperties,
-  type TokensSyncConfig,
-} from './tokens/sync-core'
+} from './tokens/sync-core';
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const rootDir = join(__dirname, '..')
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 
-const MARKER_BEGIN = (id: string) => `/* qbds:tokens:begin ${id} */`
-const MARKER_END = (id: string) => `/* qbds:tokens:end ${id} */`
+const MARKER_BEGIN = (id: string) => `/* qbds:tokens:begin ${id} */`;
+const MARKER_END = (id: string) => `/* qbds:tokens:end ${id} */`;
 
 function loadConfig(): TokensSyncConfig {
   return JSON.parse(
     readFileSync(join(rootDir, 'tokens-sync.config.json'), 'utf8'),
-  ) as TokensSyncConfig
+  ) as TokensSyncConfig;
 }
 
 function indexAfterSelectorBlock(css: string, selector: string): number {
-  const start = css.indexOf(`${selector} {`)
-  if (start === -1) return -1
-  let depth = 0
+  const start = css.indexOf(`${selector} {`);
+  if (start === -1) return -1;
+  let depth = 0;
   for (let i = css.indexOf('{', start); i < css.length; i++) {
-    if (css[i] === '{') depth++
+    if (css[i] === '{') depth++;
     else if (css[i] === '}') {
-      depth--
-      if (depth === 0) return i + 1
+      depth--;
+      if (depth === 0) return i + 1;
     }
   }
-  return -1
+  return -1;
 }
 
 function semanticSectionEndIndex(css: string): number {
@@ -49,46 +48,58 @@ function semanticSectionEndIndex(css: string): number {
     indexAfterSelectorBlock(css, '.dark') ??
     indexAfterSelectorBlock(css, ':root') ??
     css.indexOf('\n@utility shadow-elevation-0')
-  )
+  );
 }
 
 function insertMarkersIfMissing(globalsCss: string): string {
-  let css = globalsCss
+  let css = globalsCss;
   if (!css.includes(MARKER_BEGIN('theme-inline'))) {
     css = css.replace(
       '@theme inline {',
       `${MARKER_BEGIN('theme-inline')}\n@theme inline {`,
-    )
-    css = css.replace(/\n}\n\n:root \{/, `\n}\n${MARKER_END('theme-inline')}\n\n:root {`)
+    );
+    css = css.replace(
+      /\n}\n\n:root \{/,
+      `\n}\n${MARKER_END('theme-inline')}\n\n:root {`,
+    );
   }
   if (!css.includes(MARKER_BEGIN('semantic'))) {
-    css = css.replace(':root {', `${MARKER_BEGIN('semantic')}\n:root {`)
-    const insertAt = semanticSectionEndIndex(css)
+    css = css.replace(':root {', `${MARKER_BEGIN('semantic')}\n:root {`);
+    const insertAt = semanticSectionEndIndex(css);
     if (insertAt !== -1) {
-      css = css.slice(0, insertAt) + `\n${MARKER_END('semantic')}` + css.slice(insertAt)
+      css =
+        css.slice(0, insertAt) +
+        `\n${MARKER_END('semantic')}` +
+        css.slice(insertAt);
     }
   }
-  return css
+  return css;
 }
 
 function extractSectionContent(globalsCss: string, sectionId: string): string {
-  const begin = MARKER_BEGIN(sectionId)
-  const end = MARKER_END(sectionId)
-  const start = globalsCss.indexOf(begin)
-  const endIdx = globalsCss.indexOf(end)
-  if (start === -1 || endIdx === -1) return ''
-  return globalsCss.slice(start + begin.length, endIdx).replace(/^\n/, '')
+  const begin = MARKER_BEGIN(sectionId);
+  const end = MARKER_END(sectionId);
+  const start = globalsCss.indexOf(begin);
+  const endIdx = globalsCss.indexOf(end);
+  if (start === -1 || endIdx === -1) return '';
+  return globalsCss.slice(start + begin.length, endIdx).replace(/^\n/, '');
 }
 
-function patchSection(globalsCss: string, sectionId: string, newContent: string): string {
-  const begin = MARKER_BEGIN(sectionId)
-  const end = MARKER_END(sectionId)
-  const start = globalsCss.indexOf(begin)
-  const endIdx = globalsCss.indexOf(end)
+function patchSection(
+  globalsCss: string,
+  sectionId: string,
+  newContent: string,
+): string {
+  const begin = MARKER_BEGIN(sectionId);
+  const end = MARKER_END(sectionId);
+  const start = globalsCss.indexOf(begin);
+  const endIdx = globalsCss.indexOf(end);
   if (start === -1 || endIdx === -1) {
-    throw new Error(`Markers not found for section "${sectionId}". Expected:\n${begin}\n...\n${end}`)
+    throw new Error(
+      `Markers not found for section "${sectionId}". Expected:\n${begin}\n...\n${end}`,
+    );
   }
-  return `${globalsCss.slice(0, start + begin.length)}\n${newContent}\n${globalsCss.slice(endIdx)}`
+  return `${globalsCss.slice(0, start + begin.length)}\n${newContent}\n${globalsCss.slice(endIdx)}`;
 }
 
 function patchAllSections(
@@ -98,46 +109,47 @@ function patchAllSections(
   return Object.entries(sections).reduce(
     (css, [id, content]) => patchSection(css, id, content),
     globalsCss,
-  )
+  );
 }
 
 type TokenDiff = {
-  added: Array<{ name: string; after: string }>
-  removed: Array<{ name: string; before: string }>
-  changed: Array<{ name: string; before: string; after: string }>
-}
+  added: Array<{ name: string; after: string }>;
+  removed: Array<{ name: string; before: string }>;
+  changed: Array<{ name: string; before: string; after: string }>;
+};
 
 function diffCss(beforeCss: string, afterCss: string): TokenDiff {
-  const before = parseCssCustomProperties(beforeCss)
-  const after = parseCssCustomProperties(afterCss)
-  const added: TokenDiff['added'] = []
-  const removed: TokenDiff['removed'] = []
-  const changed: TokenDiff['changed'] = []
+  const before = parseCssCustomProperties(beforeCss);
+  const after = parseCssCustomProperties(afterCss);
+  const added: TokenDiff['added'] = [];
+  const removed: TokenDiff['removed'] = [];
+  const changed: TokenDiff['changed'] = [];
 
   for (const [name, value] of after) {
-    if (!before.has(name)) added.push({ name, after: value })
+    if (!before.has(name)) added.push({ name, after: value });
     else if (before.get(name) !== value) {
-      changed.push({ name, before: before.get(name)!, after: value })
+      changed.push({ name, before: before.get(name)!, after: value });
     }
   }
   for (const [name, value] of before) {
-    if (!after.has(name)) removed.push({ name, before: value })
+    if (!after.has(name)) removed.push({ name, before: value });
   }
-  const sort = <T extends { name: string }>(a: T, b: T) => a.name.localeCompare(b.name)
-  added.sort(sort)
-  removed.sort(sort)
-  changed.sort(sort)
-  return { added, removed, changed }
+  const sort = <T extends { name: string }>(a: T, b: T) =>
+    a.name.localeCompare(b.name);
+  added.sort(sort);
+  removed.sort(sort);
+  changed.sort(sort);
+  return { added, removed, changed };
 }
 
 function formatDiffReport(diff: TokenDiff, maxRows = 50): string {
-  const total = diff.added.length + diff.removed.length + diff.changed.length
+  const total = diff.added.length + diff.removed.length + diff.changed.length;
   const lines: string[] = [
     `${diff.changed.length} changed, ${diff.added.length} added, ${diff.removed.length} removed`,
-  ]
+  ];
   if (total === 0) {
-    lines.push('No token changes.')
-    return lines.join('\n')
+    lines.push('No token changes.');
+    return lines.join('\n');
   }
 
   const section = (
@@ -145,44 +157,45 @@ function formatDiffReport(diff: TokenDiff, maxRows = 50): string {
     rows: Array<{ name: string; before?: string; after?: string }>,
     format: (row: { name: string; before?: string; after?: string }) => string,
   ) => {
-    if (!rows.length) return
-    lines.push('', `${title}:`)
+    if (!rows.length) return;
+    lines.push('', `${title}:`);
     for (const row of rows.slice(0, maxRows)) {
-      lines.push(`  ${format(row)}`)
+      lines.push(`  ${format(row)}`);
     }
-    if (rows.length > maxRows) lines.push(`  …and ${rows.length - maxRows} more`)
-  }
+    if (rows.length > maxRows)
+      lines.push(`  …and ${rows.length - maxRows} more`);
+  };
 
-  section('Changed', diff.changed, (r) => `${r.name}: ${r.before} → ${r.after}`)
-  section('Added', diff.added, (r) => `${r.name}: ${r.after}`)
-  section('Removed', diff.removed, (r) => `${r.name}: ${r.before}`)
-  return lines.join('\n')
+  section('Changed', diff.changed, r => `${r.name}: ${r.before} → ${r.after}`);
+  section('Added', diff.added, r => `${r.name}: ${r.after}`);
+  section('Removed', diff.removed, r => `${r.name}: ${r.before}`);
+  return lines.join('\n');
 }
 
 function main() {
-  const config = loadConfig()
-  const globalsPath = join(rootDir, config.globalsPath)
+  const config = loadConfig();
+  const globalsPath = join(rootDir, config.globalsPath);
 
-  let globalsCss = insertMarkersIfMissing(readFileSync(globalsPath, 'utf8'))
+  const globalsCss = insertMarkersIfMissing(readFileSync(globalsPath, 'utf8'));
   const existingSections = Object.fromEntries(
-    config.sections.map((section) => [
+    config.sections.map(section => [
       section.id,
       extractSectionContent(globalsCss, section.id),
     ]),
-  )
-  const sections = generateAllSections(rootDir, config, existingSections)
-  const newGlobals = patchAllSections(globalsCss, sections)
-  const diff = diffCss(globalsCss, newGlobals)
+  );
+  const sections = generateAllSections(rootDir, config, existingSections);
+  const newGlobals = patchAllSections(globalsCss, sections);
+  const diff = diffCss(globalsCss, newGlobals);
 
-  console.log(formatDiffReport(diff))
+  console.log(formatDiffReport(diff));
 
   if (newGlobals === globalsCss) {
-    console.log('\n✓ globals.css is already in sync.')
-    return
+    console.log('\n✓ globals.css is already in sync.');
+    return;
   }
 
-  writeFileSync(globalsPath, newGlobals, 'utf8')
-  console.log(`\n✓ Updated ${config.globalsPath}`)
+  writeFileSync(globalsPath, newGlobals, 'utf8');
+  console.log(`\n✓ Updated ${config.globalsPath}`);
 }
 
-main()
+main();

--- a/scripts/sync-tokens.ts
+++ b/scripts/sync-tokens.ts
@@ -29,6 +29,29 @@ function loadConfig(): TokensSyncConfig {
   ) as TokensSyncConfig
 }
 
+function indexAfterSelectorBlock(css: string, selector: string): number {
+  const start = css.indexOf(`${selector} {`)
+  if (start === -1) return -1
+  let depth = 0
+  for (let i = css.indexOf('{', start); i < css.length; i++) {
+    if (css[i] === '{') depth++
+    else if (css[i] === '}') {
+      depth--
+      if (depth === 0) return i + 1
+    }
+  }
+  return -1
+}
+
+function semanticSectionEndIndex(css: string): number {
+  return (
+    indexAfterSelectorBlock(css, '.radius-mode') ??
+    indexAfterSelectorBlock(css, '.dark') ??
+    indexAfterSelectorBlock(css, ':root') ??
+    css.indexOf('\n@utility shadow-elevation-0')
+  )
+}
+
 function insertMarkersIfMissing(globalsCss: string): string {
   let css = globalsCss
   if (!css.includes(MARKER_BEGIN('theme-inline'))) {
@@ -40,10 +63,7 @@ function insertMarkersIfMissing(globalsCss: string): string {
   }
   if (!css.includes(MARKER_BEGIN('semantic'))) {
     css = css.replace(':root {', `${MARKER_BEGIN('semantic')}\n:root {`)
-    const insertAt =
-      css.indexOf('\n.radius-mode {') !== -1
-        ? css.indexOf('\n.radius-mode {')
-        : css.indexOf('\n@utility shadow-elevation-0')
+    const insertAt = semanticSectionEndIndex(css)
     if (insertAt !== -1) {
       css = css.slice(0, insertAt) + `\n${MARKER_END('semantic')}` + css.slice(insertAt)
     }

--- a/scripts/sync-tokens.ts
+++ b/scripts/sync-tokens.ts
@@ -1,0 +1,168 @@
+/**
+ * CLI entry point for syncing Figma token exports into globals.css.
+ *
+ * Reads tokens/*.json via tokens-sync.config.json, regenerates only the
+ * marked sections in src/styles/globals.css, preserves declaration order,
+ * and prints a short summary of added/changed/removed variables.
+ *
+ * Run: npm run sync:tokens
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  generateAllSections,
+  parseCssCustomProperties,
+  type TokensSyncConfig,
+} from './tokens/sync-core'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const rootDir = join(__dirname, '..')
+
+const MARKER_BEGIN = (id: string) => `/* qbds:tokens:begin ${id} */`
+const MARKER_END = (id: string) => `/* qbds:tokens:end ${id} */`
+
+function loadConfig(): TokensSyncConfig {
+  return JSON.parse(
+    readFileSync(join(rootDir, 'tokens-sync.config.json'), 'utf8'),
+  ) as TokensSyncConfig
+}
+
+function insertMarkersIfMissing(globalsCss: string): string {
+  let css = globalsCss
+  if (!css.includes(MARKER_BEGIN('theme-inline'))) {
+    css = css.replace(
+      '@theme inline {',
+      `${MARKER_BEGIN('theme-inline')}\n@theme inline {`,
+    )
+    css = css.replace(/\n}\n\n:root \{/, `\n}\n${MARKER_END('theme-inline')}\n\n:root {`)
+  }
+  if (!css.includes(MARKER_BEGIN('semantic'))) {
+    css = css.replace(':root {', `${MARKER_BEGIN('semantic')}\n:root {`)
+    const insertAt =
+      css.indexOf('\n.radius-mode {') !== -1
+        ? css.indexOf('\n.radius-mode {')
+        : css.indexOf('\n@utility shadow-elevation-0')
+    if (insertAt !== -1) {
+      css = css.slice(0, insertAt) + `\n${MARKER_END('semantic')}` + css.slice(insertAt)
+    }
+  }
+  return css
+}
+
+function extractSectionContent(globalsCss: string, sectionId: string): string {
+  const begin = MARKER_BEGIN(sectionId)
+  const end = MARKER_END(sectionId)
+  const start = globalsCss.indexOf(begin)
+  const endIdx = globalsCss.indexOf(end)
+  if (start === -1 || endIdx === -1) return ''
+  return globalsCss.slice(start + begin.length, endIdx).replace(/^\n/, '')
+}
+
+function patchSection(globalsCss: string, sectionId: string, newContent: string): string {
+  const begin = MARKER_BEGIN(sectionId)
+  const end = MARKER_END(sectionId)
+  const start = globalsCss.indexOf(begin)
+  const endIdx = globalsCss.indexOf(end)
+  if (start === -1 || endIdx === -1) {
+    throw new Error(`Markers not found for section "${sectionId}". Expected:\n${begin}\n...\n${end}`)
+  }
+  return `${globalsCss.slice(0, start + begin.length)}\n${newContent}\n${globalsCss.slice(endIdx)}`
+}
+
+function patchAllSections(
+  globalsCss: string,
+  sections: Record<string, string>,
+): string {
+  return Object.entries(sections).reduce(
+    (css, [id, content]) => patchSection(css, id, content),
+    globalsCss,
+  )
+}
+
+type TokenDiff = {
+  added: Array<{ name: string; after: string }>
+  removed: Array<{ name: string; before: string }>
+  changed: Array<{ name: string; before: string; after: string }>
+}
+
+function diffCss(beforeCss: string, afterCss: string): TokenDiff {
+  const before = parseCssCustomProperties(beforeCss)
+  const after = parseCssCustomProperties(afterCss)
+  const added: TokenDiff['added'] = []
+  const removed: TokenDiff['removed'] = []
+  const changed: TokenDiff['changed'] = []
+
+  for (const [name, value] of after) {
+    if (!before.has(name)) added.push({ name, after: value })
+    else if (before.get(name) !== value) {
+      changed.push({ name, before: before.get(name)!, after: value })
+    }
+  }
+  for (const [name, value] of before) {
+    if (!after.has(name)) removed.push({ name, before: value })
+  }
+  const sort = <T extends { name: string }>(a: T, b: T) => a.name.localeCompare(b.name)
+  added.sort(sort)
+  removed.sort(sort)
+  changed.sort(sort)
+  return { added, removed, changed }
+}
+
+function formatDiffReport(diff: TokenDiff, maxRows = 50): string {
+  const total = diff.added.length + diff.removed.length + diff.changed.length
+  const lines: string[] = [
+    `${diff.changed.length} changed, ${diff.added.length} added, ${diff.removed.length} removed`,
+  ]
+  if (total === 0) {
+    lines.push('No token changes.')
+    return lines.join('\n')
+  }
+
+  const section = (
+    title: string,
+    rows: Array<{ name: string; before?: string; after?: string }>,
+    format: (row: { name: string; before?: string; after?: string }) => string,
+  ) => {
+    if (!rows.length) return
+    lines.push('', `${title}:`)
+    for (const row of rows.slice(0, maxRows)) {
+      lines.push(`  ${format(row)}`)
+    }
+    if (rows.length > maxRows) lines.push(`  …and ${rows.length - maxRows} more`)
+  }
+
+  section('Changed', diff.changed, (r) => `${r.name}: ${r.before} → ${r.after}`)
+  section('Added', diff.added, (r) => `${r.name}: ${r.after}`)
+  section('Removed', diff.removed, (r) => `${r.name}: ${r.before}`)
+  return lines.join('\n')
+}
+
+function main() {
+  const config = loadConfig()
+  const globalsPath = join(rootDir, config.globalsPath)
+
+  let globalsCss = insertMarkersIfMissing(readFileSync(globalsPath, 'utf8'))
+  const existingSections = Object.fromEntries(
+    config.sections.map((section) => [
+      section.id,
+      extractSectionContent(globalsCss, section.id),
+    ]),
+  )
+  const sections = generateAllSections(rootDir, config, existingSections)
+  const newGlobals = patchAllSections(globalsCss, sections)
+  const diff = diffCss(globalsCss, newGlobals)
+
+  console.log(formatDiffReport(diff))
+
+  if (newGlobals === globalsCss) {
+    console.log('\n✓ globals.css is already in sync.')
+    return
+  }
+
+  writeFileSync(globalsPath, newGlobals, 'utf8')
+  console.log(`\n✓ Updated ${config.globalsPath}`)
+}
+
+main()

--- a/scripts/tokens/sync-core.ts
+++ b/scripts/tokens/sync-core.ts
@@ -5,40 +5,40 @@
  * primitives and semantic blocks (:root, .dark, .radius-mode), and preserves
  * existing declaration order from globals.css when regenerating.
  */
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 // --- Types ---
 
 type TokenLeaf = {
-  $type?: string
-  $value?: unknown
+  $type?: string;
+  $value?: unknown;
   $extensions?: {
-    'com.figma.aliasData'?: { targetVariableName?: string }
-    'com.figma.codeSyntax'?: { WEB?: string }
-  }
-}
+    'com.figma.aliasData'?: { targetVariableName?: string };
+    'com.figma.codeSyntax'?: { WEB?: string };
+  };
+};
 
-type FlatToken = { path: string[]; leaf: TokenLeaf }
+type FlatToken = { path: string[]; leaf: TokenLeaf };
 
-type CssDeclaration = { name: string; value: string }
+type CssDeclaration = { name: string; value: string };
 
 export type SelectorConfig = {
-  file: string
-  selector: string
-  mergeFiles?: string[]
-  label?: string
-}
+  file: string;
+  selector: string;
+  mergeFiles?: string[];
+  label?: string;
+};
 
 export type TokensSyncConfig = {
-  source: 'file' | 'figma'
-  globalsPath: string
-  themeBridgePath: string
+  source: 'file' | 'figma';
+  globalsPath: string;
+  themeBridgePath: string;
   sections: Array<
     | { id: string; wrapper: string; files: string[] }
     | { id: string; selectors: SelectorConfig[] }
-  >
-}
+  >;
+};
 
 // --- Parse Figma export JSON ---
 
@@ -48,53 +48,73 @@ function isTokenLeaf(node: unknown): node is TokenLeaf {
     node !== null &&
     '$value' in node &&
     ('$type' in node || '$extensions' in node)
-  )
+  );
 }
 
 function flattenTokens(
   obj: Record<string, unknown>,
   path: string[] = [],
 ): FlatToken[] {
-  const result: FlatToken[] = []
+  const result: FlatToken[] = [];
   for (const [key, value] of Object.entries(obj)) {
-    if (key.startsWith('$')) continue
-    const nextPath = [...path, key]
+    if (key.startsWith('$')) continue;
+    const nextPath = [...path, key];
     if (isTokenLeaf(value)) {
-      result.push({ path: nextPath, leaf: value })
+      result.push({ path: nextPath, leaf: value });
     } else if (typeof value === 'object' && value !== null) {
-      result.push(...flattenTokens(value as Record<string, unknown>, nextPath))
+      result.push(...flattenTokens(value as Record<string, unknown>, nextPath));
     }
   }
-  return result
+  return result;
 }
 
-type ColorValue = { hex?: string; alpha?: number }
+type ColorValue = { hex?: string; alpha?: number };
 
 function formatColorValue(value: ColorValue): string {
-  const hex = (value.hex ?? '#000000').replace('#', '').toUpperCase()
-  const alpha = value.alpha ?? 1
+  const hex = (value.hex ?? '#000000').replace('#', '').toUpperCase();
+  const alpha = value.alpha ?? 1;
   if (alpha >= 0.999) {
-    return `#${hex.length === 6 ? hex : hex.slice(0, 6)}`.toLowerCase()
+    return `#${hex.length === 6 ? hex : hex.slice(0, 6)}`.toLowerCase();
   }
-  const base = hex.length >= 6 ? hex.slice(0, 6) : hex.padEnd(6, '0')
+  const base = hex.length >= 6 ? hex.slice(0, 6) : hex.padEnd(6, '0');
   const a = Math.round(alpha * 255)
     .toString(16)
-    .padStart(2, '0')
-  return `#${base}${a}`.toLowerCase()
+    .padStart(2, '0');
+  return `#${base}${a}`.toLowerCase();
 }
 
 // --- Name mapping ---
 
 const PALETTE_NAMES = new Set([
-  'red', 'amber', 'yellow', 'lime', 'green', 'emerald', 'teal', 'cyan', 'sky',
-  'blue', 'indigo', 'violet', 'purple', 'fuchsia', 'pink', 'rose', 'stone',
-])
+  'red',
+  'amber',
+  'yellow',
+  'lime',
+  'green',
+  'emerald',
+  'teal',
+  'cyan',
+  'sky',
+  'blue',
+  'indigo',
+  'violet',
+  'purple',
+  'fuchsia',
+  'pink',
+  'rose',
+  'stone',
+]);
 
-const SKIP_ROOT_KEYS = new Set(['Descriptor', 'Spacing', 'Stroke-Weight'])
+const SKIP_ROOT_KEYS = new Set(['Descriptor', 'Spacing', 'Stroke-Weight']);
 
 const THEME_GROUP_ORDER = [
-  'Font', 'Mist', 'Mist 50', 'Slate', 'Slate 900', 'Brand-Accents',
-]
+  'Font',
+  'Mist',
+  'Mist 50',
+  'Slate',
+  'Slate 900',
+  'Brand-Accents',
+];
 
 function kebab(segment: string): string {
   return segment
@@ -104,122 +124,138 @@ function kebab(segment: string): string {
     .replace(/–/g, '-')
     .split('-')
     .filter(Boolean)
-    .map((part) => part.toLowerCase())
-    .join('-')
+    .map(part => part.toLowerCase())
+    .join('-');
 }
 
 function shouldSkipPath(path: string[]): boolean {
-  return path.length === 0 || (path[0] != null && SKIP_ROOT_KEYS.has(path[0]))
+  return path.length === 0 || SKIP_ROOT_KEYS.has(path[0]);
 }
 
 function collapseSemanticPath(path: string[]): string[] {
-  if (path.length === 3 && path[1] === 'Content') return [path[0], path[2]]
+  if (path.length === 3 && path[1] === 'Content') return [path[0], path[2]];
   if (path.length === 3 && path[1] === 'onSurface') {
-    return [path[0], path[2].replace(/^bg-ui/i, 'onsurface-ui-')]
+    return [path[0], path[2].replace(/^bg-ui/i, 'onsurface-ui-')];
   }
   if (path[0] === 'Elevations' && path.length === 2) {
-    const leaf = path[1].replace(/^Shade_T/i, 'shade-t').replace(/^Shade/i, 'shade')
-    return ['elevations', leaf]
+    const leaf = path[1]
+      .replace(/^Shade_T/i, 'shade-t')
+      .replace(/^Shade/i, 'shade');
+    return ['elevations', leaf];
   }
-  return path
+  return path;
 }
 
-function pathToCssVarName(path: string[], context: 'theme' | 'semantic'): string | null {
-  if (shouldSkipPath(path)) return null
+function pathToCssVarName(
+  path: string[],
+  context: 'theme' | 'semantic',
+): string | null {
+  if (shouldSkipPath(path)) return null;
   if (path[0] === 'Font') {
-    if (path[1] === 'Family' && path[2]) return `--font-${kebab(path[2])}`
-    if (path[1] === 'Weight' && path[2]) return `--font-weight-${path[2]}`
-    if (path[1] === 'Font-Size' && path[2]) return `--font-font-size-${path[2]}`
-    if (path[1] === 'Line-Height' && path[2]) return `--font-line-height-${path[2]}`
-    return null
+    if (path[1] === 'Family' && path[2]) return `--font-${kebab(path[2])}`;
+    if (path[1] === 'Weight' && path[2]) return `--font-weight-${path[2]}`;
+    if (path[1] === 'Font-Size' && path[2])
+      return `--font-font-size-${path[2]}`;
+    if (path[1] === 'Line-Height' && path[2])
+      return `--font-line-height-${path[2]}`;
+    return null;
   }
-  if (path[0] === 'Brand-Accents' && path[1]) return `--brand-accents-${kebab(path[1])}`
+  if (path[0] === 'Brand-Accents' && path[1])
+    return `--brand-accents-${kebab(path[1])}`;
   if (path.length >= 2 && PALETTE_NAMES.has(path[0].toLowerCase())) {
-    return `--color-${path[0].toLowerCase()}-${path[1]}`
+    return `--color-${path[0].toLowerCase()}-${path[1]}`;
   }
   if (context === 'semantic') {
-    return `--${collapseSemanticPath(path).map(kebab).join('-')}`
+    return `--${collapseSemanticPath(path).map(kebab).join('-')}`;
   }
   if (path[0]?.includes(' ')) {
-    const [group, ...rest] = path
-    return `--${kebab(group)}${rest.length ? `-${rest.map(kebab).join('-')}` : ''}`
+    const [group, ...rest] = path;
+    return `--${kebab(group)}${rest.length ? `-${rest.map(kebab).join('-')}` : ''}`;
   }
-  if (path.length === 2) return `--${kebab(path[0])}-${path[1]}`
-  if (path.length === 1) return `--${kebab(path[0])}`
-  return `--${path.map(kebab).join('-')}`
+  if (path.length === 2) return `--${kebab(path[0])}-${path[1]}`;
+  if (path.length === 1) return `--${kebab(path[0])}`;
+  return `--${path.map(kebab).join('-')}`;
 }
 
 function aliasToCssValue(targetVariableName: string): string {
-  const parts = targetVariableName.trim().split('/')
+  const parts = targetVariableName.trim().split('/');
   if (parts.length === 2) {
-    const [a, b] = parts
-    if (a.includes(' ')) return `var(--${kebab(a)}-${b})`
-    if (a === a.toLowerCase() && !a.includes(' ')) return `var(--color-${a}-${b})`
-    return `var(--${a.toLowerCase()}-${b})`
+    const [a, b] = parts;
+    if (a.includes(' ')) return `var(--${kebab(a)}-${b})`;
+    if (a === a.toLowerCase() && !a.includes(' '))
+      return `var(--color-${a}-${b})`;
+    return `var(--${a.toLowerCase()}-${b})`;
   }
-  return `var(--${kebab(targetVariableName)})`
+  return `var(--${kebab(targetVariableName)})`;
 }
 
 function resolveTokenValue(leaf: TokenLeaf): string | null {
-  const aliasName = leaf.$extensions?.['com.figma.aliasData']?.targetVariableName
-  if (aliasName) return aliasToCssValue(aliasName)
+  const aliasName =
+    leaf.$extensions?.['com.figma.aliasData']?.targetVariableName;
+  if (aliasName) return aliasToCssValue(aliasName);
 
-  const webSyntax = leaf.$extensions?.['com.figma.codeSyntax']?.WEB
-  if (webSyntax && !/--radi-\d/.test(webSyntax)) return webSyntax
+  const webSyntax = leaf.$extensions?.['com.figma.codeSyntax']?.WEB;
+  if (webSyntax && !/--radi-\d/.test(webSyntax)) return webSyntax;
 
-  const { $type: type, $value: value } = leaf
+  const { $type: type, $value: value } = leaf;
   if (type === 'color' && typeof value === 'object' && value !== null) {
-    return formatColorValue(value as ColorValue)
+    return formatColorValue(value as ColorValue);
   }
-  if (type === 'number' && typeof value === 'number') return `${value}px`
-  if (type === 'string' && typeof value === 'string') return `'${value}'`
-  return null
+  if (type === 'number' && typeof value === 'number') return `${value}px`;
+  if (type === 'string' && typeof value === 'string') return `'${value}'`;
+  return null;
 }
 
 // --- CSS generation ---
 
 function loadJson(rootDir: string, file: string): Record<string, unknown> {
-  return JSON.parse(readFileSync(join(rootDir, file), 'utf8')) as Record<string, unknown>
+  return JSON.parse(readFileSync(join(rootDir, file), 'utf8')) as Record<
+    string,
+    unknown
+  >;
 }
 
 function tokensFromFiles(rootDir: string, files: string[]): FlatToken[] {
-  return files.flatMap((file) => flattenTokens(loadJson(rootDir, file)))
+  return files.flatMap(file => flattenTokens(loadJson(rootDir, file)));
 }
 
 function declarationsFromTokens(
   tokens: FlatToken[],
   context: 'theme' | 'semantic',
 ): CssDeclaration[] {
-  const declarations: CssDeclaration[] = []
-  const seen = new Set<string>()
+  const declarations: CssDeclaration[] = [];
+  const seen = new Set<string>();
   for (const { path, leaf } of tokens) {
-    if (shouldSkipPath(path)) continue
-    const name = pathToCssVarName(path, context)
-    if (!name || seen.has(name)) continue
-    const value = resolveTokenValue(leaf)
-    if (!value) continue
-    seen.add(name)
-    declarations.push({ name, value })
+    if (shouldSkipPath(path)) continue;
+    const name = pathToCssVarName(path, context);
+    if (!name || seen.has(name)) continue;
+    const value = resolveTokenValue(leaf);
+    if (!value) continue;
+    seen.add(name);
+    declarations.push({ name, value });
   }
-  return declarations
+  return declarations;
 }
 
 function groupKeyFromVar(cssVar: string): string {
-  const name = cssVar.replace(/^--/, '')
-  if (name.startsWith('font-')) return 'Font'
-  if (name.startsWith('mist-50-opacity')) return 'Mist 50'
-  if (name.startsWith('mist-')) return 'Mist'
-  if (name.startsWith('slate-900-opacity')) return 'Slate 900'
-  if (name.startsWith('slate-')) return 'Slate'
-  if (name.startsWith('brand-accents')) return 'Brand-Accents'
+  const name = cssVar.replace(/^--/, '');
+  if (name.startsWith('font-')) return 'Font';
+  if (name.startsWith('mist-50-opacity')) return 'Mist 50';
+  if (name.startsWith('mist-')) return 'Mist';
+  if (name.startsWith('slate-900-opacity')) return 'Slate 900';
+  if (name.startsWith('slate-')) return 'Slate';
+  if (name.startsWith('brand-accents')) return 'Brand-Accents';
   if (name.startsWith('color-')) {
-    const parts = name.split('-')
-    if (parts.length >= 3) return `palette:${parts[1]}`
+    const parts = name.split('-');
+    if (parts.length >= 3) return `palette:${parts[1]}`;
   }
-  return 'Other'
+  return 'Other';
 }
 
-function sectionCommentForGroup(group: string, context: 'theme' | 'semantic'): string | undefined {
+function sectionCommentForGroup(
+  group: string,
+  context: 'theme' | 'semantic',
+): string | undefined {
   if (context === 'theme') {
     const map: Record<string, string> = {
       Font: 'Font Tokens',
@@ -228,64 +264,74 @@ function sectionCommentForGroup(group: string, context: 'theme' | 'semantic'): s
       Slate: 'Slate Primitives',
       'Slate 900': 'Slate Opacity Tokens',
       'Brand-Accents': 'Brand Accents',
-    }
-    return map[group] ? `/** ${map[group]} */` : undefined
+    };
+    return map[group] ? `/** ${map[group]} */` : undefined;
   }
   const semanticMap: Record<string, string> = {
-    Text: 'text', Border: 'border', Fill: 'fill', Surface: 'surface',
-    Status: 'status', Stateslayer: 'state layer', Elevations: 'elevation',
-  }
-  return semanticMap[group] ? `/** ${semanticMap[group]} tokens */` : undefined
+    Text: 'text',
+    Border: 'border',
+    Fill: 'fill',
+    Surface: 'surface',
+    Status: 'status',
+    Stateslayer: 'state layer',
+    Elevations: 'elevation',
+  };
+  return semanticMap[group] ? `/** ${semanticMap[group]} tokens */` : undefined;
 }
 
-function declarationGroup(decl: CssDeclaration, context: 'theme' | 'semantic'): string {
+function declarationGroup(
+  decl: CssDeclaration,
+  context: 'theme' | 'semantic',
+): string {
   if (context === 'semantic') {
-    const parts = decl.name.replace(/^--/, '').split('-')
+    const parts = decl.name.replace(/^--/, '').split('-');
     return (
-      ({
-        text: 'Text',
-        border: 'Border',
-        fill: 'Fill',
-        surface: 'Surface',
-        status: 'Status',
-        stateslayer: 'Stateslayer',
-        elevations: 'Elevations',
-        rad: 'Radius',
-        slider: 'Slider',
-      }) as Record<string, string>
-    )[parts[0]] ?? 'Other'
+      (
+        {
+          text: 'Text',
+          border: 'Border',
+          fill: 'Fill',
+          surface: 'Surface',
+          status: 'Status',
+          stateslayer: 'Stateslayer',
+          elevations: 'Elevations',
+          rad: 'Radius',
+          slider: 'Slider',
+        } as Record<string, string>
+      )[parts[0]] ?? 'Other'
+    );
   }
-  return groupKeyFromVar(decl.name)
+  return groupKeyFromVar(decl.name);
 }
 
 export function parseCssDeclarationOrder(css: string): string[] {
-  const order: string[] = []
-  const seen = new Set<string>()
-  const re = /(--[^:\s]+)\s*:/g
-  let match: RegExpExecArray | null
+  const order: string[] = [];
+  const seen = new Set<string>();
+  const re = /(--[^:\s]+)\s*:/g;
+  let match: RegExpExecArray | null;
   while ((match = re.exec(css)) !== null) {
     if (!seen.has(match[1])) {
-      seen.add(match[1])
-      order.push(match[1])
+      seen.add(match[1]);
+      order.push(match[1]);
     }
   }
-  return order
+  return order;
 }
 
 export function orderDeclarations(
   declarations: CssDeclaration[],
   existingOrder: string[],
 ): CssDeclaration[] {
-  const index = new Map(existingOrder.map((name, i) => [name, i]))
-  const known: CssDeclaration[] = []
-  const unknown: CssDeclaration[] = []
+  const index = new Map(existingOrder.map((name, i) => [name, i]));
+  const known: CssDeclaration[] = [];
+  const unknown: CssDeclaration[] = [];
   for (const decl of declarations) {
-    if (index.has(decl.name)) known.push(decl)
-    else unknown.push(decl)
+    if (index.has(decl.name)) known.push(decl);
+    else unknown.push(decl);
   }
-  known.sort((a, b) => index.get(a.name)! - index.get(b.name)!)
-  unknown.sort((a, b) => a.name.localeCompare(b.name))
-  return [...known, ...unknown]
+  known.sort((a, b) => index.get(a.name)! - index.get(b.name)!);
+  unknown.sort((a, b) => a.name.localeCompare(b.name));
+  return [...known, ...unknown];
 }
 
 function formatDeclarationsGrouped(
@@ -293,40 +339,54 @@ function formatDeclarationsGrouped(
   context: 'theme' | 'semantic',
   indent: string,
 ): string {
-  const byGroup = new Map<string, CssDeclaration[]>()
+  const byGroup = new Map<string, CssDeclaration[]>();
   for (const decl of declarations) {
-    const group = declarationGroup(decl, context)
-    const list = byGroup.get(group) ?? []
-    list.push(decl)
-    byGroup.set(group, list)
+    const group = declarationGroup(decl, context);
+    const list = byGroup.get(group) ?? [];
+    list.push(decl);
+    byGroup.set(group, list);
   }
 
   const order =
     context === 'theme'
       ? [
           ...THEME_GROUP_ORDER,
-          ...[...byGroup.keys()].filter((k) => !THEME_GROUP_ORDER.includes(k) && !k.startsWith('palette:')),
-          ...[...byGroup.keys()].filter((k) => k.startsWith('palette:')).sort(),
+          ...[...byGroup.keys()].filter(
+            k => !THEME_GROUP_ORDER.includes(k) && !k.startsWith('palette:'),
+          ),
+          ...[...byGroup.keys()].filter(k => k.startsWith('palette:')).sort(),
         ]
-      : ['Radius', 'Text', 'Border', 'Fill', 'Slider', 'Surface', 'Status', 'Stateslayer', 'Elevations', 'Other']
+      : [
+          'Radius',
+          'Text',
+          'Border',
+          'Fill',
+          'Slider',
+          'Surface',
+          'Status',
+          'Stateslayer',
+          'Elevations',
+          'Other',
+        ];
 
-  const lines: string[] = []
-  const emitted = new Set<string>()
+  const lines: string[] = [];
+  const emitted = new Set<string>();
   for (const group of order) {
-    const decls = byGroup.get(group)
-    if (!decls?.length || emitted.has(group)) continue
-    emitted.add(group)
-    const comment = sectionCommentForGroup(group, context)
-    if (comment) lines.push('', `${indent}${comment}`)
+    const decls = byGroup.get(group);
+    if (!decls?.length || emitted.has(group)) continue;
+    emitted.add(group);
+    const comment = sectionCommentForGroup(group, context);
+    if (comment) lines.push('', `${indent}${comment}`);
     for (const decl of decls.sort((a, b) => a.name.localeCompare(b.name))) {
-      lines.push(`${indent}${decl.name}: ${decl.value};`)
+      lines.push(`${indent}${decl.name}: ${decl.value};`);
     }
   }
   for (const [group, decls] of byGroup) {
-    if (emitted.has(group)) continue
-    for (const decl of decls) lines.push(`${indent}${decl.name}: ${decl.value};`)
+    if (emitted.has(group)) continue;
+    for (const decl of decls)
+      lines.push(`${indent}${decl.name}: ${decl.value};`);
   }
-  return lines.join('\n')
+  return lines.join('\n');
 }
 
 function formatDeclarations(
@@ -336,37 +396,41 @@ function formatDeclarations(
   existingOrder?: string[],
 ): string {
   if (!existingOrder?.length) {
-    return formatDeclarationsGrouped(declarations, context, indent)
+    return formatDeclarationsGrouped(declarations, context, indent);
   }
 
-  const ordered = orderDeclarations(declarations, existingOrder)
-  const lines: string[] = []
-  let lastGroup: string | undefined
+  const ordered = orderDeclarations(declarations, existingOrder);
+  const lines: string[] = [];
+  let lastGroup: string | undefined;
   for (const decl of ordered) {
-    const group = declarationGroup(decl, context)
+    const group = declarationGroup(decl, context);
     if (group !== lastGroup) {
-      const comment = sectionCommentForGroup(group, context)
-      if (comment) lines.push('', `${indent}${comment}`)
-      lastGroup = group
+      const comment = sectionCommentForGroup(group, context);
+      if (comment) lines.push('', `${indent}${comment}`);
+      lastGroup = group;
     }
-    lines.push(`${indent}${decl.name}: ${decl.value};`)
+    lines.push(`${indent}${decl.name}: ${decl.value};`);
   }
-  return lines.join('\n')
+  return lines.join('\n');
 }
 
 function addFontSans(declarations: CssDeclaration[]): CssDeclaration[] {
-  const display = declarations.find((d) => d.name === '--font-display')
-  if (!display || declarations.some((d) => d.name === '--font-sans')) return declarations
-  const value = display.value.replace(/^'|'$/g, '')
-  return [...declarations, { name: '--font-sans', value: `'${value}', sans-serif` }]
+  const display = declarations.find(d => d.name === '--font-display');
+  if (!display || declarations.some(d => d.name === '--font-sans'))
+    return declarations;
+  const value = display.value.replace(/^'|'$/g, '');
+  return [
+    ...declarations,
+    { name: '--font-sans', value: `'${value}', sans-serif` },
+  ];
 }
 
 function extractSelectorBlock(sectionCss: string, selector: string): string {
-  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const match = sectionCss.match(
     new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\n\\}`, 'm'),
-  )
-  return match?.[1] ?? ''
+  );
+  return match?.[1] ?? '';
 }
 
 function generateThemeInline(
@@ -375,14 +439,22 @@ function generateThemeInline(
   bridgePath: string,
   existingSection?: string,
 ): string {
-  let declarations = declarationsFromTokens(tokensFromFiles(rootDir, files), 'theme')
-  declarations = addFontSans(declarations)
+  let declarations = declarationsFromTokens(
+    tokensFromFiles(rootDir, files),
+    'theme',
+  );
+  declarations = addFontSans(declarations);
   const existingOrder = existingSection
     ? parseCssDeclarationOrder(existingSection)
-    : undefined
-  const primitives = formatDeclarations(declarations, 'theme', '  ', existingOrder)
-  const bridge = readFileSync(join(rootDir, bridgePath), 'utf8').trimEnd()
-  return `@theme inline {\n${primitives}\n\n${bridge}\n}`
+    : undefined;
+  const primitives = formatDeclarations(
+    declarations,
+    'theme',
+    '  ',
+    existingOrder,
+  );
+  const bridge = readFileSync(join(rootDir, bridgePath), 'utf8').trimEnd();
+  return `@theme inline {\n${primitives}\n\n${bridge}\n}`;
 }
 
 function formatSemanticDeclarations(
@@ -391,45 +463,56 @@ function formatSemanticDeclarations(
   existingOrder?: string[],
 ): string {
   const groupOrder = [
-    'Radius', 'Text', 'Border', 'Fill', 'Slider', 'Surface', 'Status', 'Stateslayer', 'Elevations', 'Other',
-  ]
+    'Radius',
+    'Text',
+    'Border',
+    'Fill',
+    'Slider',
+    'Surface',
+    'Status',
+    'Stateslayer',
+    'Elevations',
+    'Other',
+  ];
 
   if (!existingOrder?.length) {
-    const byGroup = new Map<string, CssDeclaration[]>()
+    const byGroup = new Map<string, CssDeclaration[]>();
     for (const decl of declarations) {
-      const group = declarationGroup(decl, 'semantic')
-      const list = byGroup.get(group) ?? []
-      list.push(decl)
-      byGroup.set(group, list)
+      const group = declarationGroup(decl, 'semantic');
+      const list = byGroup.get(group) ?? [];
+      list.push(decl);
+      byGroup.set(group, list);
     }
-    const lines: string[] = []
+    const lines: string[] = [];
     for (const group of groupOrder) {
-      const decls = byGroup.get(group)
-      if (!decls?.length) continue
-      if (groupComments[group]) lines.push('', `  /** ${groupComments[group]} */`)
+      const decls = byGroup.get(group);
+      if (!decls?.length) continue;
+      if (groupComments[group])
+        lines.push('', `  /** ${groupComments[group]} */`);
       for (const decl of decls.sort((a, b) => a.name.localeCompare(b.name))) {
-        lines.push(`  ${decl.name}: ${decl.value};`)
+        lines.push(`  ${decl.name}: ${decl.value};`);
       }
     }
     for (const [group, decls] of byGroup) {
-      if (groupOrder.includes(group)) continue
-      for (const decl of decls) lines.push(`  ${decl.name}: ${decl.value};`)
+      if (groupOrder.includes(group)) continue;
+      for (const decl of decls) lines.push(`  ${decl.name}: ${decl.value};`);
     }
-    return lines.join('\n')
+    return lines.join('\n');
   }
 
-  const ordered = orderDeclarations(declarations, existingOrder)
-  const lines: string[] = []
-  let lastGroup: string | undefined
+  const ordered = orderDeclarations(declarations, existingOrder);
+  const lines: string[] = [];
+  let lastGroup: string | undefined;
   for (const decl of ordered) {
-    const group = declarationGroup(decl, 'semantic')
+    const group = declarationGroup(decl, 'semantic');
     if (group !== lastGroup) {
-      if (groupComments[group]) lines.push('', `  /** ${groupComments[group]} */`)
-      lastGroup = group
+      if (groupComments[group])
+        lines.push('', `  /** ${groupComments[group]} */`);
+      lastGroup = group;
     }
-    lines.push(`  ${decl.name}: ${decl.value};`)
+    lines.push(`  ${decl.name}: ${decl.value};`);
   }
-  return lines.join('\n')
+  return lines.join('\n');
 }
 
 function generateSelectorBlock(
@@ -440,7 +523,10 @@ function generateSelectorBlock(
   radiusComment?: string,
   existingSelectorBody?: string,
 ): string {
-  const declarations = declarationsFromTokens(tokensFromFiles(rootDir, files), 'semantic')
+  const declarations = declarationsFromTokens(
+    tokensFromFiles(rootDir, files),
+    'semantic',
+  );
   const groupComments: Record<string, string | undefined> = {
     Radius: radiusComment ?? 'Sharp radius tokens (default - no radius)',
     Text: sectionLabel ? `${sectionLabel} text tokens` : 'text tokens',
@@ -448,14 +534,22 @@ function generateSelectorBlock(
     Fill: sectionLabel ? `${sectionLabel} fill tokens` : 'fill tokens',
     Surface: sectionLabel ? `${sectionLabel} surface tokens` : 'surface tokens',
     Status: sectionLabel ? `${sectionLabel} status tokens` : 'status tokens',
-    Stateslayer: sectionLabel ? `${sectionLabel} state layer tokens` : 'state layer tokens',
-    Elevations: sectionLabel ? `${sectionLabel} elevation tokens` : 'elevation tokens',
-  }
+    Stateslayer: sectionLabel
+      ? `${sectionLabel} state layer tokens`
+      : 'state layer tokens',
+    Elevations: sectionLabel
+      ? `${sectionLabel} elevation tokens`
+      : 'elevation tokens',
+  };
   const existingOrder = existingSelectorBody
     ? parseCssDeclarationOrder(existingSelectorBody)
-    : undefined
-  const body = formatSemanticDeclarations(declarations, groupComments, existingOrder)
-  return `${selector} {\n${body}\n}`
+    : undefined;
+  const body = formatSemanticDeclarations(
+    declarations,
+    groupComments,
+    existingOrder,
+  );
+  return `${selector} {\n${body}\n}`;
 }
 
 export function generateAllSections(
@@ -463,7 +557,7 @@ export function generateAllSections(
   config: TokensSyncConfig,
   existingSections: Record<string, string> = {},
 ): Record<string, string> {
-  const sections: Record<string, string> = {}
+  const sections: Record<string, string> = {};
   for (const section of config.sections) {
     if ('wrapper' in section && section.wrapper) {
       sections[section.id] = generateThemeInline(
@@ -471,15 +565,16 @@ export function generateAllSections(
         section.files,
         config.themeBridgePath,
         existingSections[section.id],
-      )
-      continue
+      );
+      continue;
     }
     if ('selectors' in section && section.selectors) {
-      const existingSemantic = existingSections[section.id] ?? ''
+      const existingSemantic = existingSections[section.id] ?? '';
       sections[section.id] = section.selectors
-        .map((sel) => {
-          const files = [sel.file, ...(sel.mergeFiles ?? [])]
-          const isRadiusOnly = sel.selector === '.radius-mode' && files.length === 1
+        .map(sel => {
+          const files = [sel.file, ...(sel.mergeFiles ?? [])];
+          const isRadiusOnly =
+            sel.selector === '.radius-mode' && files.length === 1;
           return generateSelectorBlock(
             rootDir,
             sel.selector,
@@ -487,18 +582,18 @@ export function generateAllSections(
             sel.label,
             isRadiusOnly ? 'Rounded radius tokens' : undefined,
             extractSelectorBlock(existingSemantic, sel.selector),
-          )
+          );
         })
-        .join('\n\n')
+        .join('\n\n');
     }
   }
-  return sections
+  return sections;
 }
 
 export function parseCssCustomProperties(css: string): Map<string, string> {
-  const map = new Map<string, string>()
-  const re = /(--[\w-]+)\s*:\s*([^;]+);/g
-  let match: RegExpExecArray | null
-  while ((match = re.exec(css)) !== null) map.set(match[1], match[2].trim())
-  return map
+  const map = new Map<string, string>();
+  const re = /(--[\w-]+)\s*:\s*([^;]+);/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(css)) !== null) map.set(match[1], match[2].trim());
+  return map;
 }

--- a/scripts/tokens/sync-core.ts
+++ b/scripts/tokens/sync-core.ts
@@ -1,0 +1,504 @@
+/**
+ * Core library for converting Figma Design Token JSON exports to CSS.
+ *
+ * Maps Figma paths and aliases to --custom-properties, builds @theme inline
+ * primitives and semantic blocks (:root, .dark, .radius-mode), and preserves
+ * existing declaration order from globals.css when regenerating.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// --- Types ---
+
+type TokenLeaf = {
+  $type?: string
+  $value?: unknown
+  $extensions?: {
+    'com.figma.aliasData'?: { targetVariableName?: string }
+    'com.figma.codeSyntax'?: { WEB?: string }
+  }
+}
+
+type FlatToken = { path: string[]; leaf: TokenLeaf }
+
+type CssDeclaration = { name: string; value: string }
+
+export type SelectorConfig = {
+  file: string
+  selector: string
+  mergeFiles?: string[]
+  label?: string
+}
+
+export type TokensSyncConfig = {
+  source: 'file' | 'figma'
+  globalsPath: string
+  themeBridgePath: string
+  sections: Array<
+    | { id: string; wrapper: string; files: string[] }
+    | { id: string; selectors: SelectorConfig[] }
+  >
+}
+
+// --- Parse Figma export JSON ---
+
+function isTokenLeaf(node: unknown): node is TokenLeaf {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    '$value' in node &&
+    ('$type' in node || '$extensions' in node)
+  )
+}
+
+function flattenTokens(
+  obj: Record<string, unknown>,
+  path: string[] = [],
+): FlatToken[] {
+  const result: FlatToken[] = []
+  for (const [key, value] of Object.entries(obj)) {
+    if (key.startsWith('$')) continue
+    const nextPath = [...path, key]
+    if (isTokenLeaf(value)) {
+      result.push({ path: nextPath, leaf: value })
+    } else if (typeof value === 'object' && value !== null) {
+      result.push(...flattenTokens(value as Record<string, unknown>, nextPath))
+    }
+  }
+  return result
+}
+
+type ColorValue = { hex?: string; alpha?: number }
+
+function formatColorValue(value: ColorValue): string {
+  const hex = (value.hex ?? '#000000').replace('#', '').toUpperCase()
+  const alpha = value.alpha ?? 1
+  if (alpha >= 0.999) {
+    return `#${hex.length === 6 ? hex : hex.slice(0, 6)}`.toLowerCase()
+  }
+  const base = hex.length >= 6 ? hex.slice(0, 6) : hex.padEnd(6, '0')
+  const a = Math.round(alpha * 255)
+    .toString(16)
+    .padStart(2, '0')
+  return `#${base}${a}`.toLowerCase()
+}
+
+// --- Name mapping ---
+
+const PALETTE_NAMES = new Set([
+  'red', 'amber', 'yellow', 'lime', 'green', 'emerald', 'teal', 'cyan', 'sky',
+  'blue', 'indigo', 'violet', 'purple', 'fuchsia', 'pink', 'rose', 'stone',
+])
+
+const SKIP_ROOT_KEYS = new Set(['Descriptor', 'Spacing', 'Stroke-Weight'])
+
+const THEME_GROUP_ORDER = [
+  'Font', 'Mist', 'Mist 50', 'Slate', 'Slate 900', 'Brand-Accents',
+]
+
+function kebab(segment: string): string {
+  return segment
+    .replace(/\s+/g, '-')
+    .replace(/_/g, '-')
+    .replace(/\u2013/g, '-')
+    .replace(/–/g, '-')
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.toLowerCase())
+    .join('-')
+}
+
+function shouldSkipPath(path: string[]): boolean {
+  return path.length === 0 || (path[0] != null && SKIP_ROOT_KEYS.has(path[0]))
+}
+
+function collapseSemanticPath(path: string[]): string[] {
+  if (path.length === 3 && path[1] === 'Content') return [path[0], path[2]]
+  if (path.length === 3 && path[1] === 'onSurface') {
+    return [path[0], path[2].replace(/^bg-ui/i, 'onsurface-ui-')]
+  }
+  if (path[0] === 'Elevations' && path.length === 2) {
+    const leaf = path[1].replace(/^Shade_T/i, 'shade-t').replace(/^Shade/i, 'shade')
+    return ['elevations', leaf]
+  }
+  return path
+}
+
+function pathToCssVarName(path: string[], context: 'theme' | 'semantic'): string | null {
+  if (shouldSkipPath(path)) return null
+  if (path[0] === 'Font') {
+    if (path[1] === 'Family' && path[2]) return `--font-${kebab(path[2])}`
+    if (path[1] === 'Weight' && path[2]) return `--font-weight-${path[2]}`
+    if (path[1] === 'Font-Size' && path[2]) return `--font-font-size-${path[2]}`
+    if (path[1] === 'Line-Height' && path[2]) return `--font-line-height-${path[2]}`
+    return null
+  }
+  if (path[0] === 'Brand-Accents' && path[1]) return `--brand-accents-${kebab(path[1])}`
+  if (path.length >= 2 && PALETTE_NAMES.has(path[0].toLowerCase())) {
+    return `--color-${path[0].toLowerCase()}-${path[1]}`
+  }
+  if (context === 'semantic') {
+    return `--${collapseSemanticPath(path).map(kebab).join('-')}`
+  }
+  if (path[0]?.includes(' ')) {
+    const [group, ...rest] = path
+    return `--${kebab(group)}${rest.length ? `-${rest.map(kebab).join('-')}` : ''}`
+  }
+  if (path.length === 2) return `--${kebab(path[0])}-${path[1]}`
+  if (path.length === 1) return `--${kebab(path[0])}`
+  return `--${path.map(kebab).join('-')}`
+}
+
+function aliasToCssValue(targetVariableName: string): string {
+  const parts = targetVariableName.trim().split('/')
+  if (parts.length === 2) {
+    const [a, b] = parts
+    if (a.includes(' ')) return `var(--${kebab(a)}-${b})`
+    if (a === a.toLowerCase() && !a.includes(' ')) return `var(--color-${a}-${b})`
+    return `var(--${a.toLowerCase()}-${b})`
+  }
+  return `var(--${kebab(targetVariableName)})`
+}
+
+function resolveTokenValue(leaf: TokenLeaf): string | null {
+  const aliasName = leaf.$extensions?.['com.figma.aliasData']?.targetVariableName
+  if (aliasName) return aliasToCssValue(aliasName)
+
+  const webSyntax = leaf.$extensions?.['com.figma.codeSyntax']?.WEB
+  if (webSyntax && !/--radi-\d/.test(webSyntax)) return webSyntax
+
+  const { $type: type, $value: value } = leaf
+  if (type === 'color' && typeof value === 'object' && value !== null) {
+    return formatColorValue(value as ColorValue)
+  }
+  if (type === 'number' && typeof value === 'number') return `${value}px`
+  if (type === 'string' && typeof value === 'string') return `'${value}'`
+  return null
+}
+
+// --- CSS generation ---
+
+function loadJson(rootDir: string, file: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(rootDir, file), 'utf8')) as Record<string, unknown>
+}
+
+function tokensFromFiles(rootDir: string, files: string[]): FlatToken[] {
+  return files.flatMap((file) => flattenTokens(loadJson(rootDir, file)))
+}
+
+function declarationsFromTokens(
+  tokens: FlatToken[],
+  context: 'theme' | 'semantic',
+): CssDeclaration[] {
+  const declarations: CssDeclaration[] = []
+  const seen = new Set<string>()
+  for (const { path, leaf } of tokens) {
+    if (shouldSkipPath(path)) continue
+    const name = pathToCssVarName(path, context)
+    if (!name || seen.has(name)) continue
+    const value = resolveTokenValue(leaf)
+    if (!value) continue
+    seen.add(name)
+    declarations.push({ name, value })
+  }
+  return declarations
+}
+
+function groupKeyFromVar(cssVar: string): string {
+  const name = cssVar.replace(/^--/, '')
+  if (name.startsWith('font-')) return 'Font'
+  if (name.startsWith('mist-50-opacity')) return 'Mist 50'
+  if (name.startsWith('mist-')) return 'Mist'
+  if (name.startsWith('slate-900-opacity')) return 'Slate 900'
+  if (name.startsWith('slate-')) return 'Slate'
+  if (name.startsWith('brand-accents')) return 'Brand-Accents'
+  if (name.startsWith('color-')) {
+    const parts = name.split('-')
+    if (parts.length >= 3) return `palette:${parts[1]}`
+  }
+  return 'Other'
+}
+
+function sectionCommentForGroup(group: string, context: 'theme' | 'semantic'): string | undefined {
+  if (context === 'theme') {
+    const map: Record<string, string> = {
+      Font: 'Font Tokens',
+      Mist: 'Mist Primitives',
+      'Mist 50': 'Mist Opacity Tokens',
+      Slate: 'Slate Primitives',
+      'Slate 900': 'Slate Opacity Tokens',
+      'Brand-Accents': 'Brand Accents',
+    }
+    return map[group] ? `/** ${map[group]} */` : undefined
+  }
+  const semanticMap: Record<string, string> = {
+    Text: 'text', Border: 'border', Fill: 'fill', Surface: 'surface',
+    Status: 'status', Stateslayer: 'state layer', Elevations: 'elevation',
+  }
+  return semanticMap[group] ? `/** ${semanticMap[group]} tokens */` : undefined
+}
+
+function declarationGroup(decl: CssDeclaration, context: 'theme' | 'semantic'): string {
+  if (context === 'semantic') {
+    const parts = decl.name.replace(/^--/, '').split('-')
+    return (
+      ({
+        text: 'Text',
+        border: 'Border',
+        fill: 'Fill',
+        surface: 'Surface',
+        status: 'Status',
+        stateslayer: 'Stateslayer',
+        elevations: 'Elevations',
+        rad: 'Radius',
+        slider: 'Slider',
+      }) as Record<string, string>
+    )[parts[0]] ?? 'Other'
+  }
+  return groupKeyFromVar(decl.name)
+}
+
+export function parseCssDeclarationOrder(css: string): string[] {
+  const order: string[] = []
+  const seen = new Set<string>()
+  const re = /(--[^:\s]+)\s*:/g
+  let match: RegExpExecArray | null
+  while ((match = re.exec(css)) !== null) {
+    if (!seen.has(match[1])) {
+      seen.add(match[1])
+      order.push(match[1])
+    }
+  }
+  return order
+}
+
+export function orderDeclarations(
+  declarations: CssDeclaration[],
+  existingOrder: string[],
+): CssDeclaration[] {
+  const index = new Map(existingOrder.map((name, i) => [name, i]))
+  const known: CssDeclaration[] = []
+  const unknown: CssDeclaration[] = []
+  for (const decl of declarations) {
+    if (index.has(decl.name)) known.push(decl)
+    else unknown.push(decl)
+  }
+  known.sort((a, b) => index.get(a.name)! - index.get(b.name)!)
+  unknown.sort((a, b) => a.name.localeCompare(b.name))
+  return [...known, ...unknown]
+}
+
+function formatDeclarationsGrouped(
+  declarations: CssDeclaration[],
+  context: 'theme' | 'semantic',
+  indent: string,
+): string {
+  const byGroup = new Map<string, CssDeclaration[]>()
+  for (const decl of declarations) {
+    const group = declarationGroup(decl, context)
+    const list = byGroup.get(group) ?? []
+    list.push(decl)
+    byGroup.set(group, list)
+  }
+
+  const order =
+    context === 'theme'
+      ? [
+          ...THEME_GROUP_ORDER,
+          ...[...byGroup.keys()].filter((k) => !THEME_GROUP_ORDER.includes(k) && !k.startsWith('palette:')),
+          ...[...byGroup.keys()].filter((k) => k.startsWith('palette:')).sort(),
+        ]
+      : ['Radius', 'Text', 'Border', 'Fill', 'Slider', 'Surface', 'Status', 'Stateslayer', 'Elevations', 'Other']
+
+  const lines: string[] = []
+  const emitted = new Set<string>()
+  for (const group of order) {
+    const decls = byGroup.get(group)
+    if (!decls?.length || emitted.has(group)) continue
+    emitted.add(group)
+    const comment = sectionCommentForGroup(group, context)
+    if (comment) lines.push('', `${indent}${comment}`)
+    for (const decl of decls.sort((a, b) => a.name.localeCompare(b.name))) {
+      lines.push(`${indent}${decl.name}: ${decl.value};`)
+    }
+  }
+  for (const [group, decls] of byGroup) {
+    if (emitted.has(group)) continue
+    for (const decl of decls) lines.push(`${indent}${decl.name}: ${decl.value};`)
+  }
+  return lines.join('\n')
+}
+
+function formatDeclarations(
+  declarations: CssDeclaration[],
+  context: 'theme' | 'semantic',
+  indent: string,
+  existingOrder?: string[],
+): string {
+  if (!existingOrder?.length) {
+    return formatDeclarationsGrouped(declarations, context, indent)
+  }
+
+  const ordered = orderDeclarations(declarations, existingOrder)
+  const lines: string[] = []
+  let lastGroup: string | undefined
+  for (const decl of ordered) {
+    const group = declarationGroup(decl, context)
+    if (group !== lastGroup) {
+      const comment = sectionCommentForGroup(group, context)
+      if (comment) lines.push('', `${indent}${comment}`)
+      lastGroup = group
+    }
+    lines.push(`${indent}${decl.name}: ${decl.value};`)
+  }
+  return lines.join('\n')
+}
+
+function addFontSans(declarations: CssDeclaration[]): CssDeclaration[] {
+  const display = declarations.find((d) => d.name === '--font-display')
+  if (!display || declarations.some((d) => d.name === '--font-sans')) return declarations
+  const value = display.value.replace(/^'|'$/g, '')
+  return [...declarations, { name: '--font-sans', value: `'${value}', sans-serif` }]
+}
+
+function extractSelectorBlock(sectionCss: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = sectionCss.match(
+    new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\n\\}`, 'm'),
+  )
+  return match?.[1] ?? ''
+}
+
+function generateThemeInline(
+  rootDir: string,
+  files: string[],
+  bridgePath: string,
+  existingSection?: string,
+): string {
+  let declarations = declarationsFromTokens(tokensFromFiles(rootDir, files), 'theme')
+  declarations = addFontSans(declarations)
+  const existingOrder = existingSection
+    ? parseCssDeclarationOrder(existingSection)
+    : undefined
+  const primitives = formatDeclarations(declarations, 'theme', '  ', existingOrder)
+  const bridge = readFileSync(join(rootDir, bridgePath), 'utf8').trimEnd()
+  return `@theme inline {\n${primitives}\n\n${bridge}\n}`
+}
+
+function formatSemanticDeclarations(
+  declarations: CssDeclaration[],
+  groupComments: Record<string, string | undefined>,
+  existingOrder?: string[],
+): string {
+  const groupOrder = [
+    'Radius', 'Text', 'Border', 'Fill', 'Slider', 'Surface', 'Status', 'Stateslayer', 'Elevations', 'Other',
+  ]
+
+  if (!existingOrder?.length) {
+    const byGroup = new Map<string, CssDeclaration[]>()
+    for (const decl of declarations) {
+      const group = declarationGroup(decl, 'semantic')
+      const list = byGroup.get(group) ?? []
+      list.push(decl)
+      byGroup.set(group, list)
+    }
+    const lines: string[] = []
+    for (const group of groupOrder) {
+      const decls = byGroup.get(group)
+      if (!decls?.length) continue
+      if (groupComments[group]) lines.push('', `  /** ${groupComments[group]} */`)
+      for (const decl of decls.sort((a, b) => a.name.localeCompare(b.name))) {
+        lines.push(`  ${decl.name}: ${decl.value};`)
+      }
+    }
+    for (const [group, decls] of byGroup) {
+      if (groupOrder.includes(group)) continue
+      for (const decl of decls) lines.push(`  ${decl.name}: ${decl.value};`)
+    }
+    return lines.join('\n')
+  }
+
+  const ordered = orderDeclarations(declarations, existingOrder)
+  const lines: string[] = []
+  let lastGroup: string | undefined
+  for (const decl of ordered) {
+    const group = declarationGroup(decl, 'semantic')
+    if (group !== lastGroup) {
+      if (groupComments[group]) lines.push('', `  /** ${groupComments[group]} */`)
+      lastGroup = group
+    }
+    lines.push(`  ${decl.name}: ${decl.value};`)
+  }
+  return lines.join('\n')
+}
+
+function generateSelectorBlock(
+  rootDir: string,
+  selector: string,
+  files: string[],
+  sectionLabel?: string,
+  radiusComment?: string,
+  existingSelectorBody?: string,
+): string {
+  const declarations = declarationsFromTokens(tokensFromFiles(rootDir, files), 'semantic')
+  const groupComments: Record<string, string | undefined> = {
+    Radius: radiusComment ?? 'Sharp radius tokens (default - no radius)',
+    Text: sectionLabel ? `${sectionLabel} text tokens` : 'text tokens',
+    Border: sectionLabel ? `${sectionLabel} border tokens` : 'border tokens',
+    Fill: sectionLabel ? `${sectionLabel} fill tokens` : 'fill tokens',
+    Surface: sectionLabel ? `${sectionLabel} surface tokens` : 'surface tokens',
+    Status: sectionLabel ? `${sectionLabel} status tokens` : 'status tokens',
+    Stateslayer: sectionLabel ? `${sectionLabel} state layer tokens` : 'state layer tokens',
+    Elevations: sectionLabel ? `${sectionLabel} elevation tokens` : 'elevation tokens',
+  }
+  const existingOrder = existingSelectorBody
+    ? parseCssDeclarationOrder(existingSelectorBody)
+    : undefined
+  const body = formatSemanticDeclarations(declarations, groupComments, existingOrder)
+  return `${selector} {\n${body}\n}`
+}
+
+export function generateAllSections(
+  rootDir: string,
+  config: TokensSyncConfig,
+  existingSections: Record<string, string> = {},
+): Record<string, string> {
+  const sections: Record<string, string> = {}
+  for (const section of config.sections) {
+    if ('wrapper' in section && section.wrapper) {
+      sections[section.id] = generateThemeInline(
+        rootDir,
+        section.files,
+        config.themeBridgePath,
+        existingSections[section.id],
+      )
+      continue
+    }
+    if ('selectors' in section && section.selectors) {
+      const existingSemantic = existingSections[section.id] ?? ''
+      sections[section.id] = section.selectors
+        .map((sel) => {
+          const files = [sel.file, ...(sel.mergeFiles ?? [])]
+          const isRadiusOnly = sel.selector === '.radius-mode' && files.length === 1
+          return generateSelectorBlock(
+            rootDir,
+            sel.selector,
+            files,
+            sel.label,
+            isRadiusOnly ? 'Rounded radius tokens' : undefined,
+            extractSelectorBlock(existingSemantic, sel.selector),
+          )
+        })
+        .join('\n\n')
+    }
+  }
+  return sections
+}
+
+export function parseCssCustomProperties(css: string): Map<string, string> {
+  const map = new Map<string, string>()
+  const re = /(--[\w-]+)\s*:\s*([^;]+);/g
+  let match: RegExpExecArray | null
+  while ((match = re.exec(css)) !== null) map.set(match[1], match[2].trim())
+  return map
+}

--- a/scripts/tokens/theme-bridge.csspart
+++ b/scripts/tokens/theme-bridge.csspart
@@ -1,0 +1,148 @@
+/*
+ * Hand-maintained Tailwind / shadcn bridge — pasted into @theme inline after
+ * Figma-synced primitives. Not generated from token JSON; edit here when adding
+ * framework aliases (e.g. --text-sm, --color-fg-*, --radius-*).
+ */
+
+  /** Text Size Mappings - shadcn convention mapped to primitives */
+  --text-xs: var(--font-font-size-12);
+  --text-xs-line-height: var(--font-line-height-12);
+  --text-sm: var(--font-font-size-14);
+  --text-sm-line-height: var(--font-line-height-16);
+  --text-base: var(--font-font-size-16);
+  --text-base-line-height: var(--font-line-height-20);
+  --text-lg: var(--font-font-size-20);
+  --text-lg-line-height: var(--font-line-height-24);
+  --text-xl: var(--font-font-size-20);
+  --text-xl-line-height: var(--font-line-height-24);
+  --text-2xl: var(--font-font-size-24);
+  --text-2xl-line-height: var(--font-line-height-28);
+  --text-3xl: var(--font-font-size-32);
+  --text-3xl-line-height: var(--font-line-height-32);
+  --text-4xl: var(--font-font-size-40);
+  --text-4xl-line-height: var(--font-line-height-40);
+  --text-5xl: var(--font-font-size-48);
+  --text-5xl-line-height: var(--font-line-height-48);
+  --text-6xl: var(--font-font-size-56);
+  --text-6xl-line-height: var(--font-line-height-56);
+
+  /** Mist Utility Colors */
+  --color-mist-50: var(--mist-50);
+  --color-mist-50-opacity-88: var(--mist-50-opacity-88);
+
+  /** Brand Accent Utility Colors */
+  --color-brand-accents-qb-accent: var(--brand-accents-qb-accent);
+
+  /** Radius Tokens - Available as Tailwind utilities */
+  --radius-round: var(--rad-round);
+  --radius-reg: var(--rad-reg);
+  --radius-sm: var(--rad-sm);
+  --radius-md: var(--rad-md);
+  --radius-lg: var(--rad-lg);
+
+  /*** Foreground (Text/Icon) Tokens */
+
+  --color-fg-primary: var(--text-primary);
+  --color-fg-secondary: var(--text-secondary);
+  --color-fg-tertiary: var(--text-tertiary);
+  --color-fg-disabled: var(--text-disabled);
+  --color-fg-primary-inverse: var(--text-primary-inverse);
+  --color-fg-secondary-inverse: var(--text-secondary-inverse);
+  --color-fg-tertiary-inverse: var(--text-tertiary-inverse);
+  --color-fg-disabled-inverse: var(--text-disabled-inverse);
+
+  /*** Stroke (Border) Tokens */
+
+  --color-stroke-divider: var(--border-divider);
+  --color-stroke-primary: var(--border-primary);
+  --color-stroke-secondary: var(--border-secondary);
+  --color-stroke-tertiary: var(--border-tertiary);
+  --color-stroke-active: var(--border-active);
+  --color-stroke-status-focus: var(--border-status-focus);
+  --color-stroke-status-mono: var(--border-status-mono);
+  --color-stroke-status-error: var(--border-status-error);
+  --color-stroke-status-success: var(--border-status-success);
+  --color-stroke-status-warning: var(--border-status-warning);
+  --color-stroke-divider-inverse: var(--border-divider-inverse);
+  --color-stroke-primary-inverse: var(--border-primary-inverse);
+  --color-stroke-secondary-inverse: var(--border-secondary-inverse);
+  --color-stroke-tertiary-inverse: var(--border-tertiary-inverse);
+  --color-stroke-tertiary-hover: var(--border-tertiary-hover);
+  --color-stroke-tertiary-hover-inverse: var(--border-tertiary-hover-inverse);
+  --color-stroke-active-inverse: var(--border-active-inverse);
+
+  /*** Fill Tokens */
+
+  --color-fill-primary: var(--fill-primary);
+  --color-fill-secondary: var(--fill-secondary);
+  --color-fill-tertiary: var(--fill-tertiary);
+  --color-fill-subtle: var(--fill-subtle);
+  --color-fill-muted: var(--fill-muted);
+  --color-fill-active: var(--fill-active);
+  --color-fill-disabled: var(--fill-disabled);
+  --color-fill-primary-inverse: var(--fill-primary-inverse);
+  --color-fill-secondary-inverse: var(--fill-secondary-inverse);
+  --color-fill-tertiary-inverse: var(--fill-tertiary-inverse);
+  --color-fill-subtle-inverse: var(--fill-subtle-inverse);
+  --color-fill-disabled-inverse: var(--fill-disabled-inverse);
+  --color-fill-active-inverse: var(--fill-active-inverse);
+  --color-fill-muted-inverse: var(--fill-muted-inverse);
+  --color-fill-selected-range: var(--fill-selected-range);
+  --color-fill-onsurface-ui-1: var(--fill-onsurface-ui-1);
+  --color-fill-onsurface-ui-2: var(--fill-onsurface-ui-2);
+  --color-fill-onsurface-ui-3: var(--fill-onsurface-ui-3);
+
+  --color-slider-track: var(--slider-track);
+
+  /*** Surface Tokens */
+
+  --color-surface-primary: var(--surface-primary);
+  --color-surface-secondary: var(--surface-secondary);
+  --color-surface-tertiary: var(--surface-tertiary);
+  --color-surface-base: var(--surface-base);
+  --color-sidebar: var(--surface-base);
+  --color-sidebar-foreground: var(--text-primary);
+
+  /*** Status Tokens */
+
+  --color-status-success: var(--status-success);
+  --color-status-error: var(--status-error);
+  --color-status-warning: var(--status-warning);
+  --color-status-information: var(--status-information);
+  --color-status-success-inverse: var(--status-success-inverse);
+  --color-status-error-inverse: var(--status-error-inverse);
+  --color-status-warning-inverse: var(--status-warning-inverse);
+  --color-status-information-inverse: var(--status-information-inverse);
+
+  /*** State Layer Tokens */
+
+  --color-stateslayer-overlay-enabled: var(--stateslayer-overlay-enabled);
+  --color-stateslayer-overlay-hover: var(--stateslayer-overlay-hover);
+  --color-stateslayer-overlay-pressed: var(--stateslayer-overlay-pressed);
+  --color-stateslayer-overlay-disabled: var(--stateslayer-overlay-disabled);
+  --color-stateslayer-overlay-active: var(--stateslayer-overlay-active);
+  --color-stateslayer-overlay-hover-inverse: var(
+    --stateslayer-overlay-hover-inverse
+  );
+  --color-stateslayer-overlay-pressed-inverse: var(
+    --stateslayer-overlay-pressed-inverse
+  );
+  --color-stateslayer-overlay-disabled-inverse: var(
+    --stateslayer-overlay-disabled-inverse
+  );
+  --color-stateslayer-overlay-active-inverse: var(
+    --stateslayer-overlay-active-inverse
+  );
+
+  /*** Elevation Tokens */
+
+  --color-elevations-shade-t: var(--elevations-shade-t);
+  --color-elevations-shade: var(--elevations-shade);
+  --color-elevations-shade-t-01: var(--elevations-shade-t-01);
+  --color-elevations-shade-01: var(--elevations-shade-01);
+  --color-elevations-shade-t-02: var(--elevations-shade-t-02);
+  --color-elevations-shade-02: var(--elevations-shade-02);
+  --color-elevations-shade-t-03: var(--elevations-shade-t-03);
+  --color-elevations-shade-03: var(--elevations-shade-03);
+  --color-elevations-shade-t-04: var(--elevations-shade-t-04);
+  --color-elevations-shade-04: var(--elevations-shade-04);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -662,13 +662,6 @@
   --rad-sm: 4px;
 }
 /* qbds:tokens:end semantic */
-.radius-mode {
-  /** Rounded radius tokens */
-  --rad-reg: 8px;
-  --rad-sm: 4px;
-  --rad-md: 12px;
-  --rad-lg: 16px;
-}
 
 @utility shadow-elevation-0 {
   --tw-shadow:

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -647,7 +647,7 @@
   --elevations-shade-04: var(--slate-900-opacity-88);
 
   /** Dark mode fill tokens */
-  --fill-stepmarkers+track: var(--slate-100);
+  --fill-stepmarkers-track: var(--slate-100);
 
   /** Sharp radius tokens (default - no radius) */
   --rad-round: 1000px;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,7 +7,9 @@
 /* Radius mode variant - for rounded corners (sharp is default) */
 @custom-variant radius-mode (&:where(.radius-mode, .radius-mode *));
 
+/* qbds:tokens:begin theme-inline */
 @theme inline {
+
   /** Font Tokens */
   --font-display: 'Inter';
   --font-headings: 'Inter';
@@ -37,28 +39,6 @@
   --font-line-height-64: 64px;
   --font-sans: 'Inter', sans-serif;
 
-  /** Text Size Mappings - shadcn convention mapped to primitives */
-  --text-xs: var(--font-font-size-12);
-  --text-xs-line-height: var(--font-line-height-12);
-  --text-sm: var(--font-font-size-14);
-  --text-sm-line-height: var(--font-line-height-16);
-  --text-base: var(--font-font-size-16);
-  --text-base-line-height: var(--font-line-height-20);
-  --text-lg: var(--font-font-size-20);
-  --text-lg-line-height: var(--font-line-height-24);
-  --text-xl: var(--font-font-size-20);
-  --text-xl-line-height: var(--font-line-height-24);
-  --text-2xl: var(--font-font-size-24);
-  --text-2xl-line-height: var(--font-line-height-28);
-  --text-3xl: var(--font-font-size-32);
-  --text-3xl-line-height: var(--font-line-height-32);
-  --text-4xl: var(--font-font-size-40);
-  --text-4xl-line-height: var(--font-line-height-40);
-  --text-5xl: var(--font-font-size-48);
-  --text-5xl-line-height: var(--font-line-height-48);
-  --text-6xl: var(--font-font-size-56);
-  --text-6xl-line-height: var(--font-line-height-56);
-
   /** Mist Primitives */
   --mist-50: #ffffff;
   --mist-100: #fafafb;
@@ -85,10 +65,6 @@
   --mist-50-opacity-50: #ffffff80;
   --mist-50-opacity-60: #ffffff99;
   --mist-50-opacity-88: #ffffffe0;
-
-  /** Mist Utility Colors */
-  --color-mist-50: var(--mist-50);
-  --color-mist-50-opacity-88: var(--mist-50-opacity-88);
 
   /** Slate Primitives */
   --slate-50: #373a44;
@@ -123,6 +99,225 @@
   --brand-accents-mckinsey-electric-blue: #2251ff;
   --brand-accents-mckinsey-cyan: #00a9f4;
   --brand-accents-qb-accent: #00a9f4;
+  --color-amber-100: #fef3c7;
+  --color-amber-200: #fde68a;
+  --color-amber-300: #fcd34d;
+  --color-amber-400: #fbbf24;
+  --color-amber-50: #fffbeb;
+  --color-amber-500: #f59e0b;
+  --color-amber-600: #d97706;
+  --color-amber-700: #b45309;
+  --color-amber-800: #92400e;
+  --color-amber-900: #78350f;
+  --color-amber-950: #431407;
+  --color-blue-100: #dbeafe;
+  --color-blue-200: #bfdbfe;
+  --color-blue-300: #93c5fd;
+  --color-blue-400: #60a5fa;
+  --color-blue-50: #eff6ff;
+  --color-blue-500: #3b82f6;
+  --color-blue-600: #2563eb;
+  --color-blue-700: #1d4ed8;
+  --color-blue-800: #1e40af;
+  --color-blue-900: #1e3a8a;
+  --color-blue-950: #172554;
+  --color-cyan-100: #cffafe;
+  --color-cyan-200: #a5f3fc;
+  --color-cyan-300: #67e8f9;
+  --color-cyan-400: #22d3ee;
+  --color-cyan-50: #ecfeff;
+  --color-cyan-500: #06b6d4;
+  --color-cyan-600: #0891b2;
+  --color-cyan-700: #0e7490;
+  --color-cyan-800: #155e75;
+  --color-cyan-900: #164e63;
+  --color-cyan-950: #083344;
+  --color-emerald-100: #d1fae5;
+  --color-emerald-200: #a7f3d0;
+  --color-emerald-300: #6ee7b7;
+  --color-emerald-400: #34d399;
+  --color-emerald-50: #ecfdf5;
+  --color-emerald-500: #10b981;
+  --color-emerald-600: #059669;
+  --color-emerald-700: #047857;
+  --color-emerald-800: #065f46;
+  --color-emerald-900: #064e3b;
+  --color-emerald-950: #022c22;
+  --color-fuchsia-100: #fae8ff;
+  --color-fuchsia-200: #f5d0fe;
+  --color-fuchsia-300: #f0abfc;
+  --color-fuchsia-400: #e879f9;
+  --color-fuchsia-50: #fdf4ff;
+  --color-fuchsia-500: #d946ef;
+  --color-fuchsia-600: #c026d3;
+  --color-fuchsia-700: #a21caf;
+  --color-fuchsia-800: #86198f;
+  --color-fuchsia-900: #701a75;
+  --color-fuchsia-950: #4a044e;
+  --color-green-100: #dcfce7;
+  --color-green-200: #bbf7d0;
+  --color-green-300: #86efac;
+  --color-green-400: #4ade80;
+  --color-green-50: #f0fdf4;
+  --color-green-500: #22c55e;
+  --color-green-600: #16a34a;
+  --color-green-700: #15803d;
+  --color-green-800: #166534;
+  --color-green-900: #14532d;
+  --color-green-950: #052e16;
+  --color-indigo-100: #e0e7ff;
+  --color-indigo-200: #c7d2fe;
+  --color-indigo-300: #a5b4fc;
+  --color-indigo-400: #818cf8;
+  --color-indigo-50: #eef2ff;
+  --color-indigo-500: #6366f1;
+  --color-indigo-600: #4f46e5;
+  --color-indigo-700: #4338ca;
+  --color-indigo-800: #3730a3;
+  --color-indigo-900: #312e81;
+  --color-indigo-950: #1e1b4b;
+  --color-lime-100: #ecfccb;
+  --color-lime-200: #d9f99d;
+  --color-lime-300: #bef264;
+  --color-lime-400: #a3e635;
+  --color-lime-50: #f7fee7;
+  --color-lime-500: #84cc16;
+  --color-lime-600: #65a30d;
+  --color-lime-700: #4d7c0f;
+  --color-lime-800: #3f6212;
+  --color-lime-900: #365314;
+  --color-lime-950: #1a2e05;
+  --color-pink-100: #fce7f3;
+  --color-pink-200: #fbcfe8;
+  --color-pink-300: #f9a8d4;
+  --color-pink-400: #f472b6;
+  --color-pink-50: #fdf2f8;
+  --color-pink-500: #ec4899;
+  --color-pink-600: #db2777;
+  --color-pink-700: #be185d;
+  --color-pink-800: #9d174d;
+  --color-pink-900: #831843;
+  --color-pink-950: #500724;
+  --color-purple-100: #f3e8ff;
+  --color-purple-200: #e9d5ff;
+  --color-purple-300: #d8b4fe;
+  --color-purple-400: #c084fc;
+  --color-purple-50: #faf5ff;
+  --color-purple-500: #a855f7;
+  --color-purple-600: #9333ea;
+  --color-purple-700: #7e22ce;
+  --color-purple-800: #6b21a8;
+  --color-purple-900: #581c87;
+  --color-purple-950: #3b0764;
+  --color-red-100: #fee2e2;
+  --color-red-200: #fecaca;
+  --color-red-300: #fca5a5;
+  --color-red-400: #f87171;
+  --color-red-50: #fef2f2;
+  --color-red-500: #ef4444;
+  --color-red-600: #dc2626;
+  --color-red-700: #b91c1c;
+  --color-red-800: #991b1b;
+  --color-red-900: #7f1d1d;
+  --color-red-950: #450a0a;
+  --color-rose-100: #ffe4e6;
+  --color-rose-200: #fecdd3;
+  --color-rose-300: #fda4af;
+  --color-rose-400: #fb7185;
+  --color-rose-50: #fff1f2;
+  --color-rose-500: #f43f5e;
+  --color-rose-600: #e11d48;
+  --color-rose-700: #be123c;
+  --color-rose-800: #9f1239;
+  --color-rose-900: #881337;
+  --color-rose-950: #4c0519;
+  --color-sky-100: #e0f2fe;
+  --color-sky-200: #bae6fd;
+  --color-sky-300: #7dd3fc;
+  --color-sky-400: #38bdf8;
+  --color-sky-50: #f0f9ff;
+  --color-sky-500: #0ea5e9;
+  --color-sky-600: #0284c7;
+  --color-sky-700: #0369a1;
+  --color-sky-800: #075985;
+  --color-sky-900: #0c4a6e;
+  --color-sky-950: #082f49;
+  --color-stone-100: #f5f5f4;
+  --color-stone-200: #e7e5e4;
+  --color-stone-300: #d6d3d1;
+  --color-stone-400: #a8a29e;
+  --color-stone-50: #fafaf9;
+  --color-stone-500: #78716c;
+  --color-stone-600: #57534e;
+  --color-stone-700: #44403c;
+  --color-stone-800: #292524;
+  --color-stone-900: #1c1917;
+  --color-stone-950: #0c0a09;
+  --color-teal-100: #ccfbf1;
+  --color-teal-200: #99f6e4;
+  --color-teal-300: #5eead4;
+  --color-teal-400: #2dd4bf;
+  --color-teal-50: #f0fdfa;
+  --color-teal-500: #14b8a6;
+  --color-teal-600: #0d9488;
+  --color-teal-700: #0f766e;
+  --color-teal-800: #115e59;
+  --color-teal-900: #134e4a;
+  --color-teal-950: #042f2e;
+  --color-violet-100: #ede9fe;
+  --color-violet-200: #ddd6fe;
+  --color-violet-300: #c4b5fd;
+  --color-violet-400: #a78bfa;
+  --color-violet-50: #f5f3ff;
+  --color-violet-500: #8b5cf6;
+  --color-violet-600: #7c3aed;
+  --color-violet-700: #6d28d9;
+  --color-violet-800: #5b21b6;
+  --color-violet-900: #4c1d95;
+  --color-violet-950: #2e1065;
+  --color-yellow-100: #fef9c3;
+  --color-yellow-200: #fef08a;
+  --color-yellow-300: #fde047;
+  --color-yellow-400: #facc15;
+  --color-yellow-50: #fefce8;
+  --color-yellow-500: #eab308;
+  --color-yellow-600: #ca8a04;
+  --color-yellow-700: #a16207;
+  --color-yellow-800: #854d0e;
+  --color-yellow-900: #713f12;
+  --color-yellow-950: #422006;
+
+/*
+ * Hand-maintained Tailwind / shadcn bridge — pasted into @theme inline after
+ * Figma-synced primitives. Not generated from token JSON; edit here when adding
+ * framework aliases (e.g. --text-sm, --color-fg-*, --radius-*).
+ */
+
+  /** Text Size Mappings - shadcn convention mapped to primitives */
+  --text-xs: var(--font-font-size-12);
+  --text-xs-line-height: var(--font-line-height-12);
+  --text-sm: var(--font-font-size-14);
+  --text-sm-line-height: var(--font-line-height-16);
+  --text-base: var(--font-font-size-16);
+  --text-base-line-height: var(--font-line-height-20);
+  --text-lg: var(--font-font-size-20);
+  --text-lg-line-height: var(--font-line-height-24);
+  --text-xl: var(--font-font-size-20);
+  --text-xl-line-height: var(--font-line-height-24);
+  --text-2xl: var(--font-font-size-24);
+  --text-2xl-line-height: var(--font-line-height-28);
+  --text-3xl: var(--font-font-size-32);
+  --text-3xl-line-height: var(--font-line-height-32);
+  --text-4xl: var(--font-font-size-40);
+  --text-4xl-line-height: var(--font-line-height-40);
+  --text-5xl: var(--font-font-size-48);
+  --text-5xl-line-height: var(--font-line-height-48);
+  --text-6xl: var(--font-font-size-56);
+  --text-6xl-line-height: var(--font-line-height-56);
+
+  /** Mist Utility Colors */
+  --color-mist-50: var(--mist-50);
+  --color-mist-50-opacity-88: var(--mist-50-opacity-88);
 
   /** Brand Accent Utility Colors */
   --color-brand-accents-qb-accent: var(--brand-accents-qb-accent);
@@ -241,8 +436,11 @@
   --color-elevations-shade-t-04: var(--elevations-shade-t-04);
   --color-elevations-shade-04: var(--elevations-shade-04);
 }
+/* qbds:tokens:end theme-inline */
 
+/* qbds:tokens:begin semantic */
 :root {
+
   /** Sharp radius tokens (default - no radius) */
   --rad-reg: 0px;
   --rad-sm: 0px;
@@ -250,7 +448,6 @@
   --rad-lg: 0px;
 
   /** Light mode text tokens */
-
   --text-primary: var(--slate-900-opacity-88);
   --text-secondary: var(--slate-900-opacity-60);
   --text-tertiary: var(--slate-900-opacity-50);
@@ -265,7 +462,6 @@
   --text-success: var(--color-green-700);
 
   /** Light mode border tokens */
-
   --border-divider: var(--slate-900-opacity-10);
   --border-primary: var(--slate-900-opacity-38);
   --border-secondary: var(--slate-900-opacity-24);
@@ -285,7 +481,6 @@
   --border-active-inverse: var(--mist-50);
 
   /** Light mode fill tokens */
-
   --fill-primary: var(--slate-900-opacity-88);
   --fill-secondary: var(--slate-900-opacity-60);
   --fill-tertiary: var(--slate-900-opacity-16);
@@ -300,22 +495,17 @@
   --fill-muted-inverse: var(--mist-50-opacity-8);
   --fill-disabled-inverse: var(--mist-50-opacity-38);
   --fill-active-inverse: var(--mist-50);
-  --fill-selected-range: var(--slate-900-opacity-8);
   --fill-onsurface-ui-1: var(--mist-100);
   --fill-onsurface-ui-2: var(--mist-300);
   --fill-onsurface-ui-3: var(--mist-200);
 
-  --slider-track: var(--mist-900);
-
   /** Light mode surface tokens */
-
   --surface-primary: var(--mist-50);
   --surface-secondary: var(--mist-400);
   --surface-tertiary: var(--mist-500);
   --surface-base: var(--mist-100);
 
   /** Light mode status tokens */
-
   --status-success: var(--color-green-600);
   --status-error: var(--color-red-600);
   --status-warning: var(--color-amber-600);
@@ -323,10 +513,9 @@
   --status-success-inverse: var(--color-green-400);
   --status-error-inverse: var(--color-red-400);
   --status-warning-inverse: var(--color-amber-400);
-  --status-information-inverse: var(--color-cyan-400);
+  --status-information-inverse: var(--color-sky-400);
 
   /** Light mode state layer tokens */
-
   --stateslayer-overlay-enabled: var(--slate-900-opacity-0);
   --stateslayer-overlay-hover: var(--slate-900-opacity-8);
   --stateslayer-overlay-pressed: var(--slate-900-opacity-16);
@@ -339,7 +528,6 @@
   --stateslayer-overlay-enabled-inverse: var(--mist-50-opacity-0);
 
   /** Light mode elevation tokens */
-
   --elevations-shade-t: var(--slate-900-opacity-8);
   --elevations-shade: var(--slate-900-opacity-38);
   --elevations-shade-t-01: var(--slate-900-opacity-12);
@@ -350,17 +538,23 @@
   --elevations-shade-03: var(--slate-900-opacity-8);
   --elevations-shade-t-04: var(--slate-900-opacity-12);
   --elevations-shade-04: var(--slate-900-opacity-8);
+
+  /** Light mode fill tokens */
+  --fill-stepmarkers+track: var(--mist-900);
+
+  /** Sharp radius tokens (default - no radius) */
+  --rad-round: 1000px;
 }
 
 .dark {
-  /** Sharp radius tokens (default - no radius, same as light mode) */
+
+  /** Sharp radius tokens (default - no radius) */
   --rad-reg: 0px;
   --rad-sm: 0px;
   --rad-md: 0px;
   --rad-lg: 0px;
 
   /** Dark mode text tokens */
-
   --text-primary: var(--mist-50-opacity-88);
   --text-secondary: var(--mist-50-opacity-60);
   --text-tertiary: var(--mist-50-opacity-50);
@@ -369,13 +563,12 @@
   --text-secondary-inverse: var(--slate-900-opacity-60);
   --text-tertiary-inverse: var(--slate-900-opacity-50);
   --text-disabled-inverse: var(--slate-900-opacity-38);
-  --text-information: var(--color-cyan-400);
+  --text-information: var(--color-sky-400);
   --text-error: var(--color-red-400);
   --text-warning: var(--color-amber-400);
   --text-success: var(--color-green-400);
 
   /** Dark mode border tokens */
-
   --border-divider: var(--mist-50-opacity-8);
   --border-primary: var(--mist-50-opacity-60);
   --border-secondary: var(--mist-50-opacity-38);
@@ -395,7 +588,6 @@
   --border-active-inverse: var(--slate-950);
 
   /** Dark mode fill tokens */
-
   --fill-primary: var(--mist-50-opacity-88);
   --fill-secondary: var(--mist-50-opacity-60);
   --fill-tertiary: var(--mist-50-opacity-16);
@@ -405,27 +597,22 @@
   --fill-disabled: var(--mist-50-opacity-38);
   --fill-primary-inverse: var(--slate-900-opacity-88);
   --fill-secondary-inverse: var(--slate-900-opacity-60);
-  --fill-tertiary-inverse: var(--mist-50-opacity-24);
+  --fill-tertiary-inverse: var(--slate-900-opacity-24);
   --fill-subtle-inverse: var(--slate-900-opacity-6);
   --fill-muted-inverse: var(--slate-900-opacity-8);
   --fill-disabled-inverse: var(--slate-900-opacity-38);
   --fill-active-inverse: var(--slate-950);
-  --fill-selected-range: var(--mist-50-opacity-8);
   --fill-onsurface-ui-1: var(--slate-600);
   --fill-onsurface-ui-2: var(--slate-300);
   --fill-onsurface-ui-3: var(--slate-400);
 
-  --slider-track: var(--slate-100);
-
   /** Dark mode surface tokens */
-
   --surface-primary: var(--slate-800);
   --surface-secondary: var(--slate-700);
   --surface-tertiary: var(--slate-500);
   --surface-base: var(--slate-900);
 
   /** Dark mode status tokens */
-
   --status-success: var(--color-green-400);
   --status-error: var(--color-red-400);
   --status-warning: var(--color-amber-400);
@@ -433,10 +620,9 @@
   --status-success-inverse: var(--color-green-600);
   --status-error-inverse: var(--color-red-600);
   --status-warning-inverse: var(--color-amber-600);
-  --status-information-inverse: var(--color-cyan-600);
+  --status-information-inverse: var(--color-sky-400);
 
   /** Dark mode state layer tokens */
-
   --stateslayer-overlay-enabled: var(--mist-50-opacity-0);
   --stateslayer-overlay-hover: var(--mist-50-opacity-8);
   --stateslayer-overlay-pressed: var(--mist-50-opacity-16);
@@ -449,7 +635,6 @@
   --stateslayer-overlay-enabled-inverse: var(--slate-900-opacity-0);
 
   /** Dark mode elevation tokens */
-
   --elevations-shade-t: var(--slate-900-opacity-88);
   --elevations-shade: var(--slate-900-opacity-88);
   --elevations-shade-t-01: var(--slate-900-opacity-60);
@@ -460,8 +645,23 @@
   --elevations-shade-03: var(--slate-900-opacity-88);
   --elevations-shade-t-04: var(--slate-900-opacity-38);
   --elevations-shade-04: var(--slate-900-opacity-88);
+
+  /** Dark mode fill tokens */
+  --fill-stepmarkers+track: var(--slate-100);
+
+  /** Sharp radius tokens (default - no radius) */
+  --rad-round: 1000px;
 }
 
+.radius-mode {
+
+  /** Rounded radius tokens */
+  --rad-lg: 16px;
+  --rad-md: 12px;
+  --rad-reg: 8px;
+  --rad-sm: 4px;
+}
+/* qbds:tokens:end semantic */
 .radius-mode {
   /** Rounded radius tokens */
   --rad-reg: 8px;

--- a/tokens-sync.config.json
+++ b/tokens-sync.config.json
@@ -1,0 +1,34 @@
+{
+  "source": "file",
+  "globalsPath": "src/styles/globals.css",
+  "themeBridgePath": "scripts/tokens/theme-bridge.csspart",
+  "sections": [
+    {
+      "id": "theme-inline",
+      "wrapper": "@theme inline",
+      "files": ["tokens/Value.tokens.json"]
+    },
+    {
+      "id": "semantic",
+      "selectors": [
+        {
+          "file": "tokens/Light.tokens.json",
+          "selector": ":root",
+          "mergeFiles": ["tokens/Sharp.tokens.json"],
+          "label": "Light mode"
+        },
+        {
+          "file": "tokens/Dark.tokens.json",
+          "selector": ".dark",
+          "mergeFiles": ["tokens/Sharp.tokens.json"],
+          "label": "Dark mode"
+        },
+        {
+          "file": "tokens/Round.tokens.json",
+          "selector": ".radius-mode",
+          "label": "Rounded radius"
+        }
+      ]
+    }
+  ]
+}

--- a/tokens/Dark.tokens.json
+++ b/tokens/Dark.tokens.json
@@ -1,0 +1,2129 @@
+{
+  "Descriptor": {
+    "$type": "number",
+    "$value": 1,
+    "$extensions": {
+      "com.figma.variableId": "VariableID:41540:17649",
+      "com.figma.scopes": [
+        "ALL_SCOPES"
+      ],
+      "com.figma.type": "boolean"
+    }
+  },
+  "Text": {
+    "Primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.8799999952316284,
+        "hex": "#FFFFFF"
+      },
+      "$description": "body copy; data entries; Headers;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43905",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2d8333a89f99ee38b1375efcdba4a6a1c0898c37/-1:-1",
+          "targetVariableName": "Mist 50/opacity-88",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.6000000238418579,
+        "hex": "#FFFFFF"
+      },
+      "$description": "secondary text; additional descriptors;\nInput labels; data labels;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43904",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:074a8dc4bc93989af1cbae12b742b5a4515a244f/-1:-1",
+          "targetVariableName": "Mist 50/opacity-60",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.5,
+        "hex": "#FFFFFF"
+      },
+      "$description": "placeholder; hint text; tertiary content;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43903",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:c3590c4c756a710d177b4afad2d56a786848a7b6/-1:-1",
+          "targetVariableName": "Mist 50/opacity-50",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Disabled": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#FFFFFF"
+      },
+      "$description": "disabled content;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35828:157685",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:cd7cffc9accaf2ca952ee9dc088b27d0fc5c0769/-1:-1",
+          "targetVariableName": "Mist 50/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Primary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.8799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "body copy; data entries; headers; on high contrast backgrounds/elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43911",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:97dbaea1224a1fe9f5528bda589dc83d379070db/-1:-1",
+          "targetVariableName": "Slate 900/opacity-88",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.6000000238418579,
+        "hex": "#141721"
+      },
+      "$description": "secondary text; additional descriptors;\nInput labels; data labels; body copy; data entries; headers; on high contrast backgrounds or elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43910",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:964f157336d230b51994a4673a31d1879b3bf8c7/-1:-1",
+          "targetVariableName": "Slate 900/opacity-60",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.5,
+        "hex": "#141721"
+      },
+      "$description": "placeholder; hint text; tertiary content; on high contrast backgrounds or elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43909",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:394fb9c721804eb70858d6988d783c2c106a7f01/-1:-1",
+          "targetVariableName": "Slate 900/opacity-50",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Disabled-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "disabled content; on high contrast backgrounds or elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43913",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Success": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.29019609093666077,
+          0.8705882430076599,
+          0.501960813999176
+        ],
+        "alpha": 1,
+        "hex": "#4ADE80"
+      },
+      "$description": "status success; AA compliant: 4.5:1",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37087:31321",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:9d4c0307269d7bbc60e41770f676ea3044b66e97/-1:-1",
+          "targetVariableName": "green/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Error": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9725490212440491,
+          0.4431372582912445,
+          0.4431372582912445
+        ],
+        "alpha": 1,
+        "hex": "#F87171"
+      },
+      "$description": "status error; AA compliant: 4.5:1",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37087:31319",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:c22a929b0f2cadef69d9640ad5d09af6bab7994c/-1:-1",
+          "targetVariableName": "red/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Warning": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9843137264251709,
+          0.7490196228027344,
+          0.1411764770746231
+        ],
+        "alpha": 1,
+        "hex": "#FBBF24"
+      },
+      "$description": "status error; AA compliant: 4.5:1",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37087:31320",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:9b395d7007bf1d42559b9d47f47f6f3a14df4f47/-1:-1",
+          "targetVariableName": "amber/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Information": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.21960784494876862,
+          0.7411764860153198,
+          0.9725490212440491
+        ],
+        "alpha": 1,
+        "hex": "#38BDF8"
+      },
+      "$description": "status generic info; AA compliant: 4.5:1",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37087:31318",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:fa426542300b3b47ee7d6fe19c0872e4dea152e4/-1:-1",
+          "targetVariableName": "sky/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "Border": {
+    "Divider": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#FFFFFF"
+      },
+      "$description": "very light separators; use for list items; button groupings;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43932",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "Border/Divider"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:442c7611b64c3bb17c719b2a8c47088aed9b9daf/-1:-1",
+          "targetVariableName": "Mist 50/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.1599999964237213,
+        "hex": "#FFFFFF"
+      },
+      "$description": "subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; disabled state for toggle items; badges; switches; ",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35889:161721",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:edd9f0e7207e101eaabe763bd98b1c437f2c15bb/-1:-1",
+          "targetVariableName": "Mist 50/opacity-16",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary-Hover": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#FFFFFF"
+      },
+      "$description": "hover state – subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; toggle items; badges; switches;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35912:2702",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:cd7cffc9accaf2ca952ee9dc088b27d0fc5c0769/-1:-1",
+          "targetVariableName": "Mist 50/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#FFFFFF"
+      },
+      "$description": "medium contrast border – switches; tags; toggle elements; emphasised states",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36238:197353",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:cd7cffc9accaf2ca952ee9dc088b27d0fc5c0769/-1:-1",
+          "targetVariableName": "Mist 50/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.6000000238418579,
+        "hex": "#FFFFFF"
+      },
+      "$description": "high contrast border – emphasised states",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43934",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:074a8dc4bc93989af1cbae12b742b5a4515a244f/-1:-1",
+          "targetVariableName": "Mist 50/opacity-60",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Active": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#FFFFFF"
+      },
+      "$description": "active state - for tabs; tags; inline inputs; switches; buttons; toggles; slider; active content states",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33906:16500",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:3244c220b3f723a8a0c1547e94ca1676b415eba9/-1:-1",
+          "targetVariableName": "Mist/50",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Divider-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#141721"
+      },
+      "$description": "very light separators; use for list items; button groupings; high contrast, theme switch friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35890:200346",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+          "targetVariableName": "Slate 900/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.1599999964237213,
+        "hex": "#141721"
+      },
+      "$description": "subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; disabled state toggle items; switches; theme switch friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35890:200350",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2d2c81996e19d35d14fc681e6a5073c41ccbfc12/-1:-1",
+          "targetVariableName": "Slate 900/opacity-16",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary-Hover-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "hover state – subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; disabled state for toggle items; badges; switches;  theme switching friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35912:2703",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "medium contrast border; switches, tags; toggle elements, emphasised states - high contrast instances, theme switching friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36238:197354",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Primary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.6000000238418579,
+        "hex": "#141721"
+      },
+      "$description": "stronger border; emphasised states - high contrast instances, theme switching friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36238:197355",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:964f157336d230b51994a4673a31d1879b3bf8c7/-1:-1",
+          "targetVariableName": "Slate 900/opacity-60",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Active-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.062745101749897,
+          0.07058823853731155,
+          0.10588235408067703
+        ],
+        "alpha": 1,
+        "hex": "#10121B"
+      },
+      "$description": "active state - for tabs; tags; inline inputs; buttons; switches; toggles; slider; active content states - high contrast or theme switch friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35890:200349",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:96f2bb07b030177884496b371238b62b777dd1e4/-1:-1",
+          "targetVariableName": "Slate/950",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Status": {
+      "Focus": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.21960784494876862,
+            0.7411764860153198,
+            0.9725490212440491
+          ],
+          "alpha": 1,
+          "hex": "#38BDF8"
+        },
+        "$description": "active/focus state for ui elements",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:36172:24485",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:fa426542300b3b47ee7d6fe19c0872e4dea152e4/-1:-1",
+            "targetVariableName": "sky/400",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Mono": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.23999999463558197,
+          "hex": "#FFFFFF"
+        },
+        "$description": "active/focus state variant for ui elements",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:37477:56186",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:5629fdfaa0003b335c20652a180d25af36f4d3e6/-1:-1",
+            "targetVariableName": "Mist 50/opacity-24",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Error": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9725490212440491,
+            0.4431372582912445,
+            0.4431372582912445
+          ],
+          "alpha": 1,
+          "hex": "#F87171"
+        },
+        "$description": "active/focus state variant for ui elements - tags, badges, indicators, cards/panels",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:37477:56190",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:c22a929b0f2cadef69d9640ad5d09af6bab7994c/-1:-1",
+            "targetVariableName": "red/400",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Success": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.29019609093666077,
+            0.8705882430076599,
+            0.501960813999176
+          ],
+          "alpha": 1,
+          "hex": "#4ADE80"
+        },
+        "$description": "active/focus state variant for ui elements - tags, badges, indicators, cards/panels",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:37477:56191",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:9d4c0307269d7bbc60e41770f676ea3044b66e97/-1:-1",
+            "targetVariableName": "green/400",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Warning": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9843137264251709,
+            0.7490196228027344,
+            0.1411764770746231
+          ],
+          "alpha": 1,
+          "hex": "#FBBF24"
+        },
+        "$description": "active/focus state variant for ui elements - tags, badges, indicators, cards/panels",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:37477:56193",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:9b395d7007bf1d42559b9d47f47f6f3a14df4f47/-1:-1",
+            "targetVariableName": "amber/400",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      }
+    }
+  },
+  "Fill": {
+    "Content": {
+      "Primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.8799999952316284,
+          "hex": "#FFFFFF"
+        },
+        "$description": "buttons, tooltips background primary; high contrast/emphasied items; accents",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43920",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2d8333a89f99ee38b1375efcdba4a6a1c0898c37/-1:-1",
+            "targetVariableName": "Mist 50/opacity-88",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Secondary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.6000000238418579,
+          "hex": "#FFFFFF"
+        },
+        "$description": "medium contrast accent backgrounds",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43919",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:074a8dc4bc93989af1cbae12b742b5a4515a244f/-1:-1",
+            "targetVariableName": "Mist 50/opacity-60",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Tertiary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.1599999964237213,
+          "hex": "#FFFFFF"
+        },
+        "$description": "medium colour contrast overlay on high contrast items, ui-shells/panels, tiles",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35829:157686",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:edd9f0e7207e101eaabe763bd98b1c437f2c15bb/-1:-1",
+            "targetVariableName": "Mist 50/opacity-16",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Disabled": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.3799999952316284,
+          "hex": "#FFFFFF"
+        },
+        "$description": "any fill for disabled elements on Fill/Muted or Surface tokens",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43924",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:cd7cffc9accaf2ca952ee9dc088b27d0fc5c0769/-1:-1",
+            "targetVariableName": "Mist 50/opacity-38",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Active": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 1,
+          "hex": "#FFFFFF"
+        },
+        "$description": "active state fill for icons, buttons backgrounds, tags, switches, toggle items, sliders",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43923",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:3244c220b3f723a8a0c1547e94ca1676b415eba9/-1:-1",
+            "targetVariableName": "Mist/50",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Primary-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.8799999952316284,
+          "hex": "#141721"
+        },
+        "$description": "buttons, tooltips background primary; high contrast/emphasied items; accents - theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43927",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:97dbaea1224a1fe9f5528bda589dc83d379070db/-1:-1",
+            "targetVariableName": "Slate 900/opacity-88",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Secondary-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.6000000238418579,
+          "hex": "#141721"
+        },
+        "$description": "medium contrast accent backgrounds; theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43926",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:964f157336d230b51994a4673a31d1879b3bf8c7/-1:-1",
+            "targetVariableName": "Slate 900/opacity-60",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Tertiary-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.23999999463558197,
+          "hex": "#141721"
+        },
+        "$description": "medium colour contrast overlay on high contrast items, ui-shells/panels, tiles",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35829:157714",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:17214497089407668df9fe4b013e1475116fea96/-1:-1",
+            "targetVariableName": "Slate 900/opacity-24",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Disabled-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.3799999952316284,
+          "hex": "#141721"
+        },
+        "$description": "any fill for disabled elements on Fill/Muted or Surface tokens; theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43931",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+            "targetVariableName": "Slate 900/opacity-38",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Active-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.062745101749897,
+            0.07058823853731155,
+            0.10588235408067703
+          ],
+          "alpha": 1,
+          "hex": "#10121B"
+        },
+        "$description": "active state fill for icons, buttons backgrounds, tags, switches, toggle items, sliders; theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43929",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:96f2bb07b030177884496b371238b62b777dd1e4/-1:-1",
+            "targetVariableName": "Slate/950",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "StepMarkers+Track": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.20000000298023224,
+            0.21176470816135406,
+            0.250980406999588
+          ],
+          "alpha": 1,
+          "hex": "#333640"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:38041:61029",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:41e7eacf6a454ceaf4115ff7c3e4ff5c6f8f7d57/-1:-1",
+            "targetVariableName": "Slate/100",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      }
+    },
+    "onSurface": {
+      "bg-ui1": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.12156862765550613,
+            0.13333334028720856,
+            0.18039216101169586
+          ],
+          "alpha": 1,
+          "hex": "#1F222E"
+        },
+        "$description": "solid used for high contrast tiles, ui containers backgrounds that sit on surface tokens",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35297:322164",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:08ff1657aa8157403f7404910dfc3baf2e78bbeb/-1:-1",
+            "targetVariableName": "Slate/600",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "bg-ui2": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.16862745583057404,
+            0.18039216101169586,
+            0.2235294133424759
+          ],
+          "alpha": 1,
+          "hex": "#2B2E39"
+        },
+        "$description": "solid used for Avatar mono backgrounds, medium contrast tiles, ui containers backgrounds that sit on Surface tokens",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35297:322162",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:3c8aa4d14c19a125703a594b18d5d46d08419422/-1:-1",
+            "targetVariableName": "Slate/300",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "bg-ui3": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.15294118225574493,
+            0.16470588743686676,
+            0.2078431397676468
+          ],
+          "alpha": 1,
+          "hex": "#272A35"
+        },
+        "$description": "solid ui backgrounds,  field inputs, notification, toast and sonner panels that sit on Surface tokens",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35297:322160",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:cfe1fc40c87de9d8cb03ed9f57e68dab0f60ef84/-1:-1",
+            "targetVariableName": "Slate/400",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Muted": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.07999999821186066,
+          "hex": "#FFFFFF"
+        },
+        "$description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35876:157737",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:442c7611b64c3bb17c719b2a8c47088aed9b9daf/-1:-1",
+            "targetVariableName": "Mist 50/opacity-8",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Subtle": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.05999999865889549,
+          "hex": "#FFFFFF"
+        },
+        "$description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:38760:64997",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:65eedf429ce68aef3347d5c72cc397dfb22f8dff/-1:-1",
+            "targetVariableName": "Mist 50/opacity-6",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Muted-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.07999999821186066,
+          "hex": "#141721"
+        },
+        "$description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills; theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43925",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+            "targetVariableName": "Slate 900/opacity-8",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Subtle-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.05999999865889549,
+          "hex": "#141721"
+        },
+        "$description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:38760:64998",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:a0e3d7bed55dbf8b906dbd8d7e8f008e521cb036/-1:-1",
+            "targetVariableName": "Slate 900/opacity-6",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      }
+    }
+  },
+  "Surface": {
+    "Primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0941176488995552,
+          0.10588235408067703,
+          0.14901961386203766
+        ],
+        "alpha": 1,
+        "hex": "#181B26"
+      },
+      "$description": "primary page/ui shell panel background",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35297:322158",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:0a9a23f77e8787d2a0bd9e1a672452c50e748895/-1:-1",
+          "targetVariableName": "Slate/800",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.10588235408067703,
+          0.11764705926179886,
+          0.16470588743686676
+        ],
+        "alpha": 1,
+        "hex": "#1B1E2A"
+      },
+      "$description": "secondary page/ui shell panel background - use for side panels",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35297:322166",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:a58c9611715efe24ccd506f902f607a8651d04dc/-1:-1",
+          "targetVariableName": "Slate/700",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.13725490868091583,
+          0.14901961386203766,
+          0.19607843458652496
+        ],
+        "alpha": 1,
+        "hex": "#232632"
+      },
+      "$description": "optional usage - tertiary background/ui shell panels when Primary or Secondary already used.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35297:322161",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:363098a73a7ee889136b2bb5c7e557e7dde82405/-1:-1",
+          "targetVariableName": "Slate/500",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Base": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 1,
+        "hex": "#141721"
+      },
+      "$description": "high contrast surface - used to create negative space/separator between primary or secondary backgrounds/ui shells. could be used for high contrast canvas",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35941:2845",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:d85d11d4c159e2a442a006928b3ac6b95a5ddca0/-1:-1",
+          "targetVariableName": "Slate/900",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "Status": {
+    "Success": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.29019609093666077,
+          0.8705882430076599,
+          0.501960813999176
+        ],
+        "alpha": 1,
+        "hex": "#4ADE80"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33962:17491",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:9d4c0307269d7bbc60e41770f676ea3044b66e97/-1:-1",
+          "targetVariableName": "green/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Error": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9725490212440491,
+          0.4431372582912445,
+          0.4431372582912445
+        ],
+        "alpha": 1,
+        "hex": "#F87171"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33962:17492",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL",
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:c22a929b0f2cadef69d9640ad5d09af6bab7994c/-1:-1",
+          "targetVariableName": "red/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Warning": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9843137264251709,
+          0.7490196228027344,
+          0.1411764770746231
+        ],
+        "alpha": 1,
+        "hex": "#FBBF24"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33962:17493",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:9b395d7007bf1d42559b9d47f47f6f3a14df4f47/-1:-1",
+          "targetVariableName": "amber/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Information": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.13333334028720856,
+          0.8274509906768799,
+          0.9333333373069763
+        ],
+        "alpha": 1,
+        "hex": "#22D3EE"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33962:17494",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:927c8d0204b63a01be8a2afb550d2944133dad4e/-1:-1",
+          "targetVariableName": "cyan/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Success-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08627451211214066,
+          0.6392157077789307,
+          0.29019609093666077
+        ],
+        "alpha": 1,
+        "hex": "#16A34A"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant - high contrast instances, theme switch friendly.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37092:39615",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:7e95615371239c4212cdaa06bf36d0c5640f7de4/-1:-1",
+          "targetVariableName": "green/600",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Error-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8627451062202454,
+          0.14901961386203766,
+          0.14901961386203766
+        ],
+        "alpha": 1,
+        "hex": "#DC2626"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant Fill/Border only, for all status modes instances; except text - not contrast AA compliant; - high contrast instances, theme switch friendly.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37092:39616",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:466793dbf745f4cbf05f321ce4dac8337b27d5e1/-1:-1",
+          "targetVariableName": "red/600",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Warning-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8509804010391235,
+          0.46666666865348816,
+          0.0235294122248888
+        ],
+        "alpha": 1,
+        "hex": "#D97706"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant; - high contrast instances, theme switch friendly.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37092:39617",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:f73ff115512e9ee356c839b62466d9f3dffbb6d2/-1:-1",
+          "targetVariableName": "amber/600",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Information-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.21960784494876862,
+          0.7411764860153198,
+          0.9725490212440491
+        ],
+        "alpha": 1,
+        "hex": "#38BDF8"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant; - high contrast instances, theme switch friendly.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37092:39618",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:fa426542300b3b47ee7d6fe19c0872e4dea152e4/-1:-1",
+          "targetVariableName": "sky/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "StatesLayer-Overlay": {
+    "Enabled": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0,
+        "hex": "#FFFFFF"
+      },
+      "$description": "Enabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:157456",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6d8d774dbdb45daf6cbeccb5fb84a40eaa1e0ab9/-1:-1",
+          "targetVariableName": "Mist 50/opacity-0",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Hover": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#FFFFFF"
+      },
+      "$description": "Hover State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:163306",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:442c7611b64c3bb17c719b2a8c47088aed9b9daf/-1:-1",
+          "targetVariableName": "Mist 50/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Pressed": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.1599999964237213,
+        "hex": "#FFFFFF"
+      },
+      "$description": "Pressed State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:165581",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:edd9f0e7207e101eaabe763bd98b1c437f2c15bb/-1:-1",
+          "targetVariableName": "Mist 50/opacity-16",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Active": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#FFFFFF"
+      },
+      "$description": "Active State overlay for entire ui item - used in most components; buttons, inputs, menus, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34921:299012",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:3244c220b3f723a8a0c1547e94ca1676b415eba9/-1:-1",
+          "targetVariableName": "Mist/50",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Disabled": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "Disabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:168625",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Enabled_Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0,
+        "hex": "#141721"
+      },
+      "$description": "Enabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items - on high contrast/accent content",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36453:106961",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e692c7c97db42c05e88ec957e07a0e3f5fc852df/-1:-1",
+          "targetVariableName": "Slate 900/opacity-0",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Hover-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#141721"
+      },
+      "$description": "Hover State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items –on high/accent contrast elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35075:41677",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+          "targetVariableName": "Slate 900/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Pressed-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.1599999964237213,
+        "hex": "#141721"
+      },
+      "$description": "Pressed State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items - on high/accent contrast elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35075:41678",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2d2c81996e19d35d14fc681e6a5073c41ccbfc12/-1:-1",
+          "targetVariableName": "Slate 900/opacity-16",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Active-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.062745101749897,
+          0.07058823853731155,
+          0.10588235408067703
+        ],
+        "alpha": 1,
+        "hex": "#10121B"
+      },
+      "$description": "Active State overlay for entire ui item - used in most components; buttons, inputs, menus, pickers, text area, tags, list items -on high/accent contrast elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:270561",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:96f2bb07b030177884496b371238b62b777dd1e4/-1:-1",
+          "targetVariableName": "Slate/950",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Disabled-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#141721"
+      },
+      "$description": "Disabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items - on high/accent elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35075:41679",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+          "targetVariableName": "Slate 900/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "Elevations": {
+    "Shade_T": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.8799999952316284,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5581",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:97dbaea1224a1fe9f5528bda589dc83d379070db/-1:-1",
+          "targetVariableName": "Slate 900/opacity-88",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.8799999952316284,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5586",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:97dbaea1224a1fe9f5528bda589dc83d379070db/-1:-1",
+          "targetVariableName": "Slate 900/opacity-88",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade_T–01": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.6000000238418579,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5591",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:964f157336d230b51994a4673a31d1879b3bf8c7/-1:-1",
+          "targetVariableName": "Slate 900/opacity-60",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade–01": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.11999999731779099,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5596",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:01923effa846443db8c37a39d7db319eba1a1ae0/-1:-1",
+          "targetVariableName": "Slate 900/opacity-12",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade_T–02": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.8799999952316284,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5601",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:97dbaea1224a1fe9f5528bda589dc83d379070db/-1:-1",
+          "targetVariableName": "Slate 900/opacity-88",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade–02": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5606",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade_T–03": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5611",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade–03": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.8799999952316284,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5616",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:97dbaea1224a1fe9f5528bda589dc83d379070db/-1:-1",
+          "targetVariableName": "Slate 900/opacity-88",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade_T–04": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35161:10708",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade–04": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.8799999952316284,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35161:10713",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:97dbaea1224a1fe9f5528bda589dc83d379070db/-1:-1",
+          "targetVariableName": "Slate 900/opacity-88",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "$extensions": {
+    "com.figma.modeName": "Dark"
+  }
+}

--- a/tokens/Light.tokens.json
+++ b/tokens/Light.tokens.json
@@ -1,0 +1,2129 @@
+{
+  "Descriptor": {
+    "$type": "number",
+    "$value": 1,
+    "$extensions": {
+      "com.figma.variableId": "VariableID:41540:17649",
+      "com.figma.scopes": [
+        "ALL_SCOPES"
+      ],
+      "com.figma.type": "boolean"
+    }
+  },
+  "Text": {
+    "Primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.8799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "body copy; data entries; Headers;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43905",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:97dbaea1224a1fe9f5528bda589dc83d379070db/-1:-1",
+          "targetVariableName": "Slate 900/opacity-88",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.6000000238418579,
+        "hex": "#141721"
+      },
+      "$description": "secondary text; additional descriptors;\nInput labels; data labels;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43904",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:964f157336d230b51994a4673a31d1879b3bf8c7/-1:-1",
+          "targetVariableName": "Slate 900/opacity-60",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.5,
+        "hex": "#141721"
+      },
+      "$description": "placeholder; hint text; tertiary content;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43903",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:394fb9c721804eb70858d6988d783c2c106a7f01/-1:-1",
+          "targetVariableName": "Slate 900/opacity-50",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Disabled": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "disabled content;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35828:157685",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Primary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.8799999952316284,
+        "hex": "#FFFFFF"
+      },
+      "$description": "body copy; data entries; headers; on high contrast backgrounds/elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43911",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2d8333a89f99ee38b1375efcdba4a6a1c0898c37/-1:-1",
+          "targetVariableName": "Mist 50/opacity-88",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.6000000238418579,
+        "hex": "#FFFFFF"
+      },
+      "$description": "secondary text; additional descriptors;\nInput labels; data labels; body copy; data entries; headers; on high contrast backgrounds or elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43910",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:074a8dc4bc93989af1cbae12b742b5a4515a244f/-1:-1",
+          "targetVariableName": "Mist 50/opacity-60",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.5,
+        "hex": "#FFFFFF"
+      },
+      "$description": "placeholder; hint text; tertiary content; on high contrast backgrounds or elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43909",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:c3590c4c756a710d177b4afad2d56a786848a7b6/-1:-1",
+          "targetVariableName": "Mist 50/opacity-50",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Disabled-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#FFFFFF"
+      },
+      "$description": "disabled content; on high contrast backgrounds or elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43913",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:cd7cffc9accaf2ca952ee9dc088b27d0fc5c0769/-1:-1",
+          "targetVariableName": "Mist 50/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Success": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08235294371843338,
+          0.501960813999176,
+          0.239215686917305
+        ],
+        "alpha": 1,
+        "hex": "#15803D"
+      },
+      "$description": "status success; AA compliant: 4.5:1",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37087:31321",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:7f892ff18231e4f9f72a6873020a76dfbabf0690/-1:-1",
+          "targetVariableName": "green/700",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Error": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7254902124404907,
+          0.10980392247438431,
+          0.10980392247438431
+        ],
+        "alpha": 1,
+        "hex": "#B91C1C"
+      },
+      "$description": "status error; AA compliant: 4.5:1",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37087:31319",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:4be4a0ecaef44221090632626724ae248c6e65da/-1:-1",
+          "targetVariableName": "red/700",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Warning": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7058823704719543,
+          0.32549020648002625,
+          0.03529411926865578
+        ],
+        "alpha": 1,
+        "hex": "#B45309"
+      },
+      "$description": "status error; AA compliant: 4.5:1",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37087:31320",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:c5c0efac4e9f9ebcd7ac4c708ecd6e82b1186661/-1:-1",
+          "targetVariableName": "amber/700",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Information": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.054901961237192154,
+          0.45490196347236633,
+          0.5647059082984924
+        ],
+        "alpha": 1,
+        "hex": "#0E7490"
+      },
+      "$description": "status generic info; AA compliant: 4.5:1",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37087:31318",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:7a7298495b72bed4e0990bb9e437818dcd8b3cab/-1:-1",
+          "targetVariableName": "cyan/700",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "Border": {
+    "Divider": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.10000000149011612,
+        "hex": "#141721"
+      },
+      "$description": "very light separators; use for list items; button groupings;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43932",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "Border/Divider"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:7c4e0756ccc25586a986ae0351414bcc90cfa792/-1:-1",
+          "targetVariableName": "Slate 900/opacity-10",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.1599999964237213,
+        "hex": "#141721"
+      },
+      "$description": "subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; disabled state for toggle items; badges; switches; ",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35889:161721",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2d2c81996e19d35d14fc681e6a5073c41ccbfc12/-1:-1",
+          "targetVariableName": "Slate 900/opacity-16",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary-Hover": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "hover state – subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; toggle items; badges; switches;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35912:2702",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.23999999463558197,
+        "hex": "#141721"
+      },
+      "$description": "medium contrast border – switches; tags; toggle elements; emphasised states",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36238:197353",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:17214497089407668df9fe4b013e1475116fea96/-1:-1",
+          "targetVariableName": "Slate 900/opacity-24",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "high contrast border – emphasised states",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43934",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Active": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.062745101749897,
+          0.07058823853731155,
+          0.10588235408067703
+        ],
+        "alpha": 1,
+        "hex": "#10121B"
+      },
+      "$description": "active state - for tabs; tags; inline inputs; switches; buttons; toggles; slider; active content states",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33906:16500",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:96f2bb07b030177884496b371238b62b777dd1e4/-1:-1",
+          "targetVariableName": "Slate/950",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Divider-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#FFFFFF"
+      },
+      "$description": "very light separators; use for list items; button groupings; high contrast, theme switch friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35890:200346",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:442c7611b64c3bb17c719b2a8c47088aed9b9daf/-1:-1",
+          "targetVariableName": "Mist 50/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.1599999964237213,
+        "hex": "#FFFFFF"
+      },
+      "$description": "subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; disabled state toggle items; switches; theme switch friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35890:200350",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:edd9f0e7207e101eaabe763bd98b1c437f2c15bb/-1:-1",
+          "targetVariableName": "Mist 50/opacity-16",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary-Hover-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#FFFFFF"
+      },
+      "$description": "hover state – subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; disabled state for toggle items; badges; switches;  theme switching friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35912:2703",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:cd7cffc9accaf2ca952ee9dc088b27d0fc5c0769/-1:-1",
+          "targetVariableName": "Mist 50/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#FFFFFF"
+      },
+      "$description": "medium contrast border; switches, tags; toggle elements, emphasised states - high contrast instances, theme switching friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36238:197354",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:cd7cffc9accaf2ca952ee9dc088b27d0fc5c0769/-1:-1",
+          "targetVariableName": "Mist 50/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Primary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.6000000238418579,
+        "hex": "#FFFFFF"
+      },
+      "$description": "stronger border; emphasised states - high contrast instances, theme switching friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36238:197355",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:074a8dc4bc93989af1cbae12b742b5a4515a244f/-1:-1",
+          "targetVariableName": "Mist 50/opacity-60",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Active-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#FFFFFF"
+      },
+      "$description": "active state - for tabs; tags; inline inputs; buttons; switches; toggles; slider; active content states - high contrast or theme switch friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35890:200349",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:3244c220b3f723a8a0c1547e94ca1676b415eba9/-1:-1",
+          "targetVariableName": "Mist/50",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Status": {
+      "Focus": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.21960784494876862,
+            0.7411764860153198,
+            0.9725490212440491
+          ],
+          "alpha": 1,
+          "hex": "#38BDF8"
+        },
+        "$description": "active/focus state for ui elements",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:36172:24485",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:fa426542300b3b47ee7d6fe19c0872e4dea152e4/-1:-1",
+            "targetVariableName": "sky/400",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Mono": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.23999999463558197,
+          "hex": "#141721"
+        },
+        "$description": "active/focus state variant for ui elements",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:37477:56186",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:17214497089407668df9fe4b013e1475116fea96/-1:-1",
+            "targetVariableName": "Slate 900/opacity-24",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Error": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.7254902124404907,
+            0.10980392247438431,
+            0.10980392247438431
+          ],
+          "alpha": 1,
+          "hex": "#B91C1C"
+        },
+        "$description": "active/focus state variant for ui elements - tags, badges, indicators, cards/panels",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:37477:56190",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:4be4a0ecaef44221090632626724ae248c6e65da/-1:-1",
+            "targetVariableName": "red/700",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Success": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.08627451211214066,
+            0.6392157077789307,
+            0.29019609093666077
+          ],
+          "alpha": 1,
+          "hex": "#16A34A"
+        },
+        "$description": "active/focus state variant for ui elements - tags, badges, indicators, cards/panels",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:37477:56191",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:7e95615371239c4212cdaa06bf36d0c5640f7de4/-1:-1",
+            "targetVariableName": "green/600",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Warning": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9607843160629272,
+            0.6196078658103943,
+            0.04313725605607033
+          ],
+          "alpha": 1,
+          "hex": "#F59E0B"
+        },
+        "$description": "active/focus state variant for ui elements - tags, badges, indicators, cards/panels",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:37477:56193",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:a930fa1a653eee124deedcf939d4776c391c23c8/-1:-1",
+            "targetVariableName": "amber/500",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      }
+    }
+  },
+  "Fill": {
+    "Content": {
+      "Primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.8799999952316284,
+          "hex": "#141721"
+        },
+        "$description": "buttons, tooltips background primary; high contrast/emphasied items; accents",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43920",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:97dbaea1224a1fe9f5528bda589dc83d379070db/-1:-1",
+            "targetVariableName": "Slate 900/opacity-88",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Secondary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.6000000238418579,
+          "hex": "#141721"
+        },
+        "$description": "medium contrast accent backgrounds",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43919",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:964f157336d230b51994a4673a31d1879b3bf8c7/-1:-1",
+            "targetVariableName": "Slate 900/opacity-60",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Tertiary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.1599999964237213,
+          "hex": "#141721"
+        },
+        "$description": "medium colour contrast overlay on high contrast items, ui-shells/panels, tiles",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35829:157686",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2d2c81996e19d35d14fc681e6a5073c41ccbfc12/-1:-1",
+            "targetVariableName": "Slate 900/opacity-16",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Disabled": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.3799999952316284,
+          "hex": "#141721"
+        },
+        "$description": "any fill for disabled elements on Fill/Muted or Surface tokens",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43924",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+            "targetVariableName": "Slate 900/opacity-38",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Active": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.062745101749897,
+            0.07058823853731155,
+            0.10588235408067703
+          ],
+          "alpha": 1,
+          "hex": "#10121B"
+        },
+        "$description": "active state fill for icons, buttons backgrounds, tags, switches, toggle items, sliders",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43923",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:96f2bb07b030177884496b371238b62b777dd1e4/-1:-1",
+            "targetVariableName": "Slate/950",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Primary-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.8799999952316284,
+          "hex": "#FFFFFF"
+        },
+        "$description": "buttons, tooltips background primary; high contrast/emphasied items; accents - theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43927",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2d8333a89f99ee38b1375efcdba4a6a1c0898c37/-1:-1",
+            "targetVariableName": "Mist 50/opacity-88",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Secondary-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.6000000238418579,
+          "hex": "#FFFFFF"
+        },
+        "$description": "medium contrast accent backgrounds; theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43926",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:074a8dc4bc93989af1cbae12b742b5a4515a244f/-1:-1",
+            "targetVariableName": "Mist 50/opacity-60",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Tertiary-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.1599999964237213,
+          "hex": "#FFFFFF"
+        },
+        "$description": "medium colour contrast overlay on high contrast items, ui-shells/panels, tiles",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35829:157714",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:edd9f0e7207e101eaabe763bd98b1c437f2c15bb/-1:-1",
+            "targetVariableName": "Mist 50/opacity-16",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Disabled-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.3799999952316284,
+          "hex": "#FFFFFF"
+        },
+        "$description": "any fill for disabled elements on Fill/Muted or Surface tokens; theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43931",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:cd7cffc9accaf2ca952ee9dc088b27d0fc5c0769/-1:-1",
+            "targetVariableName": "Mist 50/opacity-38",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Active-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 1,
+          "hex": "#FFFFFF"
+        },
+        "$description": "active state fill for icons, buttons backgrounds, tags, switches, toggle items, sliders; theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43929",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:3244c220b3f723a8a0c1547e94ca1676b415eba9/-1:-1",
+            "targetVariableName": "Mist/50",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "StepMarkers+Track": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.8274509906768799,
+            0.8392156958580017,
+            0.8509804010391235
+          ],
+          "alpha": 1,
+          "hex": "#D3D6D9"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:38041:61029",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2622d442eac791f7a75eab336b1aa3565f011ec1/-1:-1",
+            "targetVariableName": "Mist/900",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      }
+    },
+    "onSurface": {
+      "bg-ui1": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9803921580314636,
+            0.9803921580314636,
+            0.9843137264251709
+          ],
+          "alpha": 1,
+          "hex": "#FAFAFB"
+        },
+        "$description": "solid used for high contrast tiles, ui containers backgrounds that sit on surface tokens",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35297:322164",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:982cf84d00e7d2504ade4daa5a8e87659c11dc41/-1:-1",
+            "targetVariableName": "Mist/100",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "bg-ui2": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9490196108818054,
+            0.9529411792755127,
+            0.95686274766922
+          ],
+          "alpha": 1,
+          "hex": "#F2F3F4"
+        },
+        "$description": "solid used for Avatar mono backgrounds, medium contrast tiles, ui containers backgrounds that sit on Surface tokens",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35297:322162",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:909c5c2c941ef3ad05032e7a413c097d26549768/-1:-1",
+            "targetVariableName": "Mist/300",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "bg-ui3": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9607843160629272,
+            0.9647058844566345,
+            0.9647058844566345
+          ],
+          "alpha": 1,
+          "hex": "#F5F6F6"
+        },
+        "$description": "solid ui backgrounds,  field inputs, notification, toast and sonner panels that sit on Surface tokens",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35297:322160",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:690450f17d51d78fb7f1ea77696ee4b8a587cd9e/-1:-1",
+            "targetVariableName": "Mist/200",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Muted": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.07999999821186066,
+          "hex": "#141721"
+        },
+        "$description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35876:157737",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+            "targetVariableName": "Slate 900/opacity-8",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Subtle": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.05999999865889549,
+          "hex": "#141721"
+        },
+        "$description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:38760:64997",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:a0e3d7bed55dbf8b906dbd8d7e8f008e521cb036/-1:-1",
+            "targetVariableName": "Slate 900/opacity-6",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Muted-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.07999999821186066,
+          "hex": "#FFFFFF"
+        },
+        "$description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills; theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43925",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:442c7611b64c3bb17c719b2a8c47088aed9b9daf/-1:-1",
+            "targetVariableName": "Mist 50/opacity-8",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Subtle-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.05999999865889549,
+          "hex": "#FFFFFF"
+        },
+        "$description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:38760:64998",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:65eedf429ce68aef3347d5c72cc397dfb22f8dff/-1:-1",
+            "targetVariableName": "Mist 50/opacity-6",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      }
+    }
+  },
+  "Surface": {
+    "Primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#FFFFFF"
+      },
+      "$description": "primary page/ui shell panel background",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35297:322158",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:3244c220b3f723a8a0c1547e94ca1676b415eba9/-1:-1",
+          "targetVariableName": "Mist/50",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9215686321258545,
+          0.929411768913269,
+          0.9333333373069763
+        ],
+        "alpha": 1,
+        "hex": "#EBEDEE"
+      },
+      "$description": "secondary page/ui shell panel background - use for side panels",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35297:322166",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:525b84cb7bda10e8ecb99fbf55bd0c0c3db288ca/-1:-1",
+          "targetVariableName": "Mist/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9019607901573181,
+          0.9098039269447327,
+          0.9176470637321472
+        ],
+        "alpha": 1,
+        "hex": "#E6E8EA"
+      },
+      "$description": "optional usage - tertiary background/ui shell panels when Primary or Secondary already used.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35297:322161",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:c2c5285b240e9566b3998d4849b486934eac1739/-1:-1",
+          "targetVariableName": "Mist/500",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Base": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9803921580314636,
+          0.9803921580314636,
+          0.9843137264251709
+        ],
+        "alpha": 1,
+        "hex": "#FAFAFB"
+      },
+      "$description": "high contrast surface - used to create negative space/separator between primary or secondary backgrounds/ui shells. could be used for high contrast canvas",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35941:2845",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:982cf84d00e7d2504ade4daa5a8e87659c11dc41/-1:-1",
+          "targetVariableName": "Mist/100",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "Status": {
+    "Success": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08627451211214066,
+          0.6392157077789307,
+          0.29019609093666077
+        ],
+        "alpha": 1,
+        "hex": "#16A34A"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33962:17491",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:7e95615371239c4212cdaa06bf36d0c5640f7de4/-1:-1",
+          "targetVariableName": "green/600",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Error": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8627451062202454,
+          0.14901961386203766,
+          0.14901961386203766
+        ],
+        "alpha": 1,
+        "hex": "#DC2626"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33962:17492",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL",
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:466793dbf745f4cbf05f321ce4dac8337b27d5e1/-1:-1",
+          "targetVariableName": "red/600",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Warning": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8509804010391235,
+          0.46666666865348816,
+          0.0235294122248888
+        ],
+        "alpha": 1,
+        "hex": "#D97706"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33962:17493",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:f73ff115512e9ee356c839b62466d9f3dffbb6d2/-1:-1",
+          "targetVariableName": "amber/600",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Information": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0313725508749485,
+          0.5686274766921997,
+          0.6980392336845398
+        ],
+        "alpha": 1,
+        "hex": "#0891B2"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33962:17494",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:d5068d967f4827309074a6ff79f88b26674e53cb/-1:-1",
+          "targetVariableName": "cyan/600",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Success-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.29019609093666077,
+          0.8705882430076599,
+          0.501960813999176
+        ],
+        "alpha": 1,
+        "hex": "#4ADE80"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant - high contrast instances, theme switch friendly.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37092:39615",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:9d4c0307269d7bbc60e41770f676ea3044b66e97/-1:-1",
+          "targetVariableName": "green/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Error-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9725490212440491,
+          0.4431372582912445,
+          0.4431372582912445
+        ],
+        "alpha": 1,
+        "hex": "#F87171"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant Fill/Border only, for all status modes instances; except text - not contrast AA compliant; - high contrast instances, theme switch friendly.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37092:39616",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:c22a929b0f2cadef69d9640ad5d09af6bab7994c/-1:-1",
+          "targetVariableName": "red/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Warning-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9843137264251709,
+          0.7490196228027344,
+          0.1411764770746231
+        ],
+        "alpha": 1,
+        "hex": "#FBBF24"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant; - high contrast instances, theme switch friendly.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37092:39617",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:9b395d7007bf1d42559b9d47f47f6f3a14df4f47/-1:-1",
+          "targetVariableName": "amber/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Information-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.21960784494876862,
+          0.7411764860153198,
+          0.9725490212440491
+        ],
+        "alpha": 1,
+        "hex": "#38BDF8"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant; - high contrast instances, theme switch friendly.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37092:39618",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:fa426542300b3b47ee7d6fe19c0872e4dea152e4/-1:-1",
+          "targetVariableName": "sky/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "StatesLayer-Overlay": {
+    "Enabled": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0,
+        "hex": "#141721"
+      },
+      "$description": "Enabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:157456",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e692c7c97db42c05e88ec957e07a0e3f5fc852df/-1:-1",
+          "targetVariableName": "Slate 900/opacity-0",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Hover": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#141721"
+      },
+      "$description": "Hover State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:163306",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+          "targetVariableName": "Slate 900/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Pressed": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.1599999964237213,
+        "hex": "#141721"
+      },
+      "$description": "Pressed State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:165581",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2d2c81996e19d35d14fc681e6a5073c41ccbfc12/-1:-1",
+          "targetVariableName": "Slate 900/opacity-16",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Active": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.062745101749897,
+          0.07058823853731155,
+          0.10588235408067703
+        ],
+        "alpha": 1,
+        "hex": "#10121B"
+      },
+      "$description": "Active State overlay for entire ui item - used in most components; buttons, inputs, menus, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34921:299012",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:96f2bb07b030177884496b371238b62b777dd1e4/-1:-1",
+          "targetVariableName": "Slate/950",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Disabled": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#141721"
+      },
+      "$description": "Disabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:168625",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+          "targetVariableName": "Slate 900/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Enabled_Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0,
+        "hex": "#FFFFFF"
+      },
+      "$description": "Enabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items - on high contrast/accent content",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36453:106961",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6d8d774dbdb45daf6cbeccb5fb84a40eaa1e0ab9/-1:-1",
+          "targetVariableName": "Mist 50/opacity-0",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Hover-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#FFFFFF"
+      },
+      "$description": "Hover State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items –on high/accent contrast elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35075:41677",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:442c7611b64c3bb17c719b2a8c47088aed9b9daf/-1:-1",
+          "targetVariableName": "Mist 50/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Pressed-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.1599999964237213,
+        "hex": "#FFFFFF"
+      },
+      "$description": "Pressed State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items - on high/accent contrast elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35075:41678",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:edd9f0e7207e101eaabe763bd98b1c437f2c15bb/-1:-1",
+          "targetVariableName": "Mist 50/opacity-16",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Active-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#FFFFFF"
+      },
+      "$description": "Active State overlay for entire ui item - used in most components; buttons, inputs, menus, pickers, text area, tags, list items -on high/accent contrast elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:270561",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:3244c220b3f723a8a0c1547e94ca1676b415eba9/-1:-1",
+          "targetVariableName": "Mist/50",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Disabled-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "Disabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items - on high/accent elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35075:41679",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "Elevations": {
+    "Shade_T": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5581",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+          "targetVariableName": "Slate 900/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5586",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade_T–01": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.11999999731779099,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5591",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:01923effa846443db8c37a39d7db319eba1a1ae0/-1:-1",
+          "targetVariableName": "Slate 900/opacity-12",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade–01": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.11999999731779099,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5596",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:01923effa846443db8c37a39d7db319eba1a1ae0/-1:-1",
+          "targetVariableName": "Slate 900/opacity-12",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade_T–02": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.11999999731779099,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5601",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:01923effa846443db8c37a39d7db319eba1a1ae0/-1:-1",
+          "targetVariableName": "Slate 900/opacity-12",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade–02": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.23999999463558197,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5606",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:17214497089407668df9fe4b013e1475116fea96/-1:-1",
+          "targetVariableName": "Slate 900/opacity-24",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade_T–03": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.11999999731779099,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5611",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:01923effa846443db8c37a39d7db319eba1a1ae0/-1:-1",
+          "targetVariableName": "Slate 900/opacity-12",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade–03": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5616",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+          "targetVariableName": "Slate 900/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade_T–04": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.11999999731779099,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35161:10708",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:01923effa846443db8c37a39d7db319eba1a1ae0/-1:-1",
+          "targetVariableName": "Slate 900/opacity-12",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade–04": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35161:10713",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+          "targetVariableName": "Slate 900/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "$extensions": {
+    "com.figma.modeName": "Light"
+  }
+}

--- a/tokens/Mode.tokens.json
+++ b/tokens/Mode.tokens.json
@@ -1,0 +1,2129 @@
+{
+  "Descriptor": {
+    "$type": "number",
+    "$value": 1,
+    "$extensions": {
+      "com.figma.variableId": "VariableID:41540:17649",
+      "com.figma.scopes": [
+        "ALL_SCOPES"
+      ],
+      "com.figma.type": "boolean"
+    }
+  },
+  "Text": {
+    "Primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.8799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "body copy; data entries; Headers;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43905",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:97dbaea1224a1fe9f5528bda589dc83d379070db/-1:-1",
+          "targetVariableName": "Slate 900/opacity-88",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.6000000238418579,
+        "hex": "#141721"
+      },
+      "$description": "secondary text; additional descriptors;\nInput labels; data labels;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43904",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:964f157336d230b51994a4673a31d1879b3bf8c7/-1:-1",
+          "targetVariableName": "Slate 900/opacity-60",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.5,
+        "hex": "#141721"
+      },
+      "$description": "placeholder; hint text; tertiary content;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43903",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:394fb9c721804eb70858d6988d783c2c106a7f01/-1:-1",
+          "targetVariableName": "Slate 900/opacity-50",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Disabled": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "disabled content;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35828:157685",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Primary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.8799999952316284,
+        "hex": "#FFFFFF"
+      },
+      "$description": "body copy; data entries; headers; on high contrast backgrounds/elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43911",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2d8333a89f99ee38b1375efcdba4a6a1c0898c37/-1:-1",
+          "targetVariableName": "Mist 50/opacity-88",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.6000000238418579,
+        "hex": "#FFFFFF"
+      },
+      "$description": "secondary text; additional descriptors;\nInput labels; data labels; body copy; data entries; headers; on high contrast backgrounds or elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43910",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:074a8dc4bc93989af1cbae12b742b5a4515a244f/-1:-1",
+          "targetVariableName": "Mist 50/opacity-60",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.5,
+        "hex": "#FFFFFF"
+      },
+      "$description": "placeholder; hint text; tertiary content; on high contrast backgrounds or elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43909",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:c3590c4c756a710d177b4afad2d56a786848a7b6/-1:-1",
+          "targetVariableName": "Mist 50/opacity-50",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Disabled-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#FFFFFF"
+      },
+      "$description": "disabled content; on high contrast backgrounds or elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43913",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:cd7cffc9accaf2ca952ee9dc088b27d0fc5c0769/-1:-1",
+          "targetVariableName": "Mist 50/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Success": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08235294371843338,
+          0.501960813999176,
+          0.239215686917305
+        ],
+        "alpha": 1,
+        "hex": "#15803D"
+      },
+      "$description": "status success; AA compliant: 4.5:1",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37087:31321",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:7f892ff18231e4f9f72a6873020a76dfbabf0690/-1:-1",
+          "targetVariableName": "green/700",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Error": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7254902124404907,
+          0.10980392247438431,
+          0.10980392247438431
+        ],
+        "alpha": 1,
+        "hex": "#B91C1C"
+      },
+      "$description": "status error; AA compliant: 4.5:1",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37087:31319",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:4be4a0ecaef44221090632626724ae248c6e65da/-1:-1",
+          "targetVariableName": "red/700",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Warning": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7058823704719543,
+          0.32549020648002625,
+          0.03529411926865578
+        ],
+        "alpha": 1,
+        "hex": "#B45309"
+      },
+      "$description": "status error; AA compliant: 4.5:1",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37087:31320",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:c5c0efac4e9f9ebcd7ac4c708ecd6e82b1186661/-1:-1",
+          "targetVariableName": "amber/700",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Information": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.054901961237192154,
+          0.45490196347236633,
+          0.5647059082984924
+        ],
+        "alpha": 1,
+        "hex": "#0E7490"
+      },
+      "$description": "status generic info; AA compliant: 4.5:1",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37087:31318",
+        "com.figma.scopes": [
+          "TEXT_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:7a7298495b72bed4e0990bb9e437818dcd8b3cab/-1:-1",
+          "targetVariableName": "cyan/700",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "Border": {
+    "Divider": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.10000000149011612,
+        "hex": "#141721"
+      },
+      "$description": "very light separators; use for list items; button groupings;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43932",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.codeSyntax": {
+          "WEB": "Border/Divider"
+        },
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:7c4e0756ccc25586a986ae0351414bcc90cfa792/-1:-1",
+          "targetVariableName": "Slate 900/opacity-10",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.1599999964237213,
+        "hex": "#141721"
+      },
+      "$description": "subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; disabled state for toggle items; badges; switches; ",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35889:161721",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2d2c81996e19d35d14fc681e6a5073c41ccbfc12/-1:-1",
+          "targetVariableName": "Slate 900/opacity-16",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary-Hover": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "hover state – subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; toggle items; badges; switches;",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35912:2702",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.23999999463558197,
+        "hex": "#141721"
+      },
+      "$description": "medium contrast border – switches; tags; toggle elements; emphasised states",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36238:197353",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:17214497089407668df9fe4b013e1475116fea96/-1:-1",
+          "targetVariableName": "Slate 900/opacity-24",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "high contrast border – emphasised states",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:32620:43934",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Active": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.062745101749897,
+          0.07058823853731155,
+          0.10588235408067703
+        ],
+        "alpha": 1,
+        "hex": "#10121B"
+      },
+      "$description": "active state - for tabs; tags; inline inputs; switches; buttons; toggles; slider; active content states",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33906:16500",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:96f2bb07b030177884496b371238b62b777dd1e4/-1:-1",
+          "targetVariableName": "Slate/950",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Divider-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#FFFFFF"
+      },
+      "$description": "very light separators; use for list items; button groupings; high contrast, theme switch friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35890:200346",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:442c7611b64c3bb17c719b2a8c47088aed9b9daf/-1:-1",
+          "targetVariableName": "Mist 50/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.1599999964237213,
+        "hex": "#FFFFFF"
+      },
+      "$description": "subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; disabled state toggle items; switches; theme switch friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35890:200350",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:edd9f0e7207e101eaabe763bd98b1c437f2c15bb/-1:-1",
+          "targetVariableName": "Mist 50/opacity-16",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary-Hover-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#FFFFFF"
+      },
+      "$description": "hover state – subtle outlines – cards, panels; node links; inline inputs; tabs; data tables; disabled state for toggle items; badges; switches;  theme switching friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35912:2703",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:cd7cffc9accaf2ca952ee9dc088b27d0fc5c0769/-1:-1",
+          "targetVariableName": "Mist 50/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#FFFFFF"
+      },
+      "$description": "medium contrast border; switches, tags; toggle elements, emphasised states - high contrast instances, theme switching friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36238:197354",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:cd7cffc9accaf2ca952ee9dc088b27d0fc5c0769/-1:-1",
+          "targetVariableName": "Mist 50/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Primary-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.6000000238418579,
+        "hex": "#FFFFFF"
+      },
+      "$description": "stronger border; emphasised states - high contrast instances, theme switching friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36238:197355",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:074a8dc4bc93989af1cbae12b742b5a4515a244f/-1:-1",
+          "targetVariableName": "Mist 50/opacity-60",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Active-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#FFFFFF"
+      },
+      "$description": "active state - for tabs; tags; inline inputs; buttons; switches; toggles; slider; active content states - high contrast or theme switch friendly",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35890:200349",
+        "com.figma.scopes": [
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:3244c220b3f723a8a0c1547e94ca1676b415eba9/-1:-1",
+          "targetVariableName": "Mist/50",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Status": {
+      "Focus": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.21960784494876862,
+            0.7411764860153198,
+            0.9725490212440491
+          ],
+          "alpha": 1,
+          "hex": "#38BDF8"
+        },
+        "$description": "active/focus state for ui elements",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:36172:24485",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:fa426542300b3b47ee7d6fe19c0872e4dea152e4/-1:-1",
+            "targetVariableName": "sky/400",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Mono": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.23999999463558197,
+          "hex": "#141721"
+        },
+        "$description": "active/focus state variant for ui elements",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:37477:56186",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:17214497089407668df9fe4b013e1475116fea96/-1:-1",
+            "targetVariableName": "Slate 900/opacity-24",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Error": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.7254902124404907,
+            0.10980392247438431,
+            0.10980392247438431
+          ],
+          "alpha": 1,
+          "hex": "#B91C1C"
+        },
+        "$description": "active/focus state variant for ui elements - tags, badges, indicators, cards/panels",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:37477:56190",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:4be4a0ecaef44221090632626724ae248c6e65da/-1:-1",
+            "targetVariableName": "red/700",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Success": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.08627451211214066,
+            0.6392157077789307,
+            0.29019609093666077
+          ],
+          "alpha": 1,
+          "hex": "#16A34A"
+        },
+        "$description": "active/focus state variant for ui elements - tags, badges, indicators, cards/panels",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:37477:56191",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:7e95615371239c4212cdaa06bf36d0c5640f7de4/-1:-1",
+            "targetVariableName": "green/600",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Warning": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9607843160629272,
+            0.6196078658103943,
+            0.04313725605607033
+          ],
+          "alpha": 1,
+          "hex": "#F59E0B"
+        },
+        "$description": "active/focus state variant for ui elements - tags, badges, indicators, cards/panels",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:37477:56193",
+          "com.figma.scopes": [
+            "STROKE",
+            "EFFECT_COLOR"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:a930fa1a653eee124deedcf939d4776c391c23c8/-1:-1",
+            "targetVariableName": "amber/500",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      }
+    }
+  },
+  "Fill": {
+    "Content": {
+      "Primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.8799999952316284,
+          "hex": "#141721"
+        },
+        "$description": "buttons, tooltips background primary; high contrast/emphasied items; accents",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43920",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:97dbaea1224a1fe9f5528bda589dc83d379070db/-1:-1",
+            "targetVariableName": "Slate 900/opacity-88",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Secondary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.6000000238418579,
+          "hex": "#141721"
+        },
+        "$description": "medium contrast accent backgrounds",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43919",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:964f157336d230b51994a4673a31d1879b3bf8c7/-1:-1",
+            "targetVariableName": "Slate 900/opacity-60",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Tertiary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.1599999964237213,
+          "hex": "#141721"
+        },
+        "$description": "medium colour contrast overlay on high contrast items, ui-shells/panels, tiles",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35829:157686",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2d2c81996e19d35d14fc681e6a5073c41ccbfc12/-1:-1",
+            "targetVariableName": "Slate 900/opacity-16",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Disabled": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.3799999952316284,
+          "hex": "#141721"
+        },
+        "$description": "any fill for disabled elements on Fill/Muted or Surface tokens",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43924",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+            "targetVariableName": "Slate 900/opacity-38",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Active": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.062745101749897,
+            0.07058823853731155,
+            0.10588235408067703
+          ],
+          "alpha": 1,
+          "hex": "#10121B"
+        },
+        "$description": "active state fill for icons, buttons backgrounds, tags, switches, toggle items, sliders",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43923",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:96f2bb07b030177884496b371238b62b777dd1e4/-1:-1",
+            "targetVariableName": "Slate/950",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Primary-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.8799999952316284,
+          "hex": "#FFFFFF"
+        },
+        "$description": "buttons, tooltips background primary; high contrast/emphasied items; accents - theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43927",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2d8333a89f99ee38b1375efcdba4a6a1c0898c37/-1:-1",
+            "targetVariableName": "Mist 50/opacity-88",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Secondary-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.6000000238418579,
+          "hex": "#FFFFFF"
+        },
+        "$description": "medium contrast accent backgrounds; theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43926",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:074a8dc4bc93989af1cbae12b742b5a4515a244f/-1:-1",
+            "targetVariableName": "Mist 50/opacity-60",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Tertiary-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.1599999964237213,
+          "hex": "#FFFFFF"
+        },
+        "$description": "medium colour contrast overlay on high contrast items, ui-shells/panels, tiles",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35829:157714",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:edd9f0e7207e101eaabe763bd98b1c437f2c15bb/-1:-1",
+            "targetVariableName": "Mist 50/opacity-16",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Disabled-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.3799999952316284,
+          "hex": "#FFFFFF"
+        },
+        "$description": "any fill for disabled elements on Fill/Muted or Surface tokens; theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43931",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:cd7cffc9accaf2ca952ee9dc088b27d0fc5c0769/-1:-1",
+            "targetVariableName": "Mist 50/opacity-38",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Active-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 1,
+          "hex": "#FFFFFF"
+        },
+        "$description": "active state fill for icons, buttons backgrounds, tags, switches, toggle items, sliders; theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43929",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:3244c220b3f723a8a0c1547e94ca1676b415eba9/-1:-1",
+            "targetVariableName": "Mist/50",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "StepMarkers+Track": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.8274509906768799,
+            0.8392156958580017,
+            0.8509804010391235
+          ],
+          "alpha": 1,
+          "hex": "#D3D6D9"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:38041:61029",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:2622d442eac791f7a75eab336b1aa3565f011ec1/-1:-1",
+            "targetVariableName": "Mist/900",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      }
+    },
+    "onSurface": {
+      "bg-ui1": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9803921580314636,
+            0.9803921580314636,
+            0.9843137264251709
+          ],
+          "alpha": 1,
+          "hex": "#FAFAFB"
+        },
+        "$description": "solid used for high contrast tiles, ui containers backgrounds that sit on surface tokens",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35297:322164",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:982cf84d00e7d2504ade4daa5a8e87659c11dc41/-1:-1",
+            "targetVariableName": "Mist/100",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "bg-ui2": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9490196108818054,
+            0.9529411792755127,
+            0.95686274766922
+          ],
+          "alpha": 1,
+          "hex": "#F2F3F4"
+        },
+        "$description": "solid used for Avatar mono backgrounds, medium contrast tiles, ui containers backgrounds that sit on Surface tokens",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35297:322162",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:909c5c2c941ef3ad05032e7a413c097d26549768/-1:-1",
+            "targetVariableName": "Mist/300",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "bg-ui3": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9607843160629272,
+            0.9647058844566345,
+            0.9647058844566345
+          ],
+          "alpha": 1,
+          "hex": "#F5F6F6"
+        },
+        "$description": "solid ui backgrounds,  field inputs, notification, toast and sonner panels that sit on Surface tokens",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35297:322160",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:690450f17d51d78fb7f1ea77696ee4b8a587cd9e/-1:-1",
+            "targetVariableName": "Mist/200",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Muted": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.07999999821186066,
+          "hex": "#141721"
+        },
+        "$description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35876:157737",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+            "targetVariableName": "Slate 900/opacity-8",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Subtle": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.0784313753247261,
+            0.09019608050584793,
+            0.12941177189350128
+          ],
+          "alpha": 0.05999999865889549,
+          "hex": "#141721"
+        },
+        "$description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:38760:64997",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:a0e3d7bed55dbf8b906dbd8d7e8f008e521cb036/-1:-1",
+            "targetVariableName": "Slate 900/opacity-6",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Muted-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.07999999821186066,
+          "hex": "#FFFFFF"
+        },
+        "$description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills; theme switch friendly",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:32620:43925",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:442c7611b64c3bb17c719b2a8c47088aed9b9daf/-1:-1",
+            "targetVariableName": "Mist 50/opacity-8",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      },
+      "Subtle-Inverse": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "alpha": 0.05999999865889549,
+          "hex": "#FFFFFF"
+        },
+        "$description": "low colour contrast overlay on high contrast items, - disabled backgrounds when disabled icons/text present; tiles, tags, badges and secondary buttons background fills",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:38760:64998",
+          "com.figma.scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL"
+          ],
+          "com.figma.aliasData": {
+            "targetVariableId": "VariableID:65eedf429ce68aef3347d5c72cc397dfb22f8dff/-1:-1",
+            "targetVariableName": "Mist 50/opacity-6",
+            "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+            "targetVariableSetName": "DS-Primitives"
+          }
+        }
+      }
+    }
+  },
+  "Surface": {
+    "Primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#FFFFFF"
+      },
+      "$description": "primary page/ui shell panel background",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35297:322158",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:3244c220b3f723a8a0c1547e94ca1676b415eba9/-1:-1",
+          "targetVariableName": "Mist/50",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Secondary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9215686321258545,
+          0.929411768913269,
+          0.9333333373069763
+        ],
+        "alpha": 1,
+        "hex": "#EBEDEE"
+      },
+      "$description": "secondary page/ui shell panel background - use for side panels",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35297:322166",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:525b84cb7bda10e8ecb99fbf55bd0c0c3db288ca/-1:-1",
+          "targetVariableName": "Mist/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Tertiary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9019607901573181,
+          0.9098039269447327,
+          0.9176470637321472
+        ],
+        "alpha": 1,
+        "hex": "#E6E8EA"
+      },
+      "$description": "optional usage - tertiary background/ui shell panels when Primary or Secondary already used.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35297:322161",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:c2c5285b240e9566b3998d4849b486934eac1739/-1:-1",
+          "targetVariableName": "Mist/500",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Base": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9803921580314636,
+          0.9803921580314636,
+          0.9843137264251709
+        ],
+        "alpha": 1,
+        "hex": "#FAFAFB"
+      },
+      "$description": "high contrast surface - used to create negative space/separator between primary or secondary backgrounds/ui shells. could be used for high contrast canvas",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35941:2845",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:982cf84d00e7d2504ade4daa5a8e87659c11dc41/-1:-1",
+          "targetVariableName": "Mist/100",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "Status": {
+    "Success": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08627451211214066,
+          0.6392157077789307,
+          0.29019609093666077
+        ],
+        "alpha": 1,
+        "hex": "#16A34A"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33962:17491",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:7e95615371239c4212cdaa06bf36d0c5640f7de4/-1:-1",
+          "targetVariableName": "green/600",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Error": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8627451062202454,
+          0.14901961386203766,
+          0.14901961386203766
+        ],
+        "alpha": 1,
+        "hex": "#DC2626"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33962:17492",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL",
+          "STROKE"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:466793dbf745f4cbf05f321ce4dac8337b27d5e1/-1:-1",
+          "targetVariableName": "red/600",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Warning": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8509804010391235,
+          0.46666666865348816,
+          0.0235294122248888
+        ],
+        "alpha": 1,
+        "hex": "#D97706"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33962:17493",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:f73ff115512e9ee356c839b62466d9f3dffbb6d2/-1:-1",
+          "targetVariableName": "amber/600",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Information": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0313725508749485,
+          0.5686274766921997,
+          0.6980392336845398
+        ],
+        "alpha": 1,
+        "hex": "#0891B2"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33962:17494",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:d5068d967f4827309074a6ff79f88b26674e53cb/-1:-1",
+          "targetVariableName": "cyan/600",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Success-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.29019609093666077,
+          0.8705882430076599,
+          0.501960813999176
+        ],
+        "alpha": 1,
+        "hex": "#4ADE80"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant - high contrast instances, theme switch friendly.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37092:39615",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:9d4c0307269d7bbc60e41770f676ea3044b66e97/-1:-1",
+          "targetVariableName": "green/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Error-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9725490212440491,
+          0.4431372582912445,
+          0.4431372582912445
+        ],
+        "alpha": 1,
+        "hex": "#F87171"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant Fill/Border only, for all status modes instances; except text - not contrast AA compliant; - high contrast instances, theme switch friendly.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37092:39616",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:c22a929b0f2cadef69d9640ad5d09af6bab7994c/-1:-1",
+          "targetVariableName": "red/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Warning-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9843137264251709,
+          0.7490196228027344,
+          0.1411764770746231
+        ],
+        "alpha": 1,
+        "hex": "#FBBF24"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant; - high contrast instances, theme switch friendly.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37092:39617",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:9b395d7007bf1d42559b9d47f47f6f3a14df4f47/-1:-1",
+          "targetVariableName": "amber/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Information-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.21960784494876862,
+          0.7411764860153198,
+          0.9725490212440491
+        ],
+        "alpha": 1,
+        "hex": "#38BDF8"
+      },
+      "$description": "Fill/Border only, for all status modes instances; except text - not contrast AA compliant; - high contrast instances, theme switch friendly.",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37092:39618",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:fa426542300b3b47ee7d6fe19c0872e4dea152e4/-1:-1",
+          "targetVariableName": "sky/400",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "StatesLayer-Overlay": {
+    "Enabled": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0,
+        "hex": "#141721"
+      },
+      "$description": "Enabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:157456",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e692c7c97db42c05e88ec957e07a0e3f5fc852df/-1:-1",
+          "targetVariableName": "Slate 900/opacity-0",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Hover": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#141721"
+      },
+      "$description": "Hover State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:163306",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+          "targetVariableName": "Slate 900/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Pressed": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.1599999964237213,
+        "hex": "#141721"
+      },
+      "$description": "Pressed State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:165581",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:2d2c81996e19d35d14fc681e6a5073c41ccbfc12/-1:-1",
+          "targetVariableName": "Slate 900/opacity-16",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Active": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.062745101749897,
+          0.07058823853731155,
+          0.10588235408067703
+        ],
+        "alpha": 1,
+        "hex": "#10121B"
+      },
+      "$description": "Active State overlay for entire ui item - used in most components; buttons, inputs, menus, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34921:299012",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:96f2bb07b030177884496b371238b62b777dd1e4/-1:-1",
+          "targetVariableName": "Slate/950",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Disabled": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#141721"
+      },
+      "$description": "Disabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:168625",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+          "targetVariableName": "Slate 900/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Enabled_Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0,
+        "hex": "#FFFFFF"
+      },
+      "$description": "Enabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items - on high contrast/accent content",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36453:106961",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6d8d774dbdb45daf6cbeccb5fb84a40eaa1e0ab9/-1:-1",
+          "targetVariableName": "Mist 50/opacity-0",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Hover-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#FFFFFF"
+      },
+      "$description": "Hover State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items –on high/accent contrast elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35075:41677",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:442c7611b64c3bb17c719b2a8c47088aed9b9daf/-1:-1",
+          "targetVariableName": "Mist 50/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Pressed-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.1599999964237213,
+        "hex": "#FFFFFF"
+      },
+      "$description": "Pressed State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items - on high/accent contrast elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35075:41678",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:edd9f0e7207e101eaabe763bd98b1c437f2c15bb/-1:-1",
+          "targetVariableName": "Mist 50/opacity-16",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Active-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#FFFFFF"
+      },
+      "$description": "Active State overlay for entire ui item - used in most components; buttons, inputs, menus, pickers, text area, tags, list items -on high/accent contrast elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:34919:270561",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:3244c220b3f723a8a0c1547e94ca1676b415eba9/-1:-1",
+          "targetVariableName": "Mist/50",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Disabled-Inverse": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$description": "Disabled State overlay for entire ui item - used in most components; buttons, inputs, pickers, text area, tags, list items - on high/accent elements",
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35075:41679",
+        "com.figma.scopes": [
+          "FRAME_FILL",
+          "SHAPE_FILL"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "Elevations": {
+    "Shade_T": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5581",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+          "targetVariableName": "Slate 900/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5586",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:e1be29ddd1be54c50ec196a0e192e1ec4c02637a/-1:-1",
+          "targetVariableName": "Slate 900/opacity-38",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade_T–01": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.11999999731779099,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5591",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:01923effa846443db8c37a39d7db319eba1a1ae0/-1:-1",
+          "targetVariableName": "Slate 900/opacity-12",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade–01": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.11999999731779099,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5596",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:01923effa846443db8c37a39d7db319eba1a1ae0/-1:-1",
+          "targetVariableName": "Slate 900/opacity-12",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade_T–02": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.11999999731779099,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5601",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:01923effa846443db8c37a39d7db319eba1a1ae0/-1:-1",
+          "targetVariableName": "Slate 900/opacity-12",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade–02": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.23999999463558197,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5606",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:17214497089407668df9fe4b013e1475116fea96/-1:-1",
+          "targetVariableName": "Slate 900/opacity-24",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade_T–03": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.11999999731779099,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5611",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:01923effa846443db8c37a39d7db319eba1a1ae0/-1:-1",
+          "targetVariableName": "Slate 900/opacity-12",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade–03": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35144:5616",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+          "targetVariableName": "Slate 900/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade_T–04": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.11999999731779099,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35161:10708",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:01923effa846443db8c37a39d7db319eba1a1ae0/-1:-1",
+          "targetVariableName": "Slate 900/opacity-12",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    },
+    "Shade–04": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35161:10713",
+        "com.figma.scopes": [
+          "EFFECT_COLOR"
+        ],
+        "com.figma.aliasData": {
+          "targetVariableId": "VariableID:6b5020f7baea137c6d466682a921afe275711496/-1:-1",
+          "targetVariableName": "Slate 900/opacity-8",
+          "targetVariableSetId": "VariableCollectionId:7cf1ed5af259fa66585d937dfe0efccbf91edeb2/-1:-1",
+          "targetVariableSetName": "DS-Primitives"
+        }
+      }
+    }
+  },
+  "$extensions": {
+    "com.figma.modeName": "Mode"
+  }
+}

--- a/tokens/Round.tokens.json
+++ b/tokens/Round.tokens.json
@@ -1,0 +1,59 @@
+{
+  "rad-sm": {
+    "$type": "number",
+    "$value": 4,
+    "$description": "Small components like tags, badges",
+    "$extensions": {
+      "com.figma.variableId": "VariableID:35241:30793",
+      "com.figma.scopes": [
+        "CORNER_RADIUS"
+      ],
+      "com.figma.codeSyntax": {
+        "WEB": "var(--radi-1)"
+      }
+    }
+  },
+  "rad-reg": {
+    "$type": "number",
+    "$value": 8,
+    "$description": "regular or small components that often live inside others, like buttons or nested components",
+    "$extensions": {
+      "com.figma.variableId": "VariableID:35241:30792",
+      "com.figma.scopes": [
+        "CORNER_RADIUS"
+      ],
+      "com.figma.codeSyntax": {
+        "WEB": "var(--radi-2)"
+      }
+    }
+  },
+  "rad-md": {
+    "$type": "number",
+    "$value": 12,
+    "$description": "Medium components like cards, snack bars, banners",
+    "$extensions": {
+      "com.figma.variableId": "VariableID:37574:57841",
+      "com.figma.hiddenFromPublishing": true,
+      "com.figma.scopes": [
+        "CORNER_RADIUS"
+      ]
+    }
+  },
+  "rad-lg": {
+    "$type": "number",
+    "$value": 16,
+    "$description": "Large container components like sheets and dialogs",
+    "$extensions": {
+      "com.figma.variableId": "VariableID:37574:57842",
+      "com.figma.scopes": [
+        "CORNER_RADIUS"
+      ],
+      "com.figma.codeSyntax": {
+        "WEB": "var(--radi-2)"
+      }
+    }
+  },
+  "$extensions": {
+    "com.figma.modeName": "Round"
+  }
+}

--- a/tokens/Sharp.tokens.json
+++ b/tokens/Sharp.tokens.json
@@ -1,0 +1,72 @@
+{
+  "rad-sm": {
+    "$type": "number",
+    "$value": 0,
+    "$description": "Small components like tags, badges",
+    "$extensions": {
+      "com.figma.variableId": "VariableID:35241:30793",
+      "com.figma.scopes": [
+        "CORNER_RADIUS"
+      ],
+      "com.figma.codeSyntax": {
+        "WEB": "var(--radi-1)"
+      }
+    }
+  },
+  "rad-reg": {
+    "$type": "number",
+    "$value": 0,
+    "$description": "regular or small components that often live inside others, like buttons or nested components",
+    "$extensions": {
+      "com.figma.variableId": "VariableID:35241:30792",
+      "com.figma.scopes": [
+        "CORNER_RADIUS"
+      ],
+      "com.figma.codeSyntax": {
+        "WEB": "var(--radi-2)"
+      }
+    }
+  },
+  "rad-md": {
+    "$type": "number",
+    "$value": 0,
+    "$description": "Medium components like cards, snack bars, banners",
+    "$extensions": {
+      "com.figma.variableId": "VariableID:37574:57841",
+      "com.figma.hiddenFromPublishing": true,
+      "com.figma.scopes": [
+        "CORNER_RADIUS"
+      ]
+    }
+  },
+  "rad-lg": {
+    "$type": "number",
+    "$value": 0,
+    "$description": "Large container components like sheets and dialogs",
+    "$extensions": {
+      "com.figma.variableId": "VariableID:37574:57842",
+      "com.figma.scopes": [
+        "CORNER_RADIUS"
+      ],
+      "com.figma.codeSyntax": {
+        "WEB": "var(--radi-2)"
+      }
+    }
+  },
+  "rad-round": {
+    "$type": "number",
+    "$value": 1000,
+    "$extensions": {
+      "com.figma.variableId": "VariableID:35241:30787",
+      "com.figma.scopes": [
+        "CORNER_RADIUS"
+      ],
+      "com.figma.codeSyntax": {
+        "WEB": "var(--radi-10)"
+      }
+    }
+  },
+  "$extensions": {
+    "com.figma.modeName": "Sharp"
+  }
+}

--- a/tokens/Value.tokens.json
+++ b/tokens/Value.tokens.json
@@ -1,0 +1,5236 @@
+{
+  "Mist": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#FFFFFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:8989",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9803921580314636,
+          0.9803921580314636,
+          0.9843137264251709
+        ],
+        "alpha": 1,
+        "hex": "#FAFAFB"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:8990",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9607843160629272,
+          0.9647058844566345,
+          0.9647058844566345
+        ],
+        "alpha": 1,
+        "hex": "#F5F6F6"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:8991",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9490196108818054,
+          0.9529411792755127,
+          0.95686274766922
+        ],
+        "alpha": 1,
+        "hex": "#F2F3F4"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:8992",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9215686321258545,
+          0.929411768913269,
+          0.9333333373069763
+        ],
+        "alpha": 1,
+        "hex": "#EBEDEE"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:8993",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9019607901573181,
+          0.9098039269447327,
+          0.9176470637321472
+        ],
+        "alpha": 1,
+        "hex": "#E6E8EA"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:8994",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.886274516582489,
+          0.8941176533699036,
+          0.9019607901573181
+        ],
+        "alpha": 1,
+        "hex": "#E2E4E6"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:8995",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8666666746139526,
+          0.8745098114013672,
+          0.8823529481887817
+        ],
+        "alpha": 1,
+        "hex": "#DDDFE1"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:8996",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8470588326454163,
+          0.8549019694328308,
+          0.8666666746139526
+        ],
+        "alpha": 1,
+        "hex": "#D8DADD"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:8997",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8274509906768799,
+          0.8392156958580017,
+          0.8509804010391235
+        ],
+        "alpha": 1,
+        "hex": "#D3D6D9"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:8998",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "Mist 50": {
+    "opacity-0": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0,
+        "hex": "#FFFFFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36453:9734",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-4": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.03999999910593033,
+        "hex": "#FFFFFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35858:15348",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-6": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.05999999865889549,
+        "hex": "#FFFFFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35579:6408",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-8": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#FFFFFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35281:187691",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-10": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.10000000149011612,
+        "hex": "#FFFFFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9166",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-12": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.11999999731779099,
+        "hex": "#FFFFFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35312:350975",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-16": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.1599999964237213,
+        "hex": "#FFFFFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9167",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-24": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.23999999463558197,
+        "hex": "#FFFFFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9168",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-30": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.30000001192092896,
+        "hex": "#FFFFFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:42610:56401",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-38": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#FFFFFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33947:8823",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.5,
+        "hex": "#FFFFFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9169",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-60": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.6000000238418579,
+        "hex": "#FFFFFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9170",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-88": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 0.8799999952316284,
+        "hex": "#FFFFFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9171",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "Slate": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.21568627655506134,
+          0.22745098173618317,
+          0.2666666805744171
+        ],
+        "alpha": 1,
+        "hex": "#373A44"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:8999",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.20000000298023224,
+          0.21176470816135406,
+          0.250980406999588
+        ],
+        "alpha": 1,
+        "hex": "#333640"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9000",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.18431372940540314,
+          0.19607843458652496,
+          0.23529411852359772
+        ],
+        "alpha": 1,
+        "hex": "#2F323C"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9001",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.16862745583057404,
+          0.18039216101169586,
+          0.2235294133424759
+        ],
+        "alpha": 1,
+        "hex": "#2B2E39"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9002",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.15294118225574493,
+          0.16470588743686676,
+          0.2078431397676468
+        ],
+        "alpha": 1,
+        "hex": "#272A35"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9003",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.13725490868091583,
+          0.14901961386203766,
+          0.19607843458652496
+        ],
+        "alpha": 1,
+        "hex": "#232632"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9004",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.12156862765550613,
+          0.13333334028720856,
+          0.18039216101169586
+        ],
+        "alpha": 1,
+        "hex": "#1F222E"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9005",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.10588235408067703,
+          0.11764705926179886,
+          0.16470588743686676
+        ],
+        "alpha": 1,
+        "hex": "#1B1E2A"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9006",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0941176488995552,
+          0.10588235408067703,
+          0.14901961386203766
+        ],
+        "alpha": 1,
+        "hex": "#181B26"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9007",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 1,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35818:9546",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.062745101749897,
+          0.07058823853731155,
+          0.10588235408067703
+        ],
+        "alpha": 1,
+        "hex": "#10121B"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:41564:26205",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "Slate 900": {
+    "opacity-0": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36453:9735",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-4": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.03999999910593033,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35579:6409",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-6": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.05999999865889549,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35859:91855",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-8": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.07999999821186066,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9172",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-10": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.10000000149011612,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35148:5640",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-12": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.11999999731779099,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35148:5639",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-16": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.1599999964237213,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9173",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-24": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.23999999463558197,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9174",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-30": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.30000001192092896,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:42610:56402",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-38": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.3799999952316284,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33947:8824",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.5,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9175",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-60": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.6000000238418579,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9176",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "opacity-88": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.09019608050584793,
+          0.12941177189350128
+        ],
+        "alpha": 0.8799999952316284,
+        "hex": "#141721"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9177",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "Brand-Accents": {
+    "QB-Accent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.6627451181411743,
+          0.95686274766922
+        ],
+        "alpha": 1,
+        "hex": "#00A9F4"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:36160:151231",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "McKinsey-Electric-Blue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.13333334028720856,
+          0.3176470696926117,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#2251FF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9010",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "McKinsey-Cyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.6627451181411743,
+          0.95686274766922
+        ],
+        "alpha": 1,
+        "hex": "#00A9F4"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9011",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "McKinsey-Deep-Blue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.019607843831181526,
+          0.10980392247438431,
+          0.1725490242242813
+        ],
+        "alpha": 1,
+        "hex": "#051C2C"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:33946:9009",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "Stroke-Weight": {
+    "stroke-05": {
+      "$type": "number",
+      "$value": 0.5,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:39320:24733",
+        "com.figma.scopes": [
+          "STROKE_FLOAT",
+          "FONT_VARIATIONS"
+        ]
+      }
+    },
+    "stroke-1": {
+      "$type": "number",
+      "$value": 1,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:39320:24734",
+        "com.figma.scopes": [
+          "STROKE_FLOAT",
+          "FONT_VARIATIONS"
+        ]
+      }
+    },
+    "stroke-2": {
+      "$type": "number",
+      "$value": 2,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:39320:24735",
+        "com.figma.scopes": [
+          "STROKE_FLOAT",
+          "FONT_VARIATIONS"
+        ]
+      }
+    },
+    "stroke-4": {
+      "$type": "number",
+      "$value": 4,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:39320:24736",
+        "com.figma.scopes": [
+          "STROKE_FLOAT",
+          "FONT_VARIATIONS"
+        ]
+      }
+    },
+    "stroke-8": {
+      "$type": "number",
+      "$value": 8,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:39320:24738",
+        "com.figma.scopes": [
+          "STROKE_FLOAT",
+          "FONT_VARIATIONS"
+        ]
+      }
+    },
+    "stroke-12": {
+      "$type": "number",
+      "$value": 12,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:39320:24740",
+        "com.figma.scopes": [
+          "STROKE_FLOAT",
+          "FONT_VARIATIONS"
+        ]
+      }
+    },
+    "stroke-16": {
+      "$type": "number",
+      "$value": 16,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:39320:24741",
+        "com.figma.scopes": [
+          "STROKE_FLOAT",
+          "FONT_VARIATIONS"
+        ]
+      }
+    }
+  },
+  "Font": {
+    "Family": {
+      "Display": {
+        "$type": "string",
+        "$value": "Inter",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35068:125376",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.type": "string"
+        }
+      },
+      "Headings": {
+        "$type": "string",
+        "$value": "Inter",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:145011",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.type": "string"
+        }
+      },
+      "Paragraph": {
+        "$type": "string",
+        "$value": "Inter",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:160496",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.type": "string"
+        }
+      },
+      "code-text": {
+        "$type": "string",
+        "$value": "Roboto Mono",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:280550",
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.type": "string"
+        }
+      }
+    },
+    "Weight": {
+      "300": {
+        "$type": "string",
+        "$value": "Light",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:280547",
+          "com.figma.scopes": [
+            "FONT_STYLE"
+          ],
+          "com.figma.type": "string"
+        }
+      },
+      "400": {
+        "$type": "string",
+        "$value": "Regular",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:280548",
+          "com.figma.scopes": [
+            "FONT_STYLE"
+          ],
+          "com.figma.type": "string"
+        }
+      },
+      "600": {
+        "$type": "string",
+        "$value": "Semibold",
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:280549",
+          "com.figma.scopes": [
+            "FONT_STYLE"
+          ],
+          "com.figma.type": "string"
+        }
+      }
+    },
+    "Font-Size": {
+      "12": {
+        "$type": "number",
+        "$value": 12,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35982:301380",
+          "com.figma.scopes": [
+            "FONT_SIZE"
+          ]
+        }
+      },
+      "14": {
+        "$type": "number",
+        "$value": 14,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35982:301381",
+          "com.figma.scopes": [
+            "FONT_SIZE"
+          ]
+        }
+      },
+      "16": {
+        "$type": "number",
+        "$value": 16,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35982:301382",
+          "com.figma.scopes": [
+            "FONT_SIZE"
+          ]
+        }
+      },
+      "20": {
+        "$type": "number",
+        "$value": 20,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35982:301383",
+          "com.figma.scopes": [
+            "FONT_SIZE"
+          ]
+        }
+      },
+      "24": {
+        "$type": "number",
+        "$value": 24,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35982:301384",
+          "com.figma.scopes": [
+            "FONT_SIZE"
+          ]
+        }
+      },
+      "32": {
+        "$type": "number",
+        "$value": 32,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35982:301385",
+          "com.figma.scopes": [
+            "FONT_SIZE"
+          ]
+        }
+      },
+      "40": {
+        "$type": "number",
+        "$value": 40,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35982:301386",
+          "com.figma.scopes": [
+            "FONT_SIZE"
+          ]
+        }
+      },
+      "48": {
+        "$type": "number",
+        "$value": 48,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35982:301387",
+          "com.figma.scopes": [
+            "FONT_SIZE"
+          ]
+        }
+      },
+      "56": {
+        "$type": "number",
+        "$value": 56,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35982:301388",
+          "com.figma.scopes": [
+            "FONT_SIZE"
+          ]
+        }
+      }
+    },
+    "Line-Height": {
+      "12": {
+        "$type": "number",
+        "$value": 12,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:280551",
+          "com.figma.scopes": [
+            "LINE_HEIGHT"
+          ]
+        }
+      },
+      "16": {
+        "$type": "number",
+        "$value": 16,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:280560",
+          "com.figma.scopes": [
+            "LINE_HEIGHT"
+          ]
+        }
+      },
+      "20": {
+        "$type": "number",
+        "$value": 20,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:280561",
+          "com.figma.scopes": [
+            "LINE_HEIGHT"
+          ]
+        }
+      },
+      "24": {
+        "$type": "number",
+        "$value": 24,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:280562",
+          "com.figma.scopes": [
+            "LINE_HEIGHT"
+          ]
+        }
+      },
+      "28": {
+        "$type": "number",
+        "$value": 28,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:280563",
+          "com.figma.scopes": [
+            "LINE_HEIGHT"
+          ]
+        }
+      },
+      "32": {
+        "$type": "number",
+        "$value": 32,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:280564",
+          "com.figma.scopes": [
+            "LINE_HEIGHT"
+          ]
+        }
+      },
+      "40": {
+        "$type": "number",
+        "$value": 40,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:280565",
+          "com.figma.scopes": [
+            "LINE_HEIGHT"
+          ]
+        }
+      },
+      "48": {
+        "$type": "number",
+        "$value": 48,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:280566",
+          "com.figma.scopes": [
+            "LINE_HEIGHT"
+          ]
+        }
+      },
+      "56": {
+        "$type": "number",
+        "$value": 56,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35070:280567",
+          "com.figma.scopes": [
+            "LINE_HEIGHT"
+          ]
+        }
+      },
+      "64": {
+        "$type": "number",
+        "$value": 64,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:35982:518276",
+          "com.figma.scopes": [
+            "LINE_HEIGHT"
+          ]
+        }
+      }
+    },
+    "Paragraph-Spacing": {
+      "8": {
+        "$type": "number",
+        "$value": 8,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:38085:28715",
+          "com.figma.scopes": [
+            "TEXT_CONTENT",
+            "PARAGRAPH_SPACING",
+            "PARAGRAPH_INDENT",
+            "FONT_VARIATIONS"
+          ]
+        }
+      },
+      "12": {
+        "$type": "number",
+        "$value": 12,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:38085:28718",
+          "com.figma.scopes": [
+            "TEXT_CONTENT",
+            "PARAGRAPH_SPACING",
+            "PARAGRAPH_INDENT",
+            "FONT_VARIATIONS"
+          ]
+        }
+      },
+      "16": {
+        "$type": "number",
+        "$value": 16,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:38085:28720",
+          "com.figma.scopes": [
+            "TEXT_CONTENT",
+            "PARAGRAPH_SPACING",
+            "PARAGRAPH_INDENT",
+            "FONT_VARIATIONS"
+          ]
+        }
+      },
+      "20": {
+        "$type": "number",
+        "$value": 20,
+        "$extensions": {
+          "com.figma.variableId": "VariableID:38085:28721",
+          "com.figma.scopes": [
+            "TEXT_CONTENT",
+            "PARAGRAPH_SPACING",
+            "PARAGRAPH_INDENT",
+            "FONT_VARIATIONS"
+          ]
+        }
+      }
+    }
+  },
+  "Spacing": {
+    "1": {
+      "$type": "number",
+      "$value": 1,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:41536:12536",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "2": {
+      "$type": "number",
+      "$value": 2,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145333",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "4": {
+      "$type": "number",
+      "$value": 4,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145306",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "8": {
+      "$type": "number",
+      "$value": 8,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145330",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "12": {
+      "$type": "number",
+      "$value": 12,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145335",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "16": {
+      "$type": "number",
+      "$value": 16,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145324",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "20": {
+      "$type": "number",
+      "$value": 20,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145327",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "24": {
+      "$type": "number",
+      "$value": 24,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145326",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "28": {
+      "$type": "number",
+      "$value": 28,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145321",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "32": {
+      "$type": "number",
+      "$value": 32,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145328",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "36": {
+      "$type": "number",
+      "$value": 36,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145318",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "40": {
+      "$type": "number",
+      "$value": 40,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145317",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "48": {
+      "$type": "number",
+      "$value": 48,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145314",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "52": {
+      "$type": "number",
+      "$value": 52,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145334",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "56": {
+      "$type": "number",
+      "$value": 56,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145313",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "60": {
+      "$type": "number",
+      "$value": 60,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145323",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "64": {
+      "$type": "number",
+      "$value": 64,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145310",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "72": {
+      "$type": "number",
+      "$value": 72,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145336",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "80": {
+      "$type": "number",
+      "$value": 80,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145309",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "96": {
+      "$type": "number",
+      "$value": 96,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145308",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    },
+    "Infinite": {
+      "$type": "number",
+      "$value": 9999,
+      "$extensions": {
+        "com.figma.variableId": "VariableID:35680:145307",
+        "com.figma.scopes": [
+          "WIDTH_HEIGHT",
+          "GAP",
+          "STROKE_FLOAT"
+        ]
+      }
+    }
+  },
+  "red": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9960784316062927,
+          0.9490196108818054,
+          0.9490196108818054
+        ],
+        "alpha": 1,
+        "hex": "#FEF2F2"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7949",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9960784316062927,
+          0.886274516582489,
+          0.886274516582489
+        ],
+        "alpha": 1,
+        "hex": "#FEE2E2"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7950",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9960784316062927,
+          0.7921568751335144,
+          0.7921568751335144
+        ],
+        "alpha": 1,
+        "hex": "#FECACA"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7951",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9882352948188782,
+          0.6470588445663452,
+          0.6470588445663452
+        ],
+        "alpha": 1,
+        "hex": "#FCA5A5"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7952",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9725490212440491,
+          0.4431372582912445,
+          0.4431372582912445
+        ],
+        "alpha": 1,
+        "hex": "#F87171"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7953",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9372549057006836,
+          0.2666666805744171,
+          0.2666666805744171
+        ],
+        "alpha": 1,
+        "hex": "#EF4444"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7954",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8627451062202454,
+          0.14901961386203766,
+          0.14901961386203766
+        ],
+        "alpha": 1,
+        "hex": "#DC2626"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7955",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7254902124404907,
+          0.10980392247438431,
+          0.10980392247438431
+        ],
+        "alpha": 1,
+        "hex": "#B91C1C"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7956",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6000000238418579,
+          0.10588235408067703,
+          0.10588235408067703
+        ],
+        "alpha": 1,
+        "hex": "#991B1B"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7957",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.49803921580314636,
+          0.11372549086809158,
+          0.11372549086809158
+        ],
+        "alpha": 1,
+        "hex": "#7F1D1D"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7958",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2705882489681244,
+          0.03921568766236305,
+          0.03921568766236305
+        ],
+        "alpha": 1,
+        "hex": "#450A0A"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8068",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "amber": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.9843137264251709,
+          0.9215686321258545
+        ],
+        "alpha": 1,
+        "hex": "#FFFBEB"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7773",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9960784316062927,
+          0.9529411792755127,
+          0.7803921699523926
+        ],
+        "alpha": 1,
+        "hex": "#FEF3C7"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7774",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9921568632125854,
+          0.9019607901573181,
+          0.5411764979362488
+        ],
+        "alpha": 1,
+        "hex": "#FDE68A"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7775",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9882352948188782,
+          0.8274509906768799,
+          0.3019607961177826
+        ],
+        "alpha": 1,
+        "hex": "#FCD34D"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7776",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9843137264251709,
+          0.7490196228027344,
+          0.1411764770746231
+        ],
+        "alpha": 1,
+        "hex": "#FBBF24"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7777",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9607843160629272,
+          0.6196078658103943,
+          0.04313725605607033
+        ],
+        "alpha": 1,
+        "hex": "#F59E0B"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7778",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8509804010391235,
+          0.46666666865348816,
+          0.0235294122248888
+        ],
+        "alpha": 1,
+        "hex": "#D97706"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7779",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7058823704719543,
+          0.32549020648002625,
+          0.03529411926865578
+        ],
+        "alpha": 1,
+        "hex": "#B45309"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7780",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.572549045085907,
+          0.250980406999588,
+          0.054901961237192154
+        ],
+        "alpha": 1,
+        "hex": "#92400E"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7781",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47058823704719543,
+          0.2078431397676468,
+          0.05882352963089943
+        ],
+        "alpha": 1,
+        "hex": "#78350F"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7782",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.26274511218070984,
+          0.0784313753247261,
+          0.027450980618596077
+        ],
+        "alpha": 1,
+        "hex": "#431407"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8070",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "yellow": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9960784316062927,
+          0.9882352948188782,
+          0.9098039269447327
+        ],
+        "alpha": 1,
+        "hex": "#FEFCE8"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7971",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9960784316062927,
+          0.9764705896377563,
+          0.7647058963775635
+        ],
+        "alpha": 1,
+        "hex": "#FEF9C3"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7972",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9960784316062927,
+          0.9411764740943909,
+          0.5411764979362488
+        ],
+        "alpha": 1,
+        "hex": "#FEF08A"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7973",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9921568632125854,
+          0.8784313797950745,
+          0.27843138575553894
+        ],
+        "alpha": 1,
+        "hex": "#FDE047"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7974",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9803921580314636,
+          0.800000011920929,
+          0.08235294371843338
+        ],
+        "alpha": 1,
+        "hex": "#FACC15"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7975",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9176470637321472,
+          0.7019608020782471,
+          0.0313725508749485
+        ],
+        "alpha": 1,
+        "hex": "#EAB308"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7976",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7921568751335144,
+          0.5411764979362488,
+          0.01568627543747425
+        ],
+        "alpha": 1,
+        "hex": "#CA8A04"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7977",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6313725709915161,
+          0.3843137323856354,
+          0.027450980618596077
+        ],
+        "alpha": 1,
+        "hex": "#A16207"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7978",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5215686559677124,
+          0.3019607961177826,
+          0.054901961237192154
+        ],
+        "alpha": 1,
+        "hex": "#854D0E"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7979",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4431372582912445,
+          0.24705882370471954,
+          0.07058823853731155
+        ],
+        "alpha": 1,
+        "hex": "#713F12"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7980",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.25882354378700256,
+          0.125490203499794,
+          0.0235294122248888
+        ],
+        "alpha": 1,
+        "hex": "#422006"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8072",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "lime": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9686274528503418,
+          0.9960784316062927,
+          0.9058823585510254
+        ],
+        "alpha": 1,
+        "hex": "#F7FEE7"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7905",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9254902005195618,
+          0.9882352948188782,
+          0.7960784435272217
+        ],
+        "alpha": 1,
+        "hex": "#ECFCCB"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7906",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8509804010391235,
+          0.9764705896377563,
+          0.615686297416687
+        ],
+        "alpha": 1,
+        "hex": "#D9F99D"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7907",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7450980544090271,
+          0.9490196108818054,
+          0.3921568691730499
+        ],
+        "alpha": 1,
+        "hex": "#BEF264"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7908",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6392157077789307,
+          0.9019607901573181,
+          0.2078431397676468
+        ],
+        "alpha": 1,
+        "hex": "#A3E635"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7909",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5176470875740051,
+          0.800000011920929,
+          0.08627451211214066
+        ],
+        "alpha": 1,
+        "hex": "#84CC16"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7910",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3960784375667572,
+          0.6392157077789307,
+          0.05098039284348488
+        ],
+        "alpha": 1,
+        "hex": "#65A30D"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7911",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3019607961177826,
+          0.48627451062202454,
+          0.05882352963089943
+        ],
+        "alpha": 1,
+        "hex": "#4D7C0F"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7912",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24705882370471954,
+          0.3843137323856354,
+          0.07058823853731155
+        ],
+        "alpha": 1,
+        "hex": "#3F6212"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7913",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.21176470816135406,
+          0.32549020648002625,
+          0.0784313753247261
+        ],
+        "alpha": 1,
+        "hex": "#365314"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7914",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.10196078568696976,
+          0.18039216101169586,
+          0.019607843831181526
+        ],
+        "alpha": 1,
+        "hex": "#1A2E05"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8074",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "green": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9411764740943909,
+          0.9921568632125854,
+          0.95686274766922
+        ],
+        "alpha": 1,
+        "hex": "#F0FDF4"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7850",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8627451062202454,
+          0.9882352948188782,
+          0.9058823585510254
+        ],
+        "alpha": 1,
+        "hex": "#DCFCE7"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7851",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7333333492279053,
+          0.9686274528503418,
+          0.8156862854957581
+        ],
+        "alpha": 1,
+        "hex": "#BBF7D0"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7852",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5254902243614197,
+          0.9372549057006836,
+          0.6745098233222961
+        ],
+        "alpha": 1,
+        "hex": "#86EFAC"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7853",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.29019609093666077,
+          0.8705882430076599,
+          0.501960813999176
+        ],
+        "alpha": 1,
+        "hex": "#4ADE80"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7854",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.13333334028720856,
+          0.772549033164978,
+          0.3686274588108063
+        ],
+        "alpha": 1,
+        "hex": "#22C55E"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7855",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08627451211214066,
+          0.6392157077789307,
+          0.29019609093666077
+        ],
+        "alpha": 1,
+        "hex": "#16A34A"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7856",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08235294371843338,
+          0.501960813999176,
+          0.239215686917305
+        ],
+        "alpha": 1,
+        "hex": "#15803D"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7857",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08627451211214066,
+          0.3960784375667572,
+          0.20392157137393951
+        ],
+        "alpha": 1,
+        "hex": "#166534"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7858",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.32549020648002625,
+          0.1764705926179886
+        ],
+        "alpha": 1,
+        "hex": "#14532D"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7859",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.019607843831181526,
+          0.18039216101169586,
+          0.08627451211214066
+        ],
+        "alpha": 1,
+        "hex": "#052E16"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8076",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "emerald": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9254902005195618,
+          0.9921568632125854,
+          0.9607843160629272
+        ],
+        "alpha": 1,
+        "hex": "#ECFDF5"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8078",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8196078538894653,
+          0.9803921580314636,
+          0.8980392217636108
+        ],
+        "alpha": 1,
+        "hex": "#D1FAE5"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8079",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6549019813537598,
+          0.9529411792755127,
+          0.8156862854957581
+        ],
+        "alpha": 1,
+        "hex": "#A7F3D0"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8080",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4313725531101227,
+          0.9058823585510254,
+          0.7176470756530762
+        ],
+        "alpha": 1,
+        "hex": "#6EE7B7"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8081",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.20392157137393951,
+          0.8274509906768799,
+          0.6000000238418579
+        ],
+        "alpha": 1,
+        "hex": "#34D399"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8082",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.062745101749897,
+          0.7254902124404907,
+          0.5058823823928833
+        ],
+        "alpha": 1,
+        "hex": "#10B981"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8083",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.019607843831181526,
+          0.5882353186607361,
+          0.4117647111415863
+        ],
+        "alpha": 1,
+        "hex": "#059669"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8084",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.01568627543747425,
+          0.47058823704719543,
+          0.34117648005485535
+        ],
+        "alpha": 1,
+        "hex": "#047857"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8085",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0235294122248888,
+          0.37254902720451355,
+          0.27450981736183167
+        ],
+        "alpha": 1,
+        "hex": "#065F46"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8086",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0235294122248888,
+          0.30588236451148987,
+          0.23137255012989044
+        ],
+        "alpha": 1,
+        "hex": "#064E3B"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8087",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.007843137718737125,
+          0.1725490242242813,
+          0.13333334028720856
+        ],
+        "alpha": 1,
+        "hex": "#022C22"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8088",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "teal": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9411764740943909,
+          0.9921568632125854,
+          0.9803921580314636
+        ],
+        "alpha": 1,
+        "hex": "#F0FDFA"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7960",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.800000011920929,
+          0.9843137264251709,
+          0.9450980424880981
+        ],
+        "alpha": 1,
+        "hex": "#CCFBF1"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7961",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6000000238418579,
+          0.9647058844566345,
+          0.8941176533699036
+        ],
+        "alpha": 1,
+        "hex": "#99F6E4"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7962",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3686274588108063,
+          0.9176470637321472,
+          0.8313725590705872
+        ],
+        "alpha": 1,
+        "hex": "#5EEAD4"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7963",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.1764705926179886,
+          0.8313725590705872,
+          0.7490196228027344
+        ],
+        "alpha": 1,
+        "hex": "#2DD4BF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7964",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0784313753247261,
+          0.7215686440467834,
+          0.6509804129600525
+        ],
+        "alpha": 1,
+        "hex": "#14B8A6"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7965",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.05098039284348488,
+          0.5803921818733215,
+          0.5333333611488342
+        ],
+        "alpha": 1,
+        "hex": "#0D9488"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7966",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.05882352963089943,
+          0.4627451002597809,
+          0.4313725531101227
+        ],
+        "alpha": 1,
+        "hex": "#0F766E"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7967",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.06666667014360428,
+          0.3686274588108063,
+          0.3490196168422699
+        ],
+        "alpha": 1,
+        "hex": "#115E59"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7968",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.07450980693101883,
+          0.30588236451148987,
+          0.29019609093666077
+        ],
+        "alpha": 1,
+        "hex": "#134E4A"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7969",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.01568627543747425,
+          0.18431372940540314,
+          0.18039216101169586
+        ],
+        "alpha": 1,
+        "hex": "#042F2E"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8090",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "cyan": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9254902005195618,
+          0.9960784316062927,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#ECFEFF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7817",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8117647171020508,
+          0.9803921580314636,
+          0.9960784316062927
+        ],
+        "alpha": 1,
+        "hex": "#CFFAFE"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7818",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6470588445663452,
+          0.9529411792755127,
+          0.9882352948188782
+        ],
+        "alpha": 1,
+        "hex": "#A5F3FC"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7819",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.40392157435417175,
+          0.9098039269447327,
+          0.9764705896377563
+        ],
+        "alpha": 1,
+        "hex": "#67E8F9"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7820",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.13333334028720856,
+          0.8274509906768799,
+          0.9333333373069763
+        ],
+        "alpha": 1,
+        "hex": "#22D3EE"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7821",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0235294122248888,
+          0.7137255072593689,
+          0.8313725590705872
+        ],
+        "alpha": 1,
+        "hex": "#06B6D4"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7822",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0313725508749485,
+          0.5686274766921997,
+          0.6980392336845398
+        ],
+        "alpha": 1,
+        "hex": "#0891B2"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7823",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.054901961237192154,
+          0.45490196347236633,
+          0.5647059082984924
+        ],
+        "alpha": 1,
+        "hex": "#0E7490"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7824",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08235294371843338,
+          0.3686274588108063,
+          0.4588235318660736
+        ],
+        "alpha": 1,
+        "hex": "#155E75"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7825",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08627451211214066,
+          0.30588236451148987,
+          0.38823530077934265
+        ],
+        "alpha": 1,
+        "hex": "#164E63"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7826",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0313725508749485,
+          0.20000000298023224,
+          0.2666666805744171
+        ],
+        "alpha": 1,
+        "hex": "#083344"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8092",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "sky": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9411764740943909,
+          0.9764705896377563,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#F0F9FF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8094",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8784313797950745,
+          0.9490196108818054,
+          0.9960784316062927
+        ],
+        "alpha": 1,
+        "hex": "#E0F2FE"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8095",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.729411780834198,
+          0.9019607901573181,
+          0.9921568632125854
+        ],
+        "alpha": 1,
+        "hex": "#BAE6FD"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8096",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4901960790157318,
+          0.8274509906768799,
+          0.9882352948188782
+        ],
+        "alpha": 1,
+        "hex": "#7DD3FC"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8097",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.21960784494876862,
+          0.7411764860153198,
+          0.9725490212440491
+        ],
+        "alpha": 1,
+        "hex": "#38BDF8"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8098",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.054901961237192154,
+          0.6470588445663452,
+          0.9137254953384399
+        ],
+        "alpha": 1,
+        "hex": "#0EA5E9"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8099",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.007843137718737125,
+          0.5176470875740051,
+          0.7803921699523926
+        ],
+        "alpha": 1,
+        "hex": "#0284C7"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8100",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0117647061124444,
+          0.4117647111415863,
+          0.6313725709915161
+        ],
+        "alpha": 1,
+        "hex": "#0369A1"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8101",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.027450980618596077,
+          0.3490196168422699,
+          0.5215686559677124
+        ],
+        "alpha": 1,
+        "hex": "#075985"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8102",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0470588244497776,
+          0.29019609093666077,
+          0.4313725531101227
+        ],
+        "alpha": 1,
+        "hex": "#0C4A6E"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8103",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0313725508749485,
+          0.18431372940540314,
+          0.2862745225429535
+        ],
+        "alpha": 1,
+        "hex": "#082F49"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8104",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "blue": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9372549057006836,
+          0.9647058844566345,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#EFF6FF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7784",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8588235378265381,
+          0.9176470637321472,
+          0.9960784316062927
+        ],
+        "alpha": 1,
+        "hex": "#DBEAFE"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7785",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7490196228027344,
+          0.8588235378265381,
+          0.9960784316062927
+        ],
+        "alpha": 1,
+        "hex": "#BFDBFE"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7786",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5764706134796143,
+          0.772549033164978,
+          0.9921568632125854
+        ],
+        "alpha": 1,
+        "hex": "#93C5FD"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7787",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3764705955982208,
+          0.6470588445663452,
+          0.9803921580314636
+        ],
+        "alpha": 1,
+        "hex": "#60A5FA"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7788",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.23137255012989044,
+          0.5098039507865906,
+          0.9647058844566345
+        ],
+        "alpha": 1,
+        "hex": "#3B82F6"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7789",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14509804546833038,
+          0.38823530077934265,
+          0.9215686321258545
+        ],
+        "alpha": 1,
+        "hex": "#2563EB"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7790",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.11372549086809158,
+          0.30588236451148987,
+          0.8470588326454163
+        ],
+        "alpha": 1,
+        "hex": "#1D4ED8"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7791",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.11764705926179886,
+          0.250980406999588,
+          0.686274528503418
+        ],
+        "alpha": 1,
+        "hex": "#1E40AF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7792",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.11764705926179886,
+          0.22745098173618317,
+          0.5411764979362488
+        ],
+        "alpha": 1,
+        "hex": "#1E3A8A"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7793",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.09019608050584793,
+          0.14509804546833038,
+          0.3294117748737335
+        ],
+        "alpha": 1,
+        "hex": "#172554"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8106",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "indigo": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9333333373069763,
+          0.9490196108818054,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#EEF2FF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7872",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8784313797950745,
+          0.9058823585510254,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#E0E7FF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7873",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7803921699523926,
+          0.8235294222831726,
+          0.9960784316062927
+        ],
+        "alpha": 1,
+        "hex": "#C7D2FE"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7874",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6470588445663452,
+          0.7058823704719543,
+          0.9882352948188782
+        ],
+        "alpha": 1,
+        "hex": "#A5B4FC"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7875",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5058823823928833,
+          0.5490196347236633,
+          0.9725490212440491
+        ],
+        "alpha": 1,
+        "hex": "#818CF8"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7876",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.38823530077934265,
+          0.4000000059604645,
+          0.9450980424880981
+        ],
+        "alpha": 1,
+        "hex": "#6366F1"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7877",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.30980393290519714,
+          0.27450981736183167,
+          0.8980392217636108
+        ],
+        "alpha": 1,
+        "hex": "#4F46E5"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7878",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.26274511218070984,
+          0.21960784494876862,
+          0.7921568751335144
+        ],
+        "alpha": 1,
+        "hex": "#4338CA"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7879",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.21568627655506134,
+          0.1882352977991104,
+          0.6392157077789307
+        ],
+        "alpha": 1,
+        "hex": "#3730A3"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7880",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.1921568661928177,
+          0.18039216101169586,
+          0.5058823823928833
+        ],
+        "alpha": 1,
+        "hex": "#312E81"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7881",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.11764705926179886,
+          0.10588235408067703,
+          0.29411765933036804
+        ],
+        "alpha": 1,
+        "hex": "#1E1B4B"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8108",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "violet": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9607843160629272,
+          0.9529411792755127,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#F5F3FF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8110",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.929411768913269,
+          0.9137254953384399,
+          0.9960784316062927
+        ],
+        "alpha": 1,
+        "hex": "#EDE9FE"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8111",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8666666746139526,
+          0.8392156958580017,
+          0.9960784316062927
+        ],
+        "alpha": 1,
+        "hex": "#DDD6FE"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8112",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7686274647712708,
+          0.7098039388656616,
+          0.9921568632125854
+        ],
+        "alpha": 1,
+        "hex": "#C4B5FD"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8113",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6549019813537598,
+          0.545098066329956,
+          0.9803921580314636
+        ],
+        "alpha": 1,
+        "hex": "#A78BFA"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8114",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.545098066329956,
+          0.3607843220233917,
+          0.9647058844566345
+        ],
+        "alpha": 1,
+        "hex": "#8B5CF6"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8115",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.48627451062202454,
+          0.22745098173618317,
+          0.929411768913269
+        ],
+        "alpha": 1,
+        "hex": "#7C3AED"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8116",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4274509847164154,
+          0.1568627506494522,
+          0.8509804010391235
+        ],
+        "alpha": 1,
+        "hex": "#6D28D9"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8117",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.35686275362968445,
+          0.12941177189350128,
+          0.7137255072593689
+        ],
+        "alpha": 1,
+        "hex": "#5B21B6"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8118",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2980392277240753,
+          0.11372549086809158,
+          0.5843137502670288
+        ],
+        "alpha": 1,
+        "hex": "#4C1D95"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8119",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.18039216101169586,
+          0.062745101749897,
+          0.3960784375667572
+        ],
+        "alpha": 1,
+        "hex": "#2E1065"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8120",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "purple": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9803921580314636,
+          0.9607843160629272,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#FAF5FF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7938",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9529411792755127,
+          0.9098039269447327,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#F3E8FF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7939",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9137254953384399,
+          0.8352941274642944,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#E9D5FF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7940",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8470588326454163,
+          0.7058823704719543,
+          0.9960784316062927
+        ],
+        "alpha": 1,
+        "hex": "#D8B4FE"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7941",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7529411911964417,
+          0.5176470875740051,
+          0.9882352948188782
+        ],
+        "alpha": 1,
+        "hex": "#C084FC"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7942",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.658823549747467,
+          0.3333333432674408,
+          0.9686274528503418
+        ],
+        "alpha": 1,
+        "hex": "#A855F7"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7943",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5764706134796143,
+          0.20000000298023224,
+          0.9176470637321472
+        ],
+        "alpha": 1,
+        "hex": "#9333EA"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7944",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4941176474094391,
+          0.13333334028720856,
+          0.8078431487083435
+        ],
+        "alpha": 1,
+        "hex": "#7E22CE"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7945",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.41960784792900085,
+          0.12941177189350128,
+          0.658823549747467
+        ],
+        "alpha": 1,
+        "hex": "#6B21A8"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7946",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3450980484485626,
+          0.10980392247438431,
+          0.529411792755127
+        ],
+        "alpha": 1,
+        "hex": "#581C87"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7947",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.23137255012989044,
+          0.027450980618596077,
+          0.3921568691730499
+        ],
+        "alpha": 1,
+        "hex": "#3B0764"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8122",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "fuchsia": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9921568632125854,
+          0.95686274766922,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#FDF4FF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8124",
+        "com.figma.scopes": [
+          "ALL_FILLS",
+          "STROKE"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9803921580314636,
+          0.9098039269447327,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#FAE8FF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8125",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9607843160629272,
+          0.8156862854957581,
+          0.9960784316062927
+        ],
+        "alpha": 1,
+        "hex": "#F5D0FE"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8126",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9411764740943909,
+          0.6705882549285889,
+          0.9882352948188782
+        ],
+        "alpha": 1,
+        "hex": "#F0ABFC"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8127",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9098039269447327,
+          0.4745098054409027,
+          0.9764705896377563
+        ],
+        "alpha": 1,
+        "hex": "#E879F9"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8128",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8509804010391235,
+          0.27450981736183167,
+          0.9372549057006836
+        ],
+        "alpha": 1,
+        "hex": "#D946EF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8129",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7529411911964417,
+          0.14901961386203766,
+          0.8274509906768799
+        ],
+        "alpha": 1,
+        "hex": "#C026D3"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8130",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6352941393852234,
+          0.10980392247438431,
+          0.686274528503418
+        ],
+        "alpha": 1,
+        "hex": "#A21CAF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8131",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5254902243614197,
+          0.09803921729326248,
+          0.5607843399047852
+        ],
+        "alpha": 1,
+        "hex": "#86198F"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8132",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.43921568989753723,
+          0.10196078568696976,
+          0.4588235318660736
+        ],
+        "alpha": 1,
+        "hex": "#701A75"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8133",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.29019609093666077,
+          0.01568627543747425,
+          0.30588236451148987
+        ],
+        "alpha": 1,
+        "hex": "#4A044E"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8134",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "pink": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9921568632125854,
+          0.9490196108818054,
+          0.9725490212440491
+        ],
+        "alpha": 1,
+        "hex": "#FDF2F8"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7927",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9882352948188782,
+          0.9058823585510254,
+          0.9529411792755127
+        ],
+        "alpha": 1,
+        "hex": "#FCE7F3"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7928",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9843137264251709,
+          0.8117647171020508,
+          0.9098039269447327
+        ],
+        "alpha": 1,
+        "hex": "#FBCFE8"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7929",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9764705896377563,
+          0.658823549747467,
+          0.8313725590705872
+        ],
+        "alpha": 1,
+        "hex": "#F9A8D4"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7930",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.95686274766922,
+          0.4470588266849518,
+          0.7137255072593689
+        ],
+        "alpha": 1,
+        "hex": "#F472B6"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7931",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9254902005195618,
+          0.2823529541492462,
+          0.6000000238418579
+        ],
+        "alpha": 1,
+        "hex": "#EC4899"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7932",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8588235378265381,
+          0.15294118225574493,
+          0.46666666865348816
+        ],
+        "alpha": 1,
+        "hex": "#DB2777"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7933",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7450980544090271,
+          0.0941176488995552,
+          0.364705890417099
+        ],
+        "alpha": 1,
+        "hex": "#BE185D"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7934",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.615686297416687,
+          0.09019608050584793,
+          0.3019607961177826
+        ],
+        "alpha": 1,
+        "hex": "#9D174D"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7935",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5137255191802979,
+          0.0941176488995552,
+          0.26274511218070984
+        ],
+        "alpha": 1,
+        "hex": "#831843"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:7936",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3137255012989044,
+          0.027450980618596077,
+          0.1411764770746231
+        ],
+        "alpha": 1,
+        "hex": "#500724"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8136",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "rose": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.9450980424880981,
+          0.9490196108818054
+        ],
+        "alpha": 1,
+        "hex": "#FFF1F2"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8138",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.8941176533699036,
+          0.9019607901573181
+        ],
+        "alpha": 1,
+        "hex": "#FFE4E6"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8139",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9960784316062927,
+          0.8039215803146362,
+          0.8274509906768799
+        ],
+        "alpha": 1,
+        "hex": "#FECDD3"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8140",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9921568632125854,
+          0.6431372761726379,
+          0.686274528503418
+        ],
+        "alpha": 1,
+        "hex": "#FDA4AF"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8141",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9843137264251709,
+          0.4431372582912445,
+          0.5215686559677124
+        ],
+        "alpha": 1,
+        "hex": "#FB7185"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8142",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.95686274766922,
+          0.24705882370471954,
+          0.3686274588108063
+        ],
+        "alpha": 1,
+        "hex": "#F43F5E"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8143",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8823529481887817,
+          0.11372549086809158,
+          0.2823529541492462
+        ],
+        "alpha": 1,
+        "hex": "#E11D48"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8144",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7450980544090271,
+          0.07058823853731155,
+          0.23529411852359772
+        ],
+        "alpha": 1,
+        "hex": "#BE123C"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8145",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6235294342041016,
+          0.07058823853731155,
+          0.2235294133424759
+        ],
+        "alpha": 1,
+        "hex": "#9F1239"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8146",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5333333611488342,
+          0.07450980693101883,
+          0.21568627655506134
+        ],
+        "alpha": 1,
+        "hex": "#881337"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8147",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2980392277240753,
+          0.019607843831181526,
+          0.09803921729326248
+        ],
+        "alpha": 1,
+        "hex": "#4C0519"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8148",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "stone": {
+    "50": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9803921580314636,
+          0.9803921580314636,
+          0.9764705896377563
+        ],
+        "alpha": 1,
+        "hex": "#FAFAF9"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8056",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9607843160629272,
+          0.9607843160629272,
+          0.95686274766922
+        ],
+        "alpha": 1,
+        "hex": "#F5F5F4"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8057",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9058823585510254,
+          0.8980392217636108,
+          0.8941176533699036
+        ],
+        "alpha": 1,
+        "hex": "#E7E5E4"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8058",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8392156958580017,
+          0.8274509906768799,
+          0.8196078538894653
+        ],
+        "alpha": 1,
+        "hex": "#D6D3D1"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8059",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.658823549747467,
+          0.6352941393852234,
+          0.6196078658103943
+        ],
+        "alpha": 1,
+        "hex": "#A8A29E"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8060",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47058823704719543,
+          0.4431372582912445,
+          0.42352941632270813
+        ],
+        "alpha": 1,
+        "hex": "#78716C"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8061",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.34117648005485535,
+          0.32549020648002625,
+          0.30588236451148987
+        ],
+        "alpha": 1,
+        "hex": "#57534E"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8062",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2666666805744171,
+          0.250980406999588,
+          0.23529411852359772
+        ],
+        "alpha": 1,
+        "hex": "#44403C"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8063",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.16078431904315948,
+          0.14509804546833038,
+          0.1411764770746231
+        ],
+        "alpha": 1,
+        "hex": "#292524"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8064",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.10980392247438431,
+          0.09803921729326248,
+          0.09019608050584793
+        ],
+        "alpha": 1,
+        "hex": "#1C1917"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8065",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0470588244497776,
+          0.03921568766236305,
+          0.03529411926865578
+        ],
+        "alpha": 1,
+        "hex": "#0C0A09"
+      },
+      "$extensions": {
+        "com.figma.variableId": "VariableID:37044:8066",
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ]
+      }
+    }
+  },
+  "$extensions": {
+    "com.figma.modeName": "Value"
+  }
+}


### PR DESCRIPTION
## Summary
Closes https://github.com/McK-Internal/qbds-internal/issues/94 (see comments in the issue on two distinct approaches, this one is the manual one)

Adds a scripted pipeline to sync **Figma design token exports** into `src/styles/globals.css`. For this PR, token JSON files were exported from Figma and inserted into a `/tokens` folder. The scripts handle conversion and updating `globals.css` only. The command was run manually to test it out first.

## How it works

1. Figma variable exports live in `tokens/` (Value, Light, Dark, Sharp, Round) (not committed in this PR, you have to insert them manually to test it)
2. `npm run sync:tokens` regenerates only the marked regions in `globals.css`:
   - `@theme inline` primitives (from `Value.tokens.json`)
   - Semantic tokens on `:root`, `.dark`, `.radius-mode` (from Light/Dark/Sharp/Round)
3. Declaration **order is preserved** from the existing file so PR diffs focus on value changes, not reordering.
4. **`scripts/tokens/theme-bridge.csspart`** - hand-maintained Tailwind/shadcn aliases (`--text-sm`, `--color-fg-*`, `--radius-*`, etc.) pasted after Figma primitives. Not generated from Figma. 

## New files

| File | Purpose |
|------|---------|
| `scripts/sync-tokens.ts` | CLI: patch marked sections, print change summary |
| `scripts/tokens/sync-core.ts` | Figma JSON → CSS conversion |
| `scripts/tokens/theme-bridge.csspart` | Manual framework mappings |
| `tokens-sync.config.json` | Maps JSON files → CSS sections |
| `tokens/*.json` | Figma exports (source of truth for sync) |

## Usage

1. Download token files manually from Figma. I used DS_Primitives, Radius, and DS_Themes
<img width="239" height="103" alt="Screenshot 2026-05-21 at 10 43 43" src="https://github.com/user-attachments/assets/6bedf2bb-9329-402b-9747-c6e24f623904" />

2. Insert the token files into a `/tokens` folder
<img width="199" height="154" alt="Screenshot 2026-05-21 at 10 37 27" src="https://github.com/user-attachments/assets/61779c85-3f48-4274-a5d6-8e29d4c52cae" />


3. Run the command
```bash
# After adding token files into `/tokens` folder:
npm run sync:tokens
```

Then open a PR and review the `globals.css` diff.

## Out of scope (follow-ups)

- Add Figma PAT to Github secrets and add scheduled GitHub Action (use same scripts; add fetch step + secret later if we want monthly auto-PRs)