### PR TITLE
fix(input-group-demo): replace dangling icon imports with Icon component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -579,7 +579,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -603,7 +602,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4742,7 +4740,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4832,7 +4829,6 @@
       "integrity": "sha512-3DgfkukFyC/sE/VuYjaUUWoFfuVjPK55vOFDsxD56XXynFMCZDYFogH2l/hDfOsQAm1myoU/1xByJ3tWqtulXA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@babel/generator": "^7.28.0",
         "@babel/parser": "^7.28.0",
@@ -5077,7 +5073,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5088,7 +5083,6 @@
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5112,7 +5106,6 @@
       "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.57.2",
@@ -5152,7 +5145,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -5549,7 +5541,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7001,8 +6992,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -7322,7 +7312,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7383,7 +7372,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9078,7 +9066,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -10260,7 +10247,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10783,7 +10769,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10825,7 +10810,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10838,7 +10822,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
       "integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -12258,7 +12241,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -12393,7 +12375,6 @@
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12721,7 +12702,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13254,7 +13234,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/demo/[name]/ui/input-group-config.ts
+++ b/src/app/demo/[name]/ui/input-group-config.ts
@@ -4,18 +4,18 @@ export const inputGroupFieldConfig = {
     label: 'label-small-primary text-fg-secondary',
     description: 'paragraph-small-primary text-fg-tertiary',
     gap: 'gap-2',
-    iconSize: 'text-[16px]',
+    iconSize: 'sm',
   },
   default: {
     label: 'label-regular-primary text-fg-secondary',
     description: 'paragraph-regular-primary text-fg-tertiary',
     gap: 'gap-2',
-    iconSize: 'text-[16px]',
+    iconSize: 'sm',
   },
   lg: {
     label: 'label-large-primary text-fg-secondary',
     description: 'paragraph-regular-primary text-fg-tertiary',
     gap: 'gap-2',
-    iconSize: 'text-[24px]',
+    iconSize: 'default',
   },
 } as const;

