### PR TITLE
fix(tag): scope hover underline to text, remove tracking shift

### DIFF
--- a/src/components/ui/tag-toggle.tsx
+++ b/src/components/ui/tag-toggle.tsx
@@ -4,7 +4,11 @@ import * as TogglePrimitive from '@radix-ui/react-toggle';
 import type { VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
-import { tagBaseStyles, tagSizeVariants } from '@/components/ui/tag';
+import {
+  tagBaseStyles,
+  tagSizeVariants,
+  wrapTagText,
+} from '@/components/ui/tag';
 import { cn } from '@/lib/utils';
 
 type TagToggleVariant = 'default' | 'outline';
@@ -87,7 +91,7 @@ function TagToggle({
       data-slot="tag-toggle"
       className={tagToggleClasses({ variant, size, pill, className })}
       {...props}>
-      {children}
+      {wrapTagText(children, 'disabled')}
     </TogglePrimitive.Root>
   );
 }

--- a/src/components/ui/tag.tsx
+++ b/src/components/ui/tag.tsx
@@ -43,9 +43,10 @@ function tagBaseStyles(disabledPrefix: 'disabled' | 'aria-disabled') {
 }
 
 /**
- * Wrap raw string/number children in a span that carries the hover underline,
- * so the underline only crosses text — not sibling icon glyphs or the dismiss button.
- * The parent must have the `group` class for `group-hover` to take effect.
+ * Apply the hover underline to text-bearing children — raw text/number nodes
+ * and plain `<span>` wrappers — while skipping design system primitives
+ * (anything carrying a `data-slot`, like Icon or Avatar). The parent must
+ * have the `group` class for `group-hover` to take effect.
  */
 function wrapTagText(
   children: React.ReactNode,
@@ -61,6 +62,18 @@ function wrapTagText(
   return React.Children.map(children, child => {
     if (typeof child === 'string' || typeof child === 'number') {
       return <span className={underlineClass}>{child}</span>;
+    }
+
+    if (
+      React.isValidElement<{ className?: string; 'data-slot'?: string }>(
+        child,
+      ) &&
+      child.type === 'span' &&
+      !child.props['data-slot']
+    ) {
+      return React.cloneElement(child, {
+        className: cn(child.props.className, underlineClass),
+      });
     }
 
     return child;

--- a/src/components/ui/tag.tsx
+++ b/src/components/ui/tag.tsx
@@ -35,7 +35,6 @@ const dismissIconColor = {
 function tagBaseStyles(disabledPrefix: 'disabled' | 'aria-disabled') {
   return [
     'whitespace-nowrap outline-none transition-all',
-    `hover:underline [text-underline-position:from-font] ${disabledPrefix}:no-underline`,
     'focus-visible:ring-2 focus-visible:ring-stroke-status-focus',
     `${disabledPrefix}:cursor-not-allowed`,
     `${disabledPrefix}:hover:[background-image:none]`,
@@ -43,14 +42,39 @@ function tagBaseStyles(disabledPrefix: 'disabled' | 'aria-disabled') {
   ];
 }
 
+/**
+ * Wrap raw string/number children in a span that carries the hover underline,
+ * so the underline only crosses text — not sibling icon glyphs or the dismiss button.
+ * The parent must have the `group` class for `group-hover` to take effect.
+ */
+function wrapTagText(
+  children: React.ReactNode,
+  disabledPrefix: 'disabled' | 'aria-disabled',
+): React.ReactNode {
+  const underlineClass = cn(
+    'group-hover:underline [text-underline-position:from-font]',
+    disabledPrefix === 'aria-disabled'
+      ? 'group-aria-disabled:no-underline'
+      : 'group-disabled:no-underline',
+  );
+
+  return React.Children.map(children, child => {
+    if (typeof child === 'string' || typeof child === 'number') {
+      return <span className={underlineClass}>{child}</span>;
+    }
+
+    return child;
+  });
+}
+
 /** Size & pill classes shared with TagToggle */
 const tagSizeVariants = cva('inline-flex items-center w-fit px-1 gap-1', {
   variants: {
     size: {
-      xs: 'h-5 label-small-primary hover:tracking-[0.024px]',
-      sm: 'h-6 label-regular-primary hover:tracking-[-0.028px]',
-      default: 'h-7 label-regular-primary hover:tracking-[-0.028px]',
-      lg: 'h-8 label-large-primary hover:tracking-[-0.032px]',
+      xs: 'h-5 label-small-primary',
+      sm: 'h-6 label-regular-primary',
+      default: 'h-7 label-regular-primary',
+      lg: 'h-8 label-large-primary',
     },
     pill: {
       false: 'rounded-none !px-1',
@@ -174,11 +198,11 @@ function Tag({
       className={cn(
         tagSizeVariants({ size, pill }),
         tagVariants({ variant }),
-        onRemove && 'group',
+        'group',
         className,
       )}
       {...props}>
-      {children}
+      {wrapTagText(children, 'aria-disabled')}
 
       {onRemove && (
         <button
@@ -206,4 +230,4 @@ function Tag({
   );
 }
 
-export { Tag, tagBaseStyles, tagSizeVariants, tagVariants };
+export { Tag, tagBaseStyles, tagSizeVariants, tagVariants, wrapTagText };


### PR DESCRIPTION
## Summary
- Hover underline on `Tag` and `TagToggle` was drawn across the icon glyphs and the dismiss `X`, because Material Symbols icons render as inline text spans and the underline sat on the parent. Wrap raw text/number children in a `<span>` carrying `group-hover:underline` so only the label underlines.
- Drop the per-size `hover:tracking-[...]` rules on `tagSizeVariants` — they tightened letter-spacing on hover and caused a small layout shift.

Behavior preserved: the dismiss button's existing `group-hover:opacity-[0.88]` (secondary → primary) still fires. Disabled tags still suppress the underline via `group-aria-disabled:no-underline` / `group-disabled:no-underline`.

Note: the underline-across-icons bug isn't from a recent PR. `git blame` shows `hover:underline` has lived in `tagBaseStyles` since the initial release; it only became visible when icons moved from SVGs to the Material Symbols variable font.

## Visuals

Before:

<img width="201" height="128" alt="image" src="https://github.com/user-attachments/assets/8d4cb9cb-a6f0-4986-a684-4ba1558c4d22" />

---

After:

<img width="209" height="113" alt="image" src="https://github.com/user-attachments/assets/2716c701-7bf1-4005-9783-a195588f011a" />


## Test plan
- [ ] Hover a Tag with a leading icon and a trailing dismiss button — only the text label underlines; icons unchanged.
- [ ] Hover a TagToggle with a leading icon — only the label underlines.
- [ ] Hover a disabled Tag and a disabled TagToggle — no underline appears.
- [ ] Hover a Tag — no horizontal layout shift from letter-spacing change.
- [ ] All Tag variants (primary, secondary, accent, outline, accent-outline) and all sizes (xs/sm/default/lg) render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)