### PR TITLE
refactor(icons): replace lucide-react with Material Symbols Icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "date-fns": "^4.1.0",
         "embla-carousel-react": "^8.6.0",
         "input-otp": "^1.4.2",
-        "lucide-react": "^0.506.0",
         "radix-ui": "^1.4.3",
         "react": "19.2.0",
         "react-day-picker": "^9.11.1",
@@ -579,7 +578,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -603,7 +601,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4742,7 +4739,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4832,7 +4828,6 @@
       "integrity": "sha512-3DgfkukFyC/sE/VuYjaUUWoFfuVjPK55vOFDsxD56XXynFMCZDYFogH2l/hDfOsQAm1myoU/1xByJ3tWqtulXA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@babel/generator": "^7.28.0",
         "@babel/parser": "^7.28.0",
@@ -5077,7 +5072,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5088,7 +5082,6 @@
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5112,7 +5105,6 @@
       "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.57.2",
@@ -5152,7 +5144,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -5549,7 +5540,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7001,8 +6991,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -7322,7 +7311,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7383,7 +7371,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9078,7 +9065,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -9530,15 +9516,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/lucide-react": {
-      "version": "0.506.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.506.0.tgz",
-      "integrity": "sha512-/2znFFzlXcZKu0ANFCnxUOBV5I2e08m19PGtb6X+BcByRj8ODlGAl3wpe4LNVrDMLJ263JoIkZn7MOGK/5sXtw==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
@@ -10260,7 +10237,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10783,7 +10759,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10825,7 +10800,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10838,7 +10812,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
       "integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -12258,7 +12231,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -12393,7 +12365,6 @@
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12721,7 +12692,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13254,7 +13224,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",
     "input-otp": "^1.4.2",
-    "lucide-react": "^0.506.0",
     "radix-ui": "^1.4.3",
     "react": "19.2.0",
     "react-day-picker": "^9.11.1",

