### PR TITLE
feat(comp): add `ButtonGroup` as a new component

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -115,6 +115,25 @@
       ]
     },
     {
+      "name": "button-group",
+      "type": "registry:ui",
+      "title": "Button Group",
+      "description": "Groups related buttons together with consistent QBDS spacing. Supports horizontal and vertical orientation and size-driven gaps (sm, default, lg).",
+      "dependencies": [
+        "class-variance-authority"
+      ],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json"
+      ],
+      "files": [
+        {
+          "path": "src/components/ui/button-group.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "calendar",
       "type": "registry:ui",
       "title": "Calendar",

--- a/src/app/demo/[name]/index.tsx
+++ b/src/app/demo/[name]/index.tsx
@@ -57,7 +57,6 @@ import {
   examples as buttonExamples,
 } from '@/app/demo/[name]/ui/button';
 import {
-  ButtonGroupAlignment,
   ButtonGroupConfigs,
   ButtonGroupDemo,
   ButtonGroupIconOnly,
@@ -430,7 +429,6 @@ export const exampleComponentMaps: Record<
   'button-group': {
     ButtonGroupDemo,
     ButtonGroupConfigs,
-    ButtonGroupAlignment,
     ButtonGroupSizes,
     ButtonGroupVertical,
     ButtonGroupIconOnly,

--- a/src/app/demo/[name]/index.tsx
+++ b/src/app/demo/[name]/index.tsx
@@ -58,6 +58,15 @@ import {
   examples as buttonExamples,
 } from '@/app/demo/[name]/ui/button';
 import {
+  ButtonGroupConfigs,
+  ButtonGroupDemo,
+  ButtonGroupIconOnly,
+  ButtonGroupSizes,
+  ButtonGroupVertical,
+  buttonGroup,
+  examples as buttonGroupExamples,
+} from '@/app/demo/[name]/ui/button-group';
+import {
   CalendarDemo,
   CalendarDisabledDays,
   CalendarPreSelected,
@@ -419,6 +428,13 @@ export const exampleComponentMaps: Record<
     ButtonIconRounded,
     ButtonGroups,
   },
+  'button-group': {
+    ButtonGroupDemo,
+    ButtonGroupConfigs,
+    ButtonGroupSizes,
+    ButtonGroupVertical,
+    ButtonGroupIconOnly,
+  },
   calendar: {
     CalendarDemo,
     CalendarRange,
@@ -662,6 +678,7 @@ export const examplesMeta: Record<string, ExampleMeta[]> = {
   avatar: avatarExamples,
   badge: badgeExamples,
   button: buttonExamples,
+  'button-group': buttonGroupExamples,
   calendar: calendarExamples,
   card: cardExamples,
   checkbox: checkboxExamples,
@@ -722,6 +739,11 @@ export const demos: { [name: string]: Demo | NewDemo } = {
     ...button,
     examples: buttonExamples,
     exampleComponents: exampleComponentMaps.button,
+  },
+  'button-group': {
+    ...buttonGroup,
+    examples: buttonGroupExamples,
+    exampleComponents: exampleComponentMaps['button-group'],
   },
   calendar: {
     ...calendar,

--- a/src/app/demo/[name]/index.tsx
+++ b/src/app/demo/[name]/index.tsx
@@ -47,7 +47,6 @@ import {
 import {
   ButtonDemo,
   ButtonDisabled,
-  ButtonGroups,
   ButtonIconOnly,
   ButtonIconRounded,
   ButtonLoading,
@@ -58,6 +57,7 @@ import {
   examples as buttonExamples,
 } from '@/app/demo/[name]/ui/button';
 import {
+  ButtonGroupAlignment,
   ButtonGroupConfigs,
   ButtonGroupDemo,
   ButtonGroupIconOnly,
@@ -426,11 +426,11 @@ export const exampleComponentMaps: Record<
     ButtonLoading,
     ButtonIconOnly,
     ButtonIconRounded,
-    ButtonGroups,
   },
   'button-group': {
     ButtonGroupDemo,
     ButtonGroupConfigs,
+    ButtonGroupAlignment,
     ButtonGroupSizes,
     ButtonGroupVertical,
     ButtonGroupIconOnly,

--- a/src/app/demo/[name]/ui/button-group.tsx
+++ b/src/app/demo/[name]/ui/button-group.tsx
@@ -16,8 +16,50 @@ export function ButtonGroupDemo() {
   );
 }
 
-/** Common CTA pairings */
+/**
+ * CTA pairings: a primary action (mono `default` or `accent`) paired with a
+ * secondary-style action (`secondary`, `outline`, or `ghost`).
+ */
 export function ButtonGroupConfigs() {
+  return (
+    <div className="grid grid-cols-2 gap-x-8 gap-y-4">
+      {/* Mono primary */}
+      <div className="flex flex-col gap-4">
+        <ButtonGroup>
+          <Button variant="default">Button</Button>
+          <Button variant="secondary">Button</Button>
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button variant="default">Button</Button>
+          <Button variant="outline">Button</Button>
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button variant="default">Button</Button>
+          <Button variant="ghost">Button</Button>
+        </ButtonGroup>
+      </div>
+
+      {/* Accent primary */}
+      <div className="flex flex-col gap-4">
+        <ButtonGroup>
+          <Button variant="accent">Button</Button>
+          <Button variant="secondary">Button</Button>
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button variant="accent">Button</Button>
+          <Button variant="outline">Button</Button>
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button variant="accent">Button</Button>
+          <Button variant="ghost">Button</Button>
+        </ButtonGroup>
+      </div>
+    </div>
+  );
+}
+
+/** CTA alignment — primary leading (left) vs primary trailing (right) */
+export function ButtonGroupAlignment() {
   return (
     <div className="flex flex-col gap-4">
       <ButtonGroup>
@@ -26,13 +68,8 @@ export function ButtonGroupConfigs() {
       </ButtonGroup>
 
       <ButtonGroup>
+        <Button variant="secondary">Button</Button>
         <Button variant="default">Button</Button>
-        <Button variant="ghost">Button</Button>
-      </ButtonGroup>
-
-      <ButtonGroup>
-        <Button variant="accent">Button</Button>
-        <Button variant="outline">Button</Button>
       </ButtonGroup>
     </div>
   );
@@ -127,7 +164,12 @@ export const examples: DemoExample[] = [
     name: 'ButtonGroupConfigs',
     title: 'Configurations',
     description:
-      'Common CTA pairings: primary + secondary, primary + ghost, and accent + outline.',
+      'A primary action (mono or accent) paired with a secondary, outline, or ghost action.',
+  },
+  {
+    name: 'ButtonGroupAlignment',
+    title: 'Alignment',
+    description: 'The primary action can lead (left) or trail (right).',
   },
   {
     name: 'ButtonGroupSizes',
@@ -149,6 +191,7 @@ export const examples: DemoExample[] = [
 export const buttonGroup = createLegacyDemo('button-group', examples, {
   ButtonGroupDemo: <ButtonGroupDemo />,
   ButtonGroupConfigs: <ButtonGroupConfigs />,
+  ButtonGroupAlignment: <ButtonGroupAlignment />,
   ButtonGroupSizes: <ButtonGroupSizes />,
   ButtonGroupVertical: <ButtonGroupVertical />,
   ButtonGroupIconOnly: <ButtonGroupIconOnly />,

--- a/src/app/demo/[name]/ui/button-group.tsx
+++ b/src/app/demo/[name]/ui/button-group.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { ButtonGroup } from '@/components/ui/button-group';
+import { Icon } from '@/components/ui/icon';
+import { IconShell } from '@/components/ui/icon-shell';
+import { type DemoExample, createLegacyDemo } from '@/lib/demo-utils';
+
+/** Default button group — a primary action paired with a secondary action */
+export function ButtonGroupDemo() {
+  return (
+    <ButtonGroup>
+      <Button variant="default">Save</Button>
+      <Button variant="secondary">Cancel</Button>
+    </ButtonGroup>
+  );
+}
+
+/** Common CTA pairings */
+export function ButtonGroupConfigs() {
+  return (
+    <div className="flex flex-col gap-4">
+      <ButtonGroup>
+        <Button variant="default">Button</Button>
+        <Button variant="secondary">Button</Button>
+      </ButtonGroup>
+
+      <ButtonGroup>
+        <Button variant="default">Button</Button>
+        <Button variant="ghost">Button</Button>
+      </ButtonGroup>
+
+      <ButtonGroup>
+        <Button variant="accent">Button</Button>
+        <Button variant="outline">Button</Button>
+      </ButtonGroup>
+    </div>
+  );
+}
+
+/** Gap sizes — sm (8px), default (12px), lg (16px) */
+export function ButtonGroupSizes() {
+  return (
+    <div className="flex flex-col items-start gap-4">
+      <ButtonGroup size="sm">
+        <Button size="sm" variant="default">
+          Button
+        </Button>
+        <Button size="sm" variant="secondary">
+          Button
+        </Button>
+      </ButtonGroup>
+
+      <ButtonGroup size="default">
+        <Button variant="default">Button</Button>
+        <Button variant="secondary">Button</Button>
+      </ButtonGroup>
+
+      <ButtonGroup size="lg">
+        <Button size="lg" variant="default">
+          Button
+        </Button>
+        <Button size="lg" variant="secondary">
+          Button
+        </Button>
+      </ButtonGroup>
+    </div>
+  );
+}
+
+/** Vertical orientation */
+export function ButtonGroupVertical() {
+  return (
+    <ButtonGroup orientation="vertical">
+      <Button variant="default">Button</Button>
+      <Button variant="secondary">Button</Button>
+      <Button variant="ghost">Button</Button>
+    </ButtonGroup>
+  );
+}
+
+/** Icon-only buttons, horizontal and vertical */
+export function ButtonGroupIconOnly() {
+  return (
+    <div className="flex items-start gap-8">
+      <ButtonGroup>
+        <Button aria-label="Bold" size="icon" variant="outline">
+          <IconShell size="sm">
+            <Icon icon="format_bold" />
+          </IconShell>
+        </Button>
+        <Button aria-label="Italic" size="icon" variant="outline">
+          <IconShell size="sm">
+            <Icon icon="format_italic" />
+          </IconShell>
+        </Button>
+        <Button aria-label="Underline" size="icon" variant="outline">
+          <IconShell size="sm">
+            <Icon icon="format_underlined" />
+          </IconShell>
+        </Button>
+      </ButtonGroup>
+
+      <ButtonGroup orientation="vertical">
+        <Button aria-label="Zoom in" size="icon" variant="outline">
+          <IconShell size="sm">
+            <Icon icon="add" />
+          </IconShell>
+        </Button>
+        <Button aria-label="Zoom out" size="icon" variant="outline">
+          <IconShell size="sm">
+            <Icon icon="remove" />
+          </IconShell>
+        </Button>
+      </ButtonGroup>
+    </div>
+  );
+}
+
+export const examples: DemoExample[] = [
+  {
+    name: 'ButtonGroupDemo',
+    title: 'Default',
+    description: 'A primary action paired with a secondary action.',
+  },
+  {
+    name: 'ButtonGroupConfigs',
+    title: 'Configurations',
+    description:
+      'Common CTA pairings: primary + secondary, primary + ghost, and accent + outline.',
+  },
+  {
+    name: 'ButtonGroupSizes',
+    title: 'Sizes',
+    description: 'Inter-button gap scales with size: sm, default, and lg.',
+  },
+  {
+    name: 'ButtonGroupVertical',
+    title: 'Vertical',
+    description: 'Buttons stacked with vertical orientation.',
+  },
+  {
+    name: 'ButtonGroupIconOnly',
+    title: 'Icon Only',
+    description: 'Icon-only buttons grouped horizontally and vertically.',
+  },
+];
+
+export const buttonGroup = createLegacyDemo('button-group', examples, {
+  ButtonGroupDemo: <ButtonGroupDemo />,
+  ButtonGroupConfigs: <ButtonGroupConfigs />,
+  ButtonGroupSizes: <ButtonGroupSizes />,
+  ButtonGroupVertical: <ButtonGroupVertical />,
+  ButtonGroupIconOnly: <ButtonGroupIconOnly />,
+});

--- a/src/app/demo/[name]/ui/button-group.tsx
+++ b/src/app/demo/[name]/ui/button-group.tsx
@@ -18,12 +18,13 @@ export function ButtonGroupDemo() {
 
 /**
  * CTA pairings: a primary action (mono `default` or `accent`) paired with a
- * secondary-style action (`secondary`, `outline`, or `ghost`).
+ * secondary-style action (`secondary`, `outline`, or `ghost`). Each pairing is
+ * shown with the primary leading (left column) and trailing (right column).
  */
 export function ButtonGroupConfigs() {
   return (
-    <div className="grid grid-cols-2 gap-x-8 gap-y-4">
-      {/* Mono primary */}
+    <div className="grid grid-cols-2 gap-x-16 gap-y-4">
+      {/* Primary leading */}
       <div className="flex flex-col gap-4">
         <ButtonGroup>
           <Button variant="default">Button</Button>
@@ -37,10 +38,6 @@ export function ButtonGroupConfigs() {
           <Button variant="default">Button</Button>
           <Button variant="ghost">Button</Button>
         </ButtonGroup>
-      </div>
-
-      {/* Accent primary */}
-      <div className="flex flex-col gap-4">
         <ButtonGroup>
           <Button variant="accent">Button</Button>
           <Button variant="secondary">Button</Button>
@@ -54,23 +51,34 @@ export function ButtonGroupConfigs() {
           <Button variant="ghost">Button</Button>
         </ButtonGroup>
       </div>
-    </div>
-  );
-}
 
-/** CTA alignment — primary leading (left) vs primary trailing (right) */
-export function ButtonGroupAlignment() {
-  return (
-    <div className="flex flex-col gap-4">
-      <ButtonGroup>
-        <Button variant="default">Button</Button>
-        <Button variant="secondary">Button</Button>
-      </ButtonGroup>
-
-      <ButtonGroup>
-        <Button variant="secondary">Button</Button>
-        <Button variant="default">Button</Button>
-      </ButtonGroup>
+      {/* Primary trailing (reversed) */}
+      <div className="flex flex-col gap-4">
+        <ButtonGroup>
+          <Button variant="secondary">Button</Button>
+          <Button variant="default">Button</Button>
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button variant="outline">Button</Button>
+          <Button variant="default">Button</Button>
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button variant="ghost">Button</Button>
+          <Button variant="default">Button</Button>
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button variant="secondary">Button</Button>
+          <Button variant="accent">Button</Button>
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button variant="outline">Button</Button>
+          <Button variant="accent">Button</Button>
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button variant="ghost">Button</Button>
+          <Button variant="accent">Button</Button>
+        </ButtonGroup>
+      </div>
     </div>
   );
 }
@@ -164,12 +172,7 @@ export const examples: DemoExample[] = [
     name: 'ButtonGroupConfigs',
     title: 'Configurations',
     description:
-      'A primary action (mono or accent) paired with a secondary, outline, or ghost action.',
-  },
-  {
-    name: 'ButtonGroupAlignment',
-    title: 'Alignment',
-    description: 'The primary action can lead (left) or trail (right).',
+      'A primary action (mono or accent) paired with a secondary, outline, or ghost action, shown leading (left) and trailing (right).',
   },
   {
     name: 'ButtonGroupSizes',
@@ -191,7 +194,6 @@ export const examples: DemoExample[] = [
 export const buttonGroup = createLegacyDemo('button-group', examples, {
   ButtonGroupDemo: <ButtonGroupDemo />,
   ButtonGroupConfigs: <ButtonGroupConfigs />,
-  ButtonGroupAlignment: <ButtonGroupAlignment />,
   ButtonGroupSizes: <ButtonGroupSizes />,
   ButtonGroupVertical: <ButtonGroupVertical />,
   ButtonGroupIconOnly: <ButtonGroupIconOnly />,

--- a/src/app/demo/[name]/ui/button.tsx
+++ b/src/app/demo/[name]/ui/button.tsx
@@ -157,136 +157,6 @@ export function ButtonIconRounded() {
   );
 }
 
-/** Button groups / CTAs */
-export function ButtonGroups() {
-  return (
-    <div className="grid grid-cols-2 gap-x-8 gap-y-4">
-      {/* Left column: secondary | secondary, secondary | ghost, default | secondary, default | ghost */}
-      <div className="flex flex-col gap-4">
-        <div className="flex items-center gap-3">
-          <Button variant="secondary">Button</Button>
-          <Button variant="secondary">Button</Button>
-        </div>
-        <div className="flex items-center gap-3">
-          <Button variant="secondary">Button</Button>
-          <Button variant="ghost">Button</Button>
-        </div>
-        <div className="flex items-center gap-3">
-          <Button variant="default">Button</Button>
-          <Button variant="secondary">Button</Button>
-        </div>
-        <div className="flex items-center gap-3">
-          <Button variant="default">Button</Button>
-          <Button variant="ghost">Button</Button>
-        </div>
-      </div>
-      {/* Right column: outline | secondary, ghost | secondary, outline | default, ghost | default */}
-      <div className="flex flex-col gap-4">
-        <div className="flex items-center gap-3">
-          <Button variant="outline">Button</Button>
-          <Button variant="secondary">Button</Button>
-        </div>
-        <div className="flex items-center gap-3">
-          <Button variant="ghost">Button</Button>
-          <Button variant="secondary">Button</Button>
-        </div>
-        <div className="flex items-center gap-3">
-          <Button variant="outline">Button</Button>
-          <Button variant="default">Button</Button>
-        </div>
-        <div className="flex items-center gap-3">
-          <Button variant="ghost">Button</Button>
-          <Button variant="default">Button</Button>
-        </div>
-      </div>
-
-      {/* Accent + outline (left) | outline + accent (right, variants interchanged) */}
-      <div className="flex flex-col gap-4">
-        <div className="flex items-center gap-3">
-          <Button variant="accent">Button</Button>
-          <Button variant="outline">Button</Button>
-        </div>
-      </div>
-      <div className="flex flex-col gap-4">
-        <div className="flex items-center gap-3">
-          <Button variant="outline">Button</Button>
-          <Button variant="accent">Button</Button>
-        </div>
-      </div>
-
-      {/* Different sizes – default | secondary (left) | secondary | default (right, variants interchanged) */}
-      <div className="flex flex-col gap-4">
-        <div className="flex items-center gap-3">
-          <Button variant="default" size="xs">
-            Button
-          </Button>
-          <Button variant="secondary" size="xs">
-            Button
-          </Button>
-        </div>
-        <div className="flex items-center gap-3">
-          <Button variant="default" size="sm">
-            Button
-          </Button>
-          <Button variant="secondary" size="sm">
-            Button
-          </Button>
-        </div>
-        <div className="flex items-center gap-3">
-          <Button variant="default" size="default">
-            Button
-          </Button>
-          <Button variant="secondary" size="default">
-            Button
-          </Button>
-        </div>
-        <div className="flex items-center gap-3">
-          <Button variant="default" size="lg">
-            Button
-          </Button>
-          <Button variant="secondary" size="lg">
-            Button
-          </Button>
-        </div>
-      </div>
-      <div className="flex flex-col gap-4">
-        <div className="flex items-center gap-3">
-          <Button variant="secondary" size="xs">
-            Button
-          </Button>
-          <Button variant="default" size="xs">
-            Button
-          </Button>
-        </div>
-        <div className="flex items-center gap-3">
-          <Button variant="secondary" size="sm">
-            Button
-          </Button>
-          <Button variant="default" size="sm">
-            Button
-          </Button>
-        </div>
-        <div className="flex items-center gap-3">
-          <Button variant="secondary" size="default">
-            Button
-          </Button>
-          <Button variant="default" size="default">
-            Button
-          </Button>
-        </div>
-        <div className="flex items-center gap-3">
-          <Button variant="secondary" size="lg">
-            Button
-          </Button>
-          <Button variant="default" size="lg">
-            Button
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export const examples: DemoExample[] = [
   {
     name: 'ButtonDemo',
@@ -329,12 +199,6 @@ export const examples: DemoExample[] = [
     title: 'Rounded Icons',
     description: 'Circular icon buttons using rounded-full class.',
   },
-  {
-    name: 'ButtonGroups',
-    title: 'Button Groups / CTAs',
-    description:
-      'Pairs of buttons for primary and secondary actions: default, secondary, and outline combinations.',
-  },
 ];
 
 export const button = createLegacyDemo('button', examples, {
@@ -346,5 +210,4 @@ export const button = createLegacyDemo('button', examples, {
   ButtonLoading: <ButtonLoading />,
   ButtonIconOnly: <ButtonIconOnly />,
   ButtonIconRounded: <ButtonIconRounded />,
-  ButtonGroups: <ButtonGroups />,
 });

--- a/src/components/registry/registry-sidebar.tsx
+++ b/src/components/registry/registry-sidebar.tsx
@@ -30,7 +30,7 @@ const COMPONENT_GROUPS: { label: string; names: string[] }[] = [
   { label: 'Layout', names: ['aspect-ratio'] },
   {
     label: 'Buttons & Toggle',
-    names: ['button', 'segmented-controls', 'toggle'],
+    names: ['button', 'button-group', 'segmented-controls', 'toggle'],
   },
   {
     label: 'Date & Time',

--- a/src/components/ui/button-group.tsx
+++ b/src/components/ui/button-group.tsx
@@ -1,0 +1,62 @@
+import { type VariantProps, cva } from 'class-variance-authority';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+// Gap between grouped buttons scales with the size variant to match the Figma
+// spacing tokens (sm = 8px, default = 12px, lg = 16px).
+const buttonGroupVariants = cva('flex w-fit', {
+  variants: {
+    orientation: {
+      horizontal: 'flex-row items-center',
+      vertical: 'flex-col items-stretch',
+    },
+    size: {
+      sm: 'gap-2',
+      default: 'gap-3',
+      lg: 'gap-4',
+    },
+  },
+  defaultVariants: {
+    orientation: 'horizontal',
+    size: 'default',
+  },
+});
+
+interface ButtonGroupProps
+  extends
+    React.ComponentProps<'div'>,
+    VariantProps<typeof buttonGroupVariants> {}
+
+/**
+ * Groups related buttons together with consistent QBDS spacing.
+ *
+ * Place `Button` children inside and choose their variants (e.g. a primary
+ * action paired with a secondary or ghost action). The group only controls
+ * layout: `orientation` for direction and `size` for the inter-button gap.
+ *
+ * @example
+ * ```tsx
+ * <ButtonGroup>
+ *   <Button variant="default">Save</Button>
+ *   <Button variant="ghost">Cancel</Button>
+ * </ButtonGroup>
+ * ```
+ */
+function ButtonGroup({
+  className,
+  orientation,
+  size,
+  ...props
+}: ButtonGroupProps) {
+  return (
+    <div
+      data-slot="button-group"
+      role="group"
+      className={cn(buttonGroupVariants({ orientation, size }), className)}
+      {...props}
+    />
+  );
+}
+
+export { ButtonGroup, buttonGroupVariants, type ButtonGroupProps };

--- a/src/tests/button-group.test.tsx
+++ b/src/tests/button-group.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { exampleComponentMaps } from '@/app/demo/[name]/index';
+import { Renderer } from '@/app/demo/[name]/renderer';
+import { Button } from '@/components/ui/button';
+import { ButtonGroup } from '@/components/ui/button-group';
+
+const componentName = 'button-group';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe(`${componentName} — all examples render`, () => {
+  it.each(Object.entries(exampleComponentMaps[componentName]))(
+    'renders "%s" without crashing',
+    (_, Example) => {
+      expect(() =>
+        render(
+          <Renderer>
+            <Example />
+          </Renderer>,
+        ),
+      ).not.toThrow();
+    },
+  );
+});
+
+describe(`${componentName} — structure`, () => {
+  it('renders with role="group" and data-slot="button-group"', () => {
+    render(
+      <ButtonGroup>
+        <Button>One</Button>
+      </ButtonGroup>,
+    );
+    expect(screen.getByRole('group')).toHaveAttribute(
+      'data-slot',
+      'button-group',
+    );
+  });
+
+  it('renders its button children', () => {
+    render(
+      <ButtonGroup>
+        <Button>One</Button>
+        <Button>Two</Button>
+      </ButtonGroup>,
+    );
+    expect(screen.getByText('One')).toBeInTheDocument();
+    expect(screen.getByText('Two')).toBeInTheDocument();
+  });
+
+  it('defaults to horizontal layout with the default gap', () => {
+    render(
+      <ButtonGroup>
+        <Button>One</Button>
+      </ButtonGroup>,
+    );
+    expect(screen.getByRole('group')).toHaveClass('flex-row', 'gap-3');
+  });
+
+  it('applies vertical orientation', () => {
+    render(
+      <ButtonGroup orientation="vertical">
+        <Button>One</Button>
+      </ButtonGroup>,
+    );
+    expect(screen.getByRole('group')).toHaveClass('flex-col');
+  });
+
+  it.each([
+    ['sm', 'gap-2'],
+    ['default', 'gap-3'],
+    ['lg', 'gap-4'],
+  ] as const)('maps size="%s" to %s', (size, gapClass) => {
+    render(
+      <ButtonGroup size={size}>
+        <Button>One</Button>
+      </ButtonGroup>,
+    );
+    expect(screen.getByRole('group')).toHaveClass(gapClass);
+  });
+
+  it('merges a custom className', () => {
+    render(
+      <ButtonGroup className="custom-class">
+        <Button>One</Button>
+      </ButtonGroup>,
+    );
+    expect(screen.getByRole('group')).toHaveClass('custom-class');
+  });
+});


### PR DESCRIPTION
## Description

Closes https://github.com/McK-Internal/qbds-internal/issues/92 partially
- Adds the **Button Group** component that groups related buttons with consistent QBDS spacing, matching the Figma spec (gap-based, size-driven gaps, horizontal/vertical orientation).
- **Figma**: ButtonsGroup/CTAs ([38459:3902](https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr/QBDS-v2.0.0?node-id=38459-3902&m=dev)) and ButtonsGroup/Elements ([38615:99048](https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr/QBDS-v2.0.0?node-id=38615-99048)).
- Based on **shadcn's** [Button Group](https://ui.shadcn.com/docs/components/radix/button-group), which ships an equivalent component — adapted to QBDS (gapped instead of joined borders; `ButtonGroupSeparator` / `ButtonGroupText` omitted as they aren't in the design).
- **Cleanup**: Removed the ad-hoc `ButtonGroups` example from the Button demo

Probably not the most useful component, but I wanted to check how easy it is to create a new component if a shadcn component exists. This one was easy, so why not just add it and make @dandumitriu1 happy :)

## Screenshot
<img width="1920" height="1076" alt="Screenshot 2026-06-03 at 15 56 39" src="https://github.com/user-attachments/assets/dd882262-ef57-41b2-a0d2-f5129c27ecc8" />

