### PR TITLE
chore: add @huong-li-nguyen to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @pruthvip15 @tynandebold @ottis @Joseph-Perkins
+*   @pruthvip15 @tynandebold @ottis @Joseph-Perkins @huong-li-nguyen


### PR DESCRIPTION
## Summary
- Add `@huong-li-nguyen` to the wildcard CODEOWNERS entry so she is auto-requested on all PRs.

## Test plan
- [x] Confirm CODEOWNERS file parses (GitHub validates automatically on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)