--- a/src/app/demo/[name]/ui/input-group-examples.tsx
+++ b/src/app/demo/[name]/ui/input-group-examples.tsx
@@ -300,7 +300,8 @@ export function InputGroupDeleteOnFocus() {
               <InputGroupText>
                 <Icon
                   icon="search"
-                  className={`icon ${iconSize}`}
+                  size={iconSize}
+                  className="icon"
                   aria-hidden
                 />
               </InputGroupText>

--- a/src/app/demo/[name]/ui/input-group.tsx
+++ b/src/app/demo/[name]/ui/input-group.tsx
@@ -46,7 +46,7 @@ export function InputGroupDemo() {
       <FieldTitle className={label}>Label</FieldTitle>
       <InputGroup>
         <LeadingIcon>
-          <Icon icon="search" className={`icon ${iconSize}`} />
+          <Icon icon="search" size={iconSize} className="icon" />
         </LeadingIcon>
         <InputGroupInput placeholder="Placeholder" />
       </InputGroup>
@@ -65,7 +65,7 @@ export function InputGroupLeadingIcon() {
         <FieldTitle className={label}>Label</FieldTitle>
         <InputGroup>
           <LeadingIcon>
-            <Icon icon="mail" className={`icon ${iconSize}`} />
+            <Icon icon="mail" size={iconSize} className="icon" />
           </LeadingIcon>
           <InputGroupInput type="email" placeholder="Placeholder" />
         </InputGroup>
@@ -76,7 +76,7 @@ export function InputGroupLeadingIcon() {
         <FieldTitle className={label}>Label</FieldTitle>
         <InputGroup>
           <LeadingIcon>
-            <Icon icon="person" className={`icon ${iconSize}`} />
+            <Icon icon="person" size={iconSize} className="icon" />
           </LeadingIcon>
           <InputGroupInput placeholder="Placeholder" />
         </InputGroup>
@@ -109,7 +109,7 @@ export function InputGroupTrailing() {
           <InputGroupInput placeholder="Placeholder" />
           <InputGroupAddon align="inline-end">
             <InputGroupButton size="icon-xs" variant="ghost">
-              <Icon icon="send" className={`icon ${iconSize}`} />
+              <Icon icon="send" size={iconSize} className="icon" />
             </InputGroupButton>
           </InputGroupAddon>
         </InputGroup>
@@ -128,7 +128,7 @@ export function InputGroupBothSides() {
       <FieldTitle className={label}>Label</FieldTitle>
       <InputGroup>
         <LeadingIcon>
-          <Icon icon="attach_money" className={`icon ${iconSize}`} />
+          <Icon icon="attach_money" size={iconSize} className="icon" />
         </LeadingIcon>
         <InputGroupInput type="number" placeholder="Placeholder" />
         <InputGroupAddon align="inline-end">
@@ -165,7 +165,7 @@ export function InputGroupSizes() {
               <FieldTitle className={labelClass}>Label</FieldTitle>
               <InputGroup size={size}>
                 <LeadingIcon>
-                  <Icon icon="search" className={`icon ${iconSize}`} />
+                  <Icon icon="search" size={iconSize} className="icon" />
                 </LeadingIcon>
                 <InputGroupInput size={size} placeholder="Placeholder" />
               </InputGroup>
@@ -178,7 +178,7 @@ export function InputGroupSizes() {
               <FieldTitle className={inlineLabelClass}>Label</FieldTitle>
               <InputGroup variant="inline" size={size}>
                 <LeadingIcon>
-                  <Icon icon="search" className={`icon ${iconSize}`} />
+                  <Icon icon="search" size={iconSize} className="icon" />
                 </LeadingIcon>
                 <InputGroupInput
                   variant="inline"
@@ -264,7 +264,8 @@ export function InputGroupStatusStates() {
                   <InputGroupText>
                     <Icon
                       icon={statusIcon}
-                      className={`${iconSize} ${statusColor}`}
+                      size={iconSize}
+                      className={statusColor}
                     />
                   </InputGroupText>
                 </InputGroupAddon>
@@ -285,7 +286,8 @@ export function InputGroupStatusStates() {
                   <InputGroupText>
                     <Icon
                       icon={statusIcon}
-                      className={`${iconSize} ${statusColor}`}
+                      size={iconSize}
+                      className={statusColor}
                     />
                   </InputGroupText>
                 </InputGroupAddon>

--- a/src/app/demo/[name]/ui/input-group.tsx
+++ b/src/app/demo/[name]/ui/input-group.tsx
@@ -210,7 +210,7 @@ export function InputGroupStatusStates() {
   const statuses = [
     {
       label: 'Error',
-      icon: Cancel,
+      icon: 'cancel',
       statusColor: 'text-status-error',
       defaultInputProps: {
         'aria-invalid': true,
@@ -225,7 +225,7 @@ export function InputGroupStatusStates() {
     },
     {
       label: 'Warning',
-      icon: Info,
+      icon: 'info',
       statusColor: 'text-status-warning',
       defaultInputProps: { placeholder: 'Placeholder' },
       inlineInputProps: { placeholder: 'Placeholder' },
@@ -234,7 +234,7 @@ export function InputGroupStatusStates() {
     },
     {
       label: 'Success',
-      icon: CheckCircle,
+      icon: 'check_circle',
       statusColor: 'text-status-success',
       defaultInputProps: { placeholder: 'Placeholder' },
       inlineInputProps: { placeholder: 'Placeholder' },
@@ -248,7 +248,7 @@ export function InputGroupStatusStates() {
       {statuses.map(
         ({
           label,
-          icon: StatusIcon,
+          icon: statusIcon,
           statusColor,
           defaultInputProps,
           inlineInputProps,
@@ -262,7 +262,10 @@ export function InputGroupStatusStates() {
                 <InputGroupInput {...defaultInputProps} />
                 <InputGroupAddon align="inline-end">
                   <InputGroupText>
-                    <StatusIcon className={`${iconSize} ${statusColor}`} />
+                    <Icon
+                      icon={statusIcon}
+                      className={`${iconSize} ${statusColor}`}
+                    />
                   </InputGroupText>
                 </InputGroupAddon>
               </InputGroup>
@@ -280,7 +283,10 @@ export function InputGroupStatusStates() {
                 <InputGroupInput variant="inline" {...inlineInputProps} />
                 <InputGroupAddon align="inline-end">
                   <InputGroupText>
-                    <StatusIcon className={`${iconSize} ${statusColor}`} />
+                    <Icon
+                      icon={statusIcon}
+                      className={`${iconSize} ${statusColor}`}
+                    />
                   </InputGroupText>
                 </InputGroupAddon>
               </InputGroup>


### PR DESCRIPTION
## Summary
- The `/registry/input-group` page crashed on load with `ReferenceError: Cancel is not defined`.
- `InputGroupStatusStates` was still referencing `Cancel`, `Info`, and `CheckCircle` as components, but those per-icon files were removed when the icon system migrated to the universal `<Icon icon="..."/>` ligature API (PR #46).
- Swapped the three references to ligature strings (`'cancel'`, `'info'`, `'check_circle'`) and render via `<Icon icon={statusIcon} … />`.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm run test:unit` passes (123 tests)
- [ ] Verify `/registry/input-group` loads and the Error/Warning/Success row renders the correct status icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)