--- a/registry.json
+++ b/registry.json
@@ -260,7 +260,8 @@
       ],
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
-        "__REGISTRY_URL__/r/utils.json"
+        "__REGISTRY_URL__/r/utils.json",
+        "__REGISTRY_URL__/r/icon.json"
       ],
       "files": [
         {

--- a/src/components/registry/code-block.tsx
+++ b/src/components/registry/code-block.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Check, Copy } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { Icon } from '@/components/ui/icon';
 import { cn } from '@/lib/utils';
 
 interface CodeBlockProps {
@@ -76,14 +76,14 @@ export function CodeBlock({
           className="ml-auto h-8 px-2 transition-colors">
           {copied ? (
             <>
-              <Check className="text-status-success mr-1 size-4" />
+              <Icon icon="check" className="text-status-success mr-1 size-4" />
               <span className="paragraph-small-primary text-fg-primary">
                 Copied
               </span>
             </>
           ) : (
             <>
-              <Copy className="mr-1 size-4" />
+              <Icon icon="content_copy" className="mr-1 size-4" />
               <span className="paragraph-small-primary text-fg-primary">
                 Copy
               </span>

--- a/src/components/registry/example-preview.tsx
+++ b/src/components/registry/example-preview.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Check, Copy } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -118,12 +117,15 @@ export function ExamplePreview({
               className="h-7 px-2 text-xs">
               {copied ? (
                 <>
-                  <Check className="text-status-success mr-1 size-3.5" />
+                  <Icon
+                    icon="check"
+                    className="text-status-success mr-1 size-4"
+                  />
                   Copied
                 </>
               ) : (
                 <>
-                  <Copy className="mr-1 size-3.5" />
+                  <Icon icon="content_copy" className="mr-1 size-4" />
                   Copy
                 </>
               )}

--- a/src/components/registry/installation-guide.tsx
+++ b/src/components/registry/installation-guide.tsx
@@ -1,5 +1,4 @@
-import { FileCode, Package, Terminal } from 'lucide-react';
-
+import { Icon } from '@/components/ui/icon';
 import {
   type Component,
   getComponentFileTarget,
@@ -29,7 +28,7 @@ export function InstallationGuide({ component }: InstallationGuideProps) {
       {/* CLI Installation */}
       <div className="space-y-3">
         <div className="flex items-center gap-2">
-          <Terminal className="text-fg-primary size-4" />
+          <Icon icon="terminal" className="text-fg-primary size-4" />
           <h3 className="headings-h4-semibold text-fg-primary">
             CLI Installation
           </h3>
@@ -47,7 +46,7 @@ export function InstallationGuide({ component }: InstallationGuideProps) {
       {/* Manual Installation */}
       <div className="space-y-3">
         <div className="flex items-center gap-2">
-          <FileCode className="text-fg-primary size-4" />
+          <Icon icon="code" className="text-fg-primary size-4" />
           <h3 className="headings-h4-semibold text-fg-primary">
             Manual Installation
           </h3>
@@ -83,7 +82,7 @@ export function InstallationGuide({ component }: InstallationGuideProps) {
       {includedFiles.length > 0 && (
         <div className="space-y-3">
           <div className="flex items-center gap-2">
-            <Package className="text-fg-primary size-4" />
+            <Icon icon="package_2" className="text-fg-primary size-4" />
             <h3 className="headings-h4-semibold text-fg-primary">
               Files Included
             </h3>

--- a/src/components/registry/mcp-tabs.tsx
+++ b/src/components/registry/mcp-tabs.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { Check, ClipboardIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { AddToCursor } from '@/components/registry/add-to-cursor';
 import { Button } from '@/components/ui/button';
+import { Icon } from '@/components/ui/icon';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 export async function copyToClipboard(value: string) {
@@ -77,7 +77,7 @@ export function MCPTabs({ rootUrl }: { rootUrl: string }) {
               setHasCopied(true);
             }}
             className="shadow-none">
-            {hasCopied ? <Check /> : <ClipboardIcon />}
+            {hasCopied ? <Icon icon="check" /> : <Icon icon="content_paste" />}
             Copy
           </Button>
         </div>

--- a/src/components/registry/navbar.tsx
+++ b/src/components/registry/navbar.tsx
@@ -1,10 +1,10 @@
-import { Search } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router';
 
 import { RegistryLogo } from '@/components/registry/registry-logo';
 import { ModeToggle } from '@/components/registry/theme-toggle';
 import { Button } from '@/components/ui/button';
+import { Icon } from '@/components/ui/icon';
 import {
   InputGroup,
   InputGroupAddon,
@@ -102,7 +102,7 @@ export function Navbar() {
               variant="outline"
               className="text-fg-secondary hover:text-fg-primary hidden h-9 items-center gap-2 px-3 md:flex"
               onClick={() => setIsSearchOpen(true)}>
-              <Search className="size-4" />
+              <Icon icon="search" className="size-4" />
               <span className="paragraph-small-primary">Search...</span>
               <kbd className="border-stroke-tertiary bg-fill-subtle paragraph-code-text text-fg-tertiary pointer-events-none hidden h-5 items-center gap-1 border px-1.5 select-none sm:flex">
                 <span className="text-xs">⌘</span>K
@@ -115,7 +115,7 @@ export function Navbar() {
               size="icon"
               className="md:hidden"
               onClick={() => setIsSearchOpen(true)}>
-              <Search className="size-5" />
+              <Icon icon="search" className="size-5" />
             </Button>
 
             {/* Theme toggle */}
@@ -147,7 +147,7 @@ export function Navbar() {
             <div className="border-stroke-tertiary border-b">
               <InputGroup className="border-0 bg-transparent">
                 <InputGroupAddon align="inline-start">
-                  <Search className="size-4" />
+                  <Icon icon="search" className="size-4" />
                 </InputGroupAddon>
                 <InputGroupInput
                   ref={searchInputRef}

--- a/src/components/registry/navbar.tsx
+++ b/src/components/registry/navbar.tsx
@@ -115,7 +115,16 @@ export function Navbar() {
               size="icon"
               className="md:hidden"
               onClick={() => setIsSearchOpen(true)}>
-              <Icon icon="search" className="size-5" />
+              <Icon
+                icon="search"
+                className="size-5"
+                style={{
+                  fontSize: 20,
+                  width: 20,
+                  height: 20,
+                  lineHeight: '20px',
+                }}
+              />
             </Button>
 
             {/* Theme toggle */}

--- a/src/components/registry/registry-sidebar.tsx
+++ b/src/components/registry/registry-sidebar.tsx
@@ -81,7 +81,11 @@ export function MobileSidebarTrigger() {
   return (
     <div className="absolute top-8 right-4 md:hidden">
       <Button aria-label="Open menu" onClick={() => setOpenMobile(true)}>
-        <Icon icon="menu" className="size-5" />
+        <Icon
+          icon="menu"
+          className="size-5"
+          style={{ fontSize: 20, width: 20, height: 20, lineHeight: '20px' }}
+        />
       </Button>
     </div>
   );

--- a/src/components/registry/registry-sidebar.tsx
+++ b/src/components/registry/registry-sidebar.tsx
@@ -1,4 +1,3 @@
-import { ChevronDown, Menu } from 'lucide-react';
 import { Link, useLocation } from 'react-router';
 
 import { Button } from '@/components/ui/button';
@@ -7,6 +6,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
+import { Icon } from '@/components/ui/icon';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   Sidebar,
@@ -81,7 +81,7 @@ export function MobileSidebarTrigger() {
   return (
     <div className="absolute top-8 right-4 md:hidden">
       <Button aria-label="Open menu" onClick={() => setOpenMobile(true)}>
-        <Menu className="size-5" />
+        <Icon icon="menu" className="size-5" />
       </Button>
     </div>
   );
@@ -135,7 +135,11 @@ export function RegistrySidebar() {
                         <CollapsibleTrigger asChild className="cursor-pointer">
                           <SidebarMenuButton className="flex w-full items-center justify-between">
                             <span>{entry.group.label}</span>
-                            <ChevronDown className="size-3.5 flex-shrink-0 transition-transform duration-200 group-data-[state=open]/subgroup:rotate-180" />
+                            <Icon
+                              icon="keyboard_arrow_down"
+                              size="sm"
+                              className="flex-shrink-0 transition-transform duration-200 group-data-[state=open]/subgroup:rotate-180"
+                            />
                           </SidebarMenuButton>
                         </CollapsibleTrigger>
                         <CollapsibleContent>

--- a/src/components/registry/theme-toggle.tsx
+++ b/src/components/registry/theme-toggle.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Moon, Sun } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { Icon } from '@/components/ui/icon';
 
 export function ModeToggle() {
   const [isDark, setIsDark] = useState(false);
@@ -60,8 +60,14 @@ export function ModeToggle() {
 
   return (
     <Button variant="outline" size="icon" onClick={toggleTheme}>
-      <Sun className="size-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
-      <Moon className="absolute size-4 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+      <Icon
+        icon="light_mode"
+        className="size-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90"
+      />
+      <Icon
+        icon="dark_mode"
+        className="absolute size-4 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0"
+      />
       <span className="sr-only">Toggle theme</span>
     </Button>
   );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -69,7 +69,7 @@ function DialogContent({
           <DialogPrimitive.Close
             data-slot="dialog-close"
             className="text-fg-secondary ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-            <Icon icon="close" size="sm" />
+            <Icon icon="close" className="size-4" />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
         )}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { XIcon } from 'lucide-react';
 import * as React from 'react';
 
+import { Icon } from '@/components/ui/icon';
 import { cn } from '@/lib/utils';
 
 function Dialog({
@@ -68,8 +68,8 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="text-fg-secondary ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
-            <XIcon />
+            className="text-fg-secondary ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+            <Icon icon="close" size="sm" />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
         )}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
-import { CheckIcon, ChevronRightIcon, Circle } from 'lucide-react';
 import * as React from 'react';
 
+import { Icon } from '@/components/ui/icon';
 import { cn } from '@/lib/utils';
 
 function DropdownMenu({
@@ -107,7 +107,7 @@ function DropdownMenuCheckboxItem({
       {...props}>
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
+          <Icon icon="check" className="size-4" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -141,7 +141,10 @@ function DropdownMenuRadioItem({
       {...props}>
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <Circle className="size-2 fill-current" />
+          <Icon
+            icon="circle"
+            style={{ fontSize: 8, width: 8, height: 8, lineHeight: '8px' }}
+          />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -229,7 +232,7 @@ function DropdownMenuSubTrigger({
       )}
       {...props}>
       {children}
-      <ChevronRightIcon className="ml-auto size-4" />
+      <Icon icon="chevron_right" className="ml-auto size-4" />
     </DropdownMenuPrimitive.SubTrigger>
   );
 }

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -143,7 +143,13 @@ function DropdownMenuRadioItem({
         <DropdownMenuPrimitive.ItemIndicator>
           <Icon
             icon="circle"
-            style={{ fontSize: 8, width: 8, height: 8, lineHeight: '8px' }}
+            style={{
+              fontSize: 8,
+              width: 8,
+              height: 8,
+              lineHeight: '8px',
+              fontVariationSettings: "'FILL' 1, 'wght' 400, 'opsz' 20",
+            }}
           />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -156,7 +156,13 @@ function MenubarRadioItem({
         <MenubarPrimitive.ItemIndicator>
           <Icon
             icon="circle"
-            style={{ fontSize: 4, width: 4, height: 4, lineHeight: '4px' }}
+            style={{
+              fontSize: 4,
+              width: 4,
+              height: 4,
+              lineHeight: '4px',
+              fontVariationSettings: "'FILL' 1, 'wght' 400, 'opsz' 20",
+            }}
           />
         </MenubarPrimitive.ItemIndicator>
       </span>

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import * as MenubarPrimitive from '@radix-ui/react-menubar';
-import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
 import type * as React from 'react';
 
+import { Icon } from '@/components/ui/icon';
 import { cn } from '@/lib/utils';
 
 function Menubar({
@@ -128,7 +128,10 @@ function MenubarCheckboxItem({
       {...props}>
       <span className="pointer-events-none absolute left-1 flex size-1.75 items-center justify-center">
         <MenubarPrimitive.ItemIndicator>
-          <CheckIcon className="size-2" />
+          <Icon
+            icon="check"
+            style={{ fontSize: 8, width: 8, height: 8, lineHeight: '8px' }}
+          />
         </MenubarPrimitive.ItemIndicator>
       </span>
       {children}
@@ -151,7 +154,10 @@ function MenubarRadioItem({
       {...props}>
       <span className="pointer-events-none absolute left-1 flex size-1.75 items-center justify-center">
         <MenubarPrimitive.ItemIndicator>
-          <CircleIcon className="size-1 fill-current" />
+          <Icon
+            icon="circle"
+            style={{ fontSize: 4, width: 4, height: 4, lineHeight: '4px' }}
+          />
         </MenubarPrimitive.ItemIndicator>
       </span>
       {children}
@@ -232,7 +238,11 @@ function MenubarSubTrigger({
       )}
       {...props}>
       {children}
-      <ChevronRightIcon className="ml-auto size-2" />
+      <Icon
+        icon="chevron_right"
+        className="ml-auto"
+        style={{ fontSize: 8, width: 8, height: 8, lineHeight: '8px' }}
+      />
     </MenubarPrimitive.SubTrigger>
   );
 }

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -2,10 +2,10 @@
 
 import { Slot } from '@radix-ui/react-slot';
 import { type VariantProps, cva } from 'class-variance-authority';
-import { PanelLeftIcon } from 'lucide-react';
 import * as React from 'react';
 
 import { Button } from '@/components/ui/button';
+import { Icon } from '@/components/ui/icon';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -234,7 +234,7 @@ function SidebarTrigger({
         toggleSidebar();
       }}
       {...props}>
-      <PanelLeftIcon />
+      <Icon icon="left_panel_open" size="sm" />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   );


### PR DESCRIPTION
## Summary

Replaces every Lucide icon import across the codebase with the in-house `<Icon>` component (Material Symbols Sharp variable font). Removes `lucide-react` as a dependency.

Closes https://github.com/McK-Internal/qbds-internal/issues/95

### Icon mapping

| Lucide | Material Symbols ligature |
|---|---|
| `XIcon` | `close` |
| `CheckIcon` / `Check` | `check` |
| `ChevronRightIcon` | `chevron_right` |
| `Circle` / `CircleIcon` | `circle` |
| `PanelLeftIcon` | `left_panel_open` |
| `Copy` | `content_copy` |
| `ClipboardIcon` | `content_paste` |
| `FileCode` | `code` |
| `Package` | `package_2` |
| `Terminal` | `terminal` |
| `Search` | `search` |
| `ChevronDown` | `keyboard_arrow_down` |
| `Menu` | `menu` |
| `Moon` | `dark_mode` |
| `Sun` | `light_mode` |

### Files touched

**Shipped registry components** (`src/components/ui/`)
- `dialog.tsx`, `dropdown-menu.tsx`, `menubar.tsx`, `sidebar.tsx`

**Registry site UI** (`src/components/registry/`)
- `code-block.tsx`, `example-preview.tsx`, `installation-guide.tsx`, `mcp-tabs.tsx`, `navbar.tsx`, `registry-sidebar.tsx`, `theme-toggle.tsx`

**Config**
- `registry.json` — added `icon.json` as a registry dependency on `dialog` (dropdown-menu already depended on it) so the shadcn CLI pulls the Icon component when consumers install Dialog.
- `package.json` / `package-lock.json` — removed `lucide-react`.

### Notes on sizing

The `<Icon>` component infers size from `size-4`/`size-5`/`size-6`/`size-8` className utilities (sm/sm/default/lg). For Lucide call sites using non-standard utilities like `size-3.5`, `size-2`, or `size-1`, the inferred size would fall back to default (24px), so those were either bumped to the nearest standard size (e.g. `size-3.5` → `size-4`) or given an explicit inline `fontSize`/`width`/`height` override to preserve the original pixel size. The radio indicators in `dropdown-menu.tsx` and `menubar.tsx` use inline overrides (8px / 4px) so the dot stays small inside its container.

## Test plan
- [ ] Verify Dialog close button renders the Material Symbols `close` glyph at 16px.
- [ ] Verify Dropdown Menu checkbox/radio indicators render correctly (`check` glyph, small filled `circle`) and sub-menu trigger shows the right chevron.
- [ ] Verify Sidebar trigger button renders `left_panel_open`.
- [ ] Verify navbar search input and search button render the `search` glyph.
- [ ] Verify the registry sidebar mobile trigger (`menu`) and collapsible group chevron (`keyboard_arrow_down`) render and rotate correctly.
- [ ] Verify theme toggle: sun glyph in light mode, moon glyph in dark mode, with the existing rotate/scale transition.
- [ ] Verify code block / example preview copy buttons swap between `content_copy` and `check` on click.
- [ ] Verify installation guide section icons (`terminal`, `code`, `package_2`) render.
- [ ] Verify MCP tabs copy button toggles between `content_paste` and `check`.
- [ ] Designer review pass for visual fidelity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)