### PR TITLE
feat(comp): add `Toolbar` as a new component 

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.10",
+    "@radix-ui/react-toolbar": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-form": "^1.29.3",
     "@tanstack/react-query": "^5.62.0",

--- a/registry.json
+++ b/registry.json
@@ -888,7 +888,7 @@
       "name": "toolbar",
       "type": "registry:ui",
       "title": "Toolbar",
-      "description": "Groups icon-only controls with keyboard navigation. Supports horizontal and vertical orientations, boxed and unboxed containers, circle and square shapes, and three sizes.",
+      "description": "Groups icon-only controls with keyboard navigation. Defaults to an unboxed horizontal layout; also supports optional boxed containers, vertical orientation, circle and square shapes, and sm, reg, and lg sizes.",
       "dependencies": [
         "@radix-ui/react-toolbar"
       ],

--- a/registry.json
+++ b/registry.json
@@ -864,6 +864,26 @@
           "type": "registry:ui"
         }
       ]
+    },
+    {
+      "name": "toolbar",
+      "type": "registry:ui",
+      "title": "Toolbar",
+      "description": "Groups icon-only controls with keyboard navigation. Supports horizontal and vertical orientations, boxed and unboxed containers, circle and square shapes, and three sizes.",
+      "dependencies": [
+        "@radix-ui/react-toolbar"
+      ],
+      "registryDependencies": [
+        "__REGISTRY_URL__/r/theme.json",
+        "__REGISTRY_URL__/r/utils.json",
+        "__REGISTRY_URL__/r/button.json"
+      ],
+      "files": [
+        {
+          "path": "src/components/ui/toolbar.tsx",
+          "type": "registry:ui"
+        }
+      ]
     }
   ]
 }

--- a/src/app/demo/[name]/index.tsx
+++ b/src/app/demo/[name]/index.tsx
@@ -345,6 +345,16 @@ import {
   examples as toggleExamples,
 } from '@/app/demo/[name]/ui/toggle';
 import {
+  ToolbarBoxed,
+  ToolbarDemo,
+  ToolbarShapes,
+  ToolbarSizes,
+  ToolbarVertical,
+  ToolbarWithDropdown,
+  toolbar,
+  examples as toolbarExamples,
+} from '@/app/demo/[name]/ui/toolbar';
+import {
   TooltipAlignment,
   TooltipDemo,
   TooltipLongContent,
@@ -647,6 +657,14 @@ export const exampleComponentMaps: Record<
     ToggleIconsRound,
     ToggleIconSizes,
   },
+  toolbar: {
+    ToolbarDemo,
+    ToolbarBoxed,
+    ToolbarShapes,
+    ToolbarSizes,
+    ToolbarVertical,
+    ToolbarWithDropdown,
+  },
   tooltip: {
     TooltipDemo,
     TooltipPositions,
@@ -693,6 +711,7 @@ export const examplesMeta: Record<string, ExampleMeta[]> = {
   'time-input': timeInputExamples,
   'time-picker': timePickerExamples,
   toggle: toggleExamples,
+  toolbar: toolbarExamples,
   tooltip: tooltipExamples,
 };
 
@@ -877,6 +896,11 @@ export const demos: { [name: string]: Demo | NewDemo } = {
     ...toggle,
     examples: toggleExamples,
     exampleComponents: exampleComponentMaps.toggle,
+  },
+  toolbar: {
+    ...toolbar,
+    examples: toolbarExamples,
+    exampleComponents: exampleComponentMaps.toolbar,
   },
   tooltip: {
     ...tooltip,

--- a/src/app/demo/[name]/ui/toolbar.tsx
+++ b/src/app/demo/[name]/ui/toolbar.tsx
@@ -64,7 +64,7 @@ function DefaultToolbarItems() {
 
 function DemoSurface({ children }: { children: ReactNode }) {
   return (
-    <div className="dark bg-surface-base flex w-fit items-center rounded-lg p-8">
+    <div className="bg-surface-base flex w-fit items-center rounded-lg p-8">
       {children}
     </div>
   );

--- a/src/app/demo/[name]/ui/toolbar.tsx
+++ b/src/app/demo/[name]/ui/toolbar.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import type { ReactNode } from 'react';
-
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -62,121 +60,101 @@ function DefaultToolbarItems() {
   );
 }
 
-function DemoSurface({ children }: { children: ReactNode }) {
-  return (
-    <div className="bg-surface-base flex w-fit items-center rounded-lg p-8">
-      {children}
-    </div>
-  );
-}
-
 /** Default unboxed toolbar */
 export function ToolbarDemo() {
   return (
-    <DemoSurface>
-      <Toolbar aria-label="Editor tools">
-        <DefaultToolbarItems />
-      </Toolbar>
-    </DemoSurface>
+    <Toolbar aria-label="Editor tools">
+      <DefaultToolbarItems />
+    </Toolbar>
   );
 }
 
 /** Boxed vs unboxed */
 export function ToolbarBoxed() {
   return (
-    <DemoSurface>
-      <div className="flex flex-col gap-6">
-        <Toolbar aria-label="Boxed tools" boxed>
-          <DefaultToolbarItems />
-        </Toolbar>
-        <Toolbar aria-label="Unboxed tools">
-          <DefaultToolbarItems />
-        </Toolbar>
-      </div>
-    </DemoSurface>
+    <div className="flex flex-col gap-6">
+      <Toolbar aria-label="Boxed tools" boxed>
+        <DefaultToolbarItems />
+      </Toolbar>
+      <Toolbar aria-label="Unboxed tools">
+        <DefaultToolbarItems />
+      </Toolbar>
+    </div>
   );
 }
 
 /** Circle vs square shapes */
 export function ToolbarShapes() {
   return (
-    <DemoSurface>
-      <div className="flex flex-col gap-6">
-        <Toolbar aria-label="Circle shape tools" boxed shape="circle">
-          <DefaultToolbarItems />
-        </Toolbar>
-        <Toolbar aria-label="Square shape tools" boxed shape="square">
-          <DefaultToolbarItems />
-        </Toolbar>
-      </div>
-    </DemoSurface>
+    <div className="flex flex-col gap-6">
+      <Toolbar aria-label="Circle shape tools" boxed shape="circle">
+        <DefaultToolbarItems />
+      </Toolbar>
+      <Toolbar aria-label="Square shape tools" boxed shape="square">
+        <DefaultToolbarItems />
+      </Toolbar>
+    </div>
   );
 }
 
 /** Toolbar sizes */
 export function ToolbarSizes() {
   return (
-    <DemoSurface>
-      <div className="flex flex-col items-start gap-6">
-        <Toolbar aria-label="Small tools" boxed size="sm">
-          <DefaultToolbarItems />
-        </Toolbar>
-        <Toolbar aria-label="Regular tools" boxed size="reg">
-          <DefaultToolbarItems />
-        </Toolbar>
-        <Toolbar aria-label="Large tools" boxed size="lg">
-          <DefaultToolbarItems />
-        </Toolbar>
-      </div>
-    </DemoSurface>
+    <div className="flex flex-col items-start gap-6">
+      <Toolbar aria-label="Small tools" boxed size="sm">
+        <DefaultToolbarItems />
+      </Toolbar>
+      <Toolbar aria-label="Regular tools" boxed size="reg">
+        <DefaultToolbarItems />
+      </Toolbar>
+      <Toolbar aria-label="Large tools" boxed size="lg">
+        <DefaultToolbarItems />
+      </Toolbar>
+    </div>
   );
 }
 
 /** Vertical orientation */
 export function ToolbarVertical() {
   return (
-    <DemoSurface>
-      <div className="flex gap-8">
-        <Toolbar aria-label="Vertical boxed tools" boxed orientation="vertical">
-          <DefaultToolbarItems />
-        </Toolbar>
-        <Toolbar aria-label="Vertical unboxed tools" orientation="vertical">
-          <DefaultToolbarItems />
-        </Toolbar>
-      </div>
-    </DemoSurface>
+    <div className="flex gap-8">
+      <Toolbar aria-label="Vertical boxed tools" boxed orientation="vertical">
+        <DefaultToolbarItems />
+      </Toolbar>
+      <Toolbar aria-label="Vertical unboxed tools" orientation="vertical">
+        <DefaultToolbarItems />
+      </Toolbar>
+    </div>
   );
 }
 
 /** Toolbar with dropdown menu trigger */
 export function ToolbarWithDropdown() {
   return (
-    <DemoSurface>
-      <Toolbar aria-label="Tools with menu" boxed>
-        <ToolbarToggleGroup type="single" defaultValue="tool-1">
-          <ToolbarToggleItem aria-label="Tool 1" value="tool-1">
-            <ToolbarIcon />
-          </ToolbarToggleItem>
-          <ToolbarToggleItem aria-label="Tool 2" value="tool-2">
-            <ToolbarIcon />
-          </ToolbarToggleItem>
-        </ToolbarToggleGroup>
+    <Toolbar aria-label="Tools with menu" boxed>
+      <ToolbarToggleGroup type="single" defaultValue="tool-1">
+        <ToolbarToggleItem aria-label="Tool 1" value="tool-1">
+          <ToolbarIcon />
+        </ToolbarToggleItem>
+        <ToolbarToggleItem aria-label="Tool 2" value="tool-2">
+          <ToolbarIcon />
+        </ToolbarToggleItem>
+      </ToolbarToggleGroup>
 
-        <ToolbarSeparator />
+      <ToolbarSeparator />
 
-        <DropdownMenu>
-          <ToolbarButton aria-label="Tool 3" asChild>
-            <DropdownMenuTrigger>
-              <ToolbarIcon />
-            </DropdownMenuTrigger>
-          </ToolbarButton>
-          <DropdownMenuContent align="start">
-            <DropdownMenuItem>Duplicate</DropdownMenuItem>
-            <DropdownMenuItem>Export</DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </Toolbar>
-    </DemoSurface>
+      <DropdownMenu>
+        <ToolbarButton aria-label="Tool 3" asChild>
+          <DropdownMenuTrigger>
+            <ToolbarIcon />
+          </DropdownMenuTrigger>
+        </ToolbarButton>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem>Duplicate</DropdownMenuItem>
+          <DropdownMenuItem>Export</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </Toolbar>
   );
 }
 

--- a/src/app/demo/[name]/ui/toolbar.tsx
+++ b/src/app/demo/[name]/ui/toolbar.tsx
@@ -16,12 +16,16 @@ import {
   ToolbarSeparator,
   ToolbarToggleGroup,
   ToolbarToggleItem,
+  toolbarIconShellSizeMap,
+  useToolbar,
 } from '@/components/ui/toolbar';
 import { type DemoExample, createLegacyDemo } from '@/lib/demo-utils';
 
 function ToolbarIcon() {
+  const { size } = useToolbar();
+
   return (
-    <IconShell size="sm" variant="secondary">
+    <IconShell size={toolbarIconShellSizeMap[size]} variant="secondary">
       <Icon icon="crop_free" />
     </IconShell>
   );
@@ -66,11 +70,11 @@ function DemoSurface({ children }: { children: ReactNode }) {
   );
 }
 
-/** Default boxed toolbar */
+/** Default unboxed toolbar */
 export function ToolbarDemo() {
   return (
     <DemoSurface>
-      <Toolbar boxed>
+      <Toolbar aria-label="Editor tools">
         <DefaultToolbarItems />
       </Toolbar>
     </DemoSurface>
@@ -82,10 +86,10 @@ export function ToolbarBoxed() {
   return (
     <DemoSurface>
       <div className="flex flex-col gap-6">
-        <Toolbar boxed>
+        <Toolbar aria-label="Boxed tools" boxed>
           <DefaultToolbarItems />
         </Toolbar>
-        <Toolbar>
+        <Toolbar aria-label="Unboxed tools">
           <DefaultToolbarItems />
         </Toolbar>
       </div>
@@ -98,10 +102,10 @@ export function ToolbarShapes() {
   return (
     <DemoSurface>
       <div className="flex flex-col gap-6">
-        <Toolbar boxed shape="circle">
+        <Toolbar aria-label="Circle shape tools" boxed shape="circle">
           <DefaultToolbarItems />
         </Toolbar>
-        <Toolbar boxed shape="square">
+        <Toolbar aria-label="Square shape tools" boxed shape="square">
           <DefaultToolbarItems />
         </Toolbar>
       </div>
@@ -114,13 +118,13 @@ export function ToolbarSizes() {
   return (
     <DemoSurface>
       <div className="flex flex-col items-start gap-6">
-        <Toolbar boxed size="sm">
+        <Toolbar aria-label="Small tools" boxed size="sm">
           <DefaultToolbarItems />
         </Toolbar>
-        <Toolbar boxed size="reg">
+        <Toolbar aria-label="Regular tools" boxed size="reg">
           <DefaultToolbarItems />
         </Toolbar>
-        <Toolbar boxed size="lg">
+        <Toolbar aria-label="Large tools" boxed size="lg">
           <DefaultToolbarItems />
         </Toolbar>
       </div>
@@ -133,10 +137,10 @@ export function ToolbarVertical() {
   return (
     <DemoSurface>
       <div className="flex gap-8">
-        <Toolbar boxed orientation="vertical">
+        <Toolbar aria-label="Vertical boxed tools" boxed orientation="vertical">
           <DefaultToolbarItems />
         </Toolbar>
-        <Toolbar orientation="vertical">
+        <Toolbar aria-label="Vertical unboxed tools" orientation="vertical">
           <DefaultToolbarItems />
         </Toolbar>
       </div>
@@ -148,7 +152,7 @@ export function ToolbarVertical() {
 export function ToolbarWithDropdown() {
   return (
     <DemoSurface>
-      <Toolbar boxed>
+      <Toolbar aria-label="Tools with menu" boxed>
         <ToolbarToggleGroup type="single" defaultValue="tool-1">
           <ToolbarToggleItem aria-label="Tool 1" value="tool-1">
             <ToolbarIcon />
@@ -181,12 +185,13 @@ export const examples: DemoExample[] = [
     name: 'ToolbarDemo',
     title: 'Default',
     description:
-      'Boxed horizontal toolbar with toggle group, separator, and actions.',
+      'Unboxed horizontal toolbar (default) with toggle group, separator, and icon actions.',
   },
   {
     name: 'ToolbarBoxed',
     title: 'Boxed',
-    description: 'Boxed and unboxed toolbar containers.',
+    description:
+      'Optional boxed container with elevation; compare with the default unboxed layout.',
   },
   {
     name: 'ToolbarShapes',

--- a/src/app/demo/[name]/ui/toolbar.tsx
+++ b/src/app/demo/[name]/ui/toolbar.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Icon } from '@/components/ui/icon';
+import { IconShell } from '@/components/ui/icon-shell';
+import {
+  Toolbar,
+  ToolbarButton,
+  ToolbarSeparator,
+  ToolbarToggleGroup,
+  ToolbarToggleItem,
+} from '@/components/ui/toolbar';
+import { type DemoExample, createLegacyDemo } from '@/lib/demo-utils';
+
+function ToolbarIcon() {
+  return (
+    <IconShell size="sm" variant="secondary">
+      <Icon icon="crop_free" />
+    </IconShell>
+  );
+}
+
+/** Shared toolbar items matching the Figma composition */
+function DefaultToolbarItems() {
+  return (
+    <>
+      <ToolbarToggleGroup type="single" defaultValue="tool-1">
+        <ToolbarToggleItem aria-label="Tool 1" value="tool-1">
+          <ToolbarIcon />
+        </ToolbarToggleItem>
+        <ToolbarToggleItem aria-label="Tool 2" value="tool-2">
+          <ToolbarIcon />
+        </ToolbarToggleItem>
+        <ToolbarToggleItem aria-label="Tool 3" value="tool-3">
+          <ToolbarIcon />
+        </ToolbarToggleItem>
+        <ToolbarToggleItem aria-label="Tool 4" value="tool-4">
+          <ToolbarIcon />
+        </ToolbarToggleItem>
+      </ToolbarToggleGroup>
+
+      <ToolbarSeparator />
+
+      <ToolbarButton aria-label="Tool 5">
+        <ToolbarIcon />
+      </ToolbarButton>
+      <ToolbarButton aria-label="Tool 6">
+        <ToolbarIcon />
+      </ToolbarButton>
+    </>
+  );
+}
+
+function DemoSurface({ children }: { children: ReactNode }) {
+  return (
+    <div className="dark bg-surface-base flex w-fit items-center rounded-lg p-8">
+      {children}
+    </div>
+  );
+}
+
+/** Default boxed toolbar */
+export function ToolbarDemo() {
+  return (
+    <DemoSurface>
+      <Toolbar boxed>
+        <DefaultToolbarItems />
+      </Toolbar>
+    </DemoSurface>
+  );
+}
+
+/** Boxed vs unboxed */
+export function ToolbarBoxed() {
+  return (
+    <DemoSurface>
+      <div className="flex flex-col gap-6">
+        <Toolbar boxed>
+          <DefaultToolbarItems />
+        </Toolbar>
+        <Toolbar>
+          <DefaultToolbarItems />
+        </Toolbar>
+      </div>
+    </DemoSurface>
+  );
+}
+
+/** Circle vs square shapes */
+export function ToolbarShapes() {
+  return (
+    <DemoSurface>
+      <div className="flex flex-col gap-6">
+        <Toolbar boxed shape="circle">
+          <DefaultToolbarItems />
+        </Toolbar>
+        <Toolbar boxed shape="square">
+          <DefaultToolbarItems />
+        </Toolbar>
+      </div>
+    </DemoSurface>
+  );
+}
+
+/** Toolbar sizes */
+export function ToolbarSizes() {
+  return (
+    <DemoSurface>
+      <div className="flex flex-col items-start gap-6">
+        <Toolbar boxed size="sm">
+          <DefaultToolbarItems />
+        </Toolbar>
+        <Toolbar boxed size="reg">
+          <DefaultToolbarItems />
+        </Toolbar>
+        <Toolbar boxed size="lg">
+          <DefaultToolbarItems />
+        </Toolbar>
+      </div>
+    </DemoSurface>
+  );
+}
+
+/** Vertical orientation */
+export function ToolbarVertical() {
+  return (
+    <DemoSurface>
+      <div className="flex gap-8">
+        <Toolbar boxed orientation="vertical">
+          <DefaultToolbarItems />
+        </Toolbar>
+        <Toolbar orientation="vertical">
+          <DefaultToolbarItems />
+        </Toolbar>
+      </div>
+    </DemoSurface>
+  );
+}
+
+/** Toolbar with dropdown menu trigger */
+export function ToolbarWithDropdown() {
+  return (
+    <DemoSurface>
+      <Toolbar boxed>
+        <ToolbarToggleGroup type="single" defaultValue="tool-1">
+          <ToolbarToggleItem aria-label="Tool 1" value="tool-1">
+            <ToolbarIcon />
+          </ToolbarToggleItem>
+          <ToolbarToggleItem aria-label="Tool 2" value="tool-2">
+            <ToolbarIcon />
+          </ToolbarToggleItem>
+        </ToolbarToggleGroup>
+
+        <ToolbarSeparator />
+
+        <DropdownMenu>
+          <ToolbarButton aria-label="Tool 3" asChild>
+            <DropdownMenuTrigger>
+              <ToolbarIcon />
+            </DropdownMenuTrigger>
+          </ToolbarButton>
+          <DropdownMenuContent align="start">
+            <DropdownMenuItem>Duplicate</DropdownMenuItem>
+            <DropdownMenuItem>Export</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </Toolbar>
+    </DemoSurface>
+  );
+}
+
+export const examples: DemoExample[] = [
+  {
+    name: 'ToolbarDemo',
+    title: 'Default',
+    description:
+      'Boxed horizontal toolbar with toggle group, separator, and actions.',
+  },
+  {
+    name: 'ToolbarBoxed',
+    title: 'Boxed',
+    description: 'Boxed and unboxed toolbar containers.',
+  },
+  {
+    name: 'ToolbarShapes',
+    title: 'Shapes',
+    description: 'Circle and square container and button shapes.',
+  },
+  {
+    name: 'ToolbarSizes',
+    title: 'Sizes',
+    description: 'Small, regular, and large toolbar sizes.',
+  },
+  {
+    name: 'ToolbarVertical',
+    title: 'Vertical',
+    description: 'Vertical orientation with boxed and unboxed variants.',
+  },
+  {
+    name: 'ToolbarWithDropdown',
+    title: 'With Dropdown',
+    description: 'Toolbar button composed with a dropdown menu trigger.',
+  },
+];
+
+export const toolbar = createLegacyDemo('toolbar', examples, {
+  ToolbarDemo: <ToolbarDemo />,
+  ToolbarBoxed: <ToolbarBoxed />,
+  ToolbarShapes: <ToolbarShapes />,
+  ToolbarSizes: <ToolbarSizes />,
+  ToolbarVertical: <ToolbarVertical />,
+  ToolbarWithDropdown: <ToolbarWithDropdown />,
+});

--- a/src/app/demo/[name]/ui/toolbar.tsx
+++ b/src/app/demo/[name]/ui/toolbar.tsx
@@ -29,7 +29,6 @@ function ToolbarIcon() {
   );
 }
 
-/** Shared toolbar items matching the Figma composition */
 function DefaultToolbarItems() {
   return (
     <>
@@ -60,7 +59,6 @@ function DefaultToolbarItems() {
   );
 }
 
-/** Default unboxed toolbar */
 export function ToolbarDemo() {
   return (
     <Toolbar aria-label="Editor tools">
@@ -69,7 +67,6 @@ export function ToolbarDemo() {
   );
 }
 
-/** Boxed vs unboxed */
 export function ToolbarBoxed() {
   return (
     <div className="flex flex-col gap-6">
@@ -83,7 +80,6 @@ export function ToolbarBoxed() {
   );
 }
 
-/** Circle vs square shapes */
 export function ToolbarShapes() {
   return (
     <div className="flex flex-col gap-6">
@@ -97,7 +93,6 @@ export function ToolbarShapes() {
   );
 }
 
-/** Toolbar sizes */
 export function ToolbarSizes() {
   return (
     <div className="flex flex-col items-start gap-6">
@@ -114,7 +109,6 @@ export function ToolbarSizes() {
   );
 }
 
-/** Vertical orientation */
 export function ToolbarVertical() {
   return (
     <div className="flex gap-8">
@@ -128,7 +122,6 @@ export function ToolbarVertical() {
   );
 }
 
-/** Toolbar with dropdown menu trigger */
 export function ToolbarWithDropdown() {
   return (
     <Toolbar aria-label="Tools with menu" boxed>
@@ -144,11 +137,11 @@ export function ToolbarWithDropdown() {
       <ToolbarSeparator />
 
       <DropdownMenu>
-        <ToolbarButton aria-label="Tool 3" asChild>
-          <DropdownMenuTrigger>
+        <DropdownMenuTrigger asChild>
+          <ToolbarButton aria-label="Tool 3">
             <ToolbarIcon />
-          </DropdownMenuTrigger>
-        </ToolbarButton>
+          </ToolbarButton>
+        </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
           <DropdownMenuItem>Duplicate</DropdownMenuItem>
           <DropdownMenuItem>Export</DropdownMenuItem>

--- a/src/components/ui/toolbar.tsx
+++ b/src/components/ui/toolbar.tsx
@@ -26,15 +26,17 @@ const ToolbarContext = React.createContext<ToolbarContextValue>({
 
 type ToolbarGapClass = 'gap-1' | 'gap-2' | 'gap-3';
 
-/** Inter-item gap from Figma spacing/4, /8, /12 per size × boxed × shape. */
+/**
+ * Inter-item gap from Figma Spacing/4, /8, /12 — matrix by size, not a single axis.
+ * lg → 12px; reg + circle + unboxed → 4px; all other cells → 8px.
+ */
 function toolbarGapClass({
   boxed,
   shape,
   size,
 }: Pick<ToolbarContextValue, 'boxed' | 'shape' | 'size'>): ToolbarGapClass {
-  if (boxed || shape === 'square') return 'gap-2';
-  if (size === 'reg') return 'gap-1';
   if (size === 'lg') return 'gap-3';
+  if (size === 'reg' && shape === 'circle' && !boxed) return 'gap-1';
   return 'gap-2';
 }
 

--- a/src/components/ui/toolbar.tsx
+++ b/src/components/ui/toolbar.tsx
@@ -184,7 +184,7 @@ function ToolbarButton({
   className,
   ...props
 }: React.ComponentProps<typeof ToolbarPrimitive.Button>) {
-  const context = React.useContext(ToolbarContext);
+  const context = useToolbar();
 
   return (
     <ToolbarPrimitive.Button
@@ -202,7 +202,7 @@ function ToolbarSeparator({
   React.ComponentProps<typeof ToolbarPrimitive.Separator>,
   'decorative' | 'orientation'
 >) {
-  const context = React.useContext(ToolbarContext);
+  const context = useToolbar();
 
   return (
     <ToolbarPrimitive.Separator
@@ -236,7 +236,7 @@ function ToolbarToggleGroup({
   className,
   ...props
 }: React.ComponentProps<typeof ToolbarPrimitive.ToggleGroup>) {
-  const { boxed, shape, size, orientation } = React.useContext(ToolbarContext);
+  const { boxed, shape, size, orientation } = useToolbar();
 
   return (
     <ToolbarPrimitive.ToggleGroup
@@ -256,7 +256,7 @@ function ToolbarToggleItem({
   className,
   ...props
 }: React.ComponentProps<typeof ToolbarPrimitive.ToggleItem>) {
-  const context = React.useContext(ToolbarContext);
+  const context = useToolbar();
 
   return (
     <ToolbarPrimitive.ToggleItem

--- a/src/components/ui/toolbar.tsx
+++ b/src/components/ui/toolbar.tsx
@@ -40,10 +40,14 @@ function toolbarGapClass({
   return 'gap-2';
 }
 
-const toolbarSeparatorGapOffset: Record<ToolbarGapClass, string> = {
-  'gap-1': '1',
-  'gap-2': '2',
-  'gap-3': '3',
+/** Full class names for Tailwind static scanning (see button.tsx). */
+const toolbarSeparatorGapOffset: Record<
+  ToolbarGapClass,
+  { horizontal: string; vertical: string }
+> = {
+  'gap-1': { horizontal: '-ms-1', vertical: '-mt-1' },
+  'gap-2': { horizontal: '-ms-2', vertical: '-mt-2' },
+  'gap-3': { horizontal: '-ms-3', vertical: '-mt-3' },
 };
 
 /**
@@ -53,8 +57,8 @@ const toolbarSeparatorGapOffset: Record<ToolbarGapClass, string> = {
 function toolbarSeparatorOffsetClass(context: ToolbarContextValue) {
   const offset = toolbarSeparatorGapOffset[toolbarGapClass(context)];
   return context.orientation === 'horizontal'
-    ? `-ms-${offset}`
-    : `-mt-${offset}`;
+    ? offset.horizontal
+    : offset.vertical;
 }
 
 const toolbarIconSizeMap: Record<ToolbarSize, 'icon-sm' | 'icon' | 'icon-lg'> =
@@ -220,7 +224,10 @@ function ToolbarLink({
 function ToolbarSeparator({
   className,
   ...props
-}: React.ComponentProps<typeof ToolbarPrimitive.Separator>) {
+}: Omit<
+  React.ComponentProps<typeof ToolbarPrimitive.Separator>,
+  'decorative' | 'orientation'
+>) {
   const context = React.useContext(ToolbarContext);
 
   return (

--- a/src/components/ui/toolbar.tsx
+++ b/src/components/ui/toolbar.tsx
@@ -36,6 +36,9 @@ function toolbarGapClass({
   return 'gap-2';
 }
 
+// Negative margin cancels the flex gap before the separator (Figma spacer-on-prior-item).
+// Only use between two items — first/last overflows the container. Keys must match
+// every class `toolbarGapClass` can return.
 const toolbarSeparatorGapOffset: Record<
   ToolbarGapClass,
   { horizontal: string; vertical: string }

--- a/src/components/ui/toolbar.tsx
+++ b/src/components/ui/toolbar.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import * as ToolbarPrimitive from '@radix-ui/react-toolbar';
+import { cva } from 'class-variance-authority';
+import * as React from 'react';
+
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type ToolbarSize = 'sm' | 'reg' | 'lg';
+type ToolbarShape = 'square' | 'circle';
+
+interface ToolbarContextValue {
+  size: ToolbarSize;
+  shape: ToolbarShape;
+  orientation: 'horizontal' | 'vertical';
+}
+
+const ToolbarContext = React.createContext<ToolbarContextValue>({
+  size: 'reg',
+  shape: 'circle',
+  orientation: 'horizontal',
+});
+
+const toolbarIconSizeMap: Record<ToolbarSize, 'icon-sm' | 'icon' | 'icon-lg'> =
+  {
+    sm: 'icon-sm',
+    reg: 'icon',
+    lg: 'icon-lg',
+  };
+
+const toolbarSeparatorSizeMap: Record<ToolbarSize, string> = {
+  sm: 'h-6',
+  reg: 'h-7',
+  lg: 'h-10',
+};
+
+const toolbarVariants = cva('inline-flex w-fit items-center', {
+  variants: {
+    boxed: {
+      true: 'bg-fill-secondary-inverse border border-stroke-tertiary p-2 shadow-elevation-1',
+      false: '',
+    },
+    orientation: {
+      horizontal: 'flex-row',
+      vertical: 'flex-col',
+    },
+    shape: {
+      circle: '',
+      square: '',
+    },
+    size: {
+      sm: '',
+      reg: '',
+      lg: '',
+    },
+  },
+  compoundVariants: [
+    { boxed: true, shape: 'circle', className: 'rounded-full' },
+    { boxed: true, shape: 'square', className: 'rounded-md' },
+    {
+      orientation: 'horizontal',
+      boxed: true,
+      className: 'gap-2',
+    },
+    {
+      orientation: 'vertical',
+      boxed: true,
+      className: 'gap-2',
+    },
+    {
+      orientation: 'horizontal',
+      boxed: false,
+      shape: 'circle',
+      className: 'gap-1',
+    },
+    {
+      orientation: 'horizontal',
+      boxed: false,
+      shape: 'square',
+      className: 'gap-2',
+    },
+    {
+      orientation: 'vertical',
+      boxed: false,
+      shape: 'circle',
+      className: 'gap-1',
+    },
+    {
+      orientation: 'vertical',
+      boxed: false,
+      shape: 'square',
+      className: 'gap-2',
+    },
+  ],
+  defaultVariants: {
+    boxed: false,
+    orientation: 'horizontal',
+    shape: 'circle',
+    size: 'reg',
+  },
+});
+
+function toolbarItemClasses({
+  size,
+  shape,
+  className,
+}: ToolbarContextValue & { className?: string }) {
+  return cn(
+    buttonVariants({
+      variant: 'ghost',
+      size: toolbarIconSizeMap[size],
+    }),
+    shape === 'circle' && 'rounded-full',
+    className,
+  );
+}
+
+interface ToolbarProps extends React.ComponentProps<
+  typeof ToolbarPrimitive.Root
+> {
+  size?: ToolbarSize;
+  shape?: ToolbarShape;
+  boxed?: boolean;
+}
+
+function Toolbar({
+  className,
+  size = 'reg',
+  shape = 'circle',
+  boxed = false,
+  orientation = 'horizontal',
+  ...props
+}: ToolbarProps) {
+  return (
+    <ToolbarContext.Provider value={{ size, shape, orientation }}>
+      <ToolbarPrimitive.Root
+        data-slot="toolbar"
+        data-size={size}
+        data-shape={shape}
+        data-boxed={boxed ? 'true' : 'false'}
+        orientation={orientation}
+        className={cn(
+          toolbarVariants({ boxed, orientation, shape, size }),
+          className,
+        )}
+        {...props}
+      />
+    </ToolbarContext.Provider>
+  );
+}
+
+function ToolbarButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof ToolbarPrimitive.Button>) {
+  const context = React.useContext(ToolbarContext);
+
+  return (
+    <ToolbarPrimitive.Button
+      data-slot="toolbar-button"
+      className={toolbarItemClasses({ ...context, className })}
+      {...props}
+    />
+  );
+}
+
+function ToolbarLink({
+  className,
+  ...props
+}: React.ComponentProps<typeof ToolbarPrimitive.Link>) {
+  const context = React.useContext(ToolbarContext);
+
+  return (
+    <ToolbarPrimitive.Link
+      data-slot="toolbar-link"
+      className={toolbarItemClasses({ ...context, className })}
+      {...props}
+    />
+  );
+}
+
+function ToolbarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof ToolbarPrimitive.Separator>) {
+  const { size, orientation } = React.useContext(ToolbarContext);
+
+  return (
+    <ToolbarPrimitive.Separator
+      data-slot="toolbar-separator"
+      decorative
+      orientation={orientation === 'horizontal' ? 'vertical' : 'horizontal'}
+      className={cn(
+        'bg-stroke-tertiary shrink-0',
+        orientation === 'horizontal'
+          ? cn('mx-1 w-px', toolbarSeparatorSizeMap[size])
+          : cn('my-1 h-px w-7'),
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ToolbarToggleGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof ToolbarPrimitive.ToggleGroup>) {
+  const { orientation } = React.useContext(ToolbarContext);
+
+  return (
+    <ToolbarPrimitive.ToggleGroup
+      data-slot="toolbar-toggle-group"
+      className={cn(
+        'inline-flex items-center gap-1',
+        orientation === 'vertical' ? 'flex-col' : 'flex-row',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ToolbarToggleItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof ToolbarPrimitive.ToggleItem>) {
+  const context = React.useContext(ToolbarContext);
+
+  return (
+    <ToolbarPrimitive.ToggleItem
+      data-slot="toolbar-toggle-item"
+      className={cn(
+        toolbarItemClasses(context),
+        'data-[state=on]:bg-fill-active data-[state=on]:text-fg-primary-inverse',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Toolbar,
+  ToolbarButton,
+  ToolbarLink,
+  ToolbarSeparator,
+  ToolbarToggleGroup,
+  ToolbarToggleItem,
+  type ToolbarSize,
+  type ToolbarShape,
+};

--- a/src/components/ui/toolbar.tsx
+++ b/src/components/ui/toolbar.tsx
@@ -13,14 +13,47 @@ type ToolbarShape = 'square' | 'circle';
 interface ToolbarContextValue {
   size: ToolbarSize;
   shape: ToolbarShape;
+  boxed: boolean;
   orientation: 'horizontal' | 'vertical';
 }
 
 const ToolbarContext = React.createContext<ToolbarContextValue>({
   size: 'reg',
   shape: 'circle',
+  boxed: false,
   orientation: 'horizontal',
 });
+
+type ToolbarGapClass = 'gap-1' | 'gap-2' | 'gap-3';
+
+/** Inter-item gap from Figma spacing/4, /8, /12 per size × boxed × shape. */
+function toolbarGapClass({
+  boxed,
+  shape,
+  size,
+}: Pick<ToolbarContextValue, 'boxed' | 'shape' | 'size'>): ToolbarGapClass {
+  if (boxed || shape === 'square') return 'gap-2';
+  if (size === 'reg') return 'gap-1';
+  if (size === 'lg') return 'gap-3';
+  return 'gap-2';
+}
+
+const toolbarSeparatorGapOffset: Record<ToolbarGapClass, string> = {
+  'gap-1': '1',
+  'gap-2': '2',
+  'gap-3': '3',
+};
+
+/**
+ * Collapse the flex gap before the separator so it sits flush after the
+ * preceding control, matching Figma’s spacer-on-last-toggle pattern.
+ */
+function toolbarSeparatorOffsetClass(context: ToolbarContextValue) {
+  const offset = toolbarSeparatorGapOffset[toolbarGapClass(context)];
+  return context.orientation === 'horizontal'
+    ? `-ms-${offset}`
+    : `-mt-${offset}`;
+}
 
 const toolbarIconSizeMap: Record<ToolbarSize, 'icon-sm' | 'icon' | 'icon-lg'> =
   {
@@ -29,16 +62,45 @@ const toolbarIconSizeMap: Record<ToolbarSize, 'icon-sm' | 'icon' | 'icon-lg'> =
     lg: 'icon-lg',
   };
 
-const toolbarSeparatorSizeMap: Record<ToolbarSize, string> = {
-  sm: 'h-6',
+/** IconShell size paired with each toolbar button size (matches icon toggle demos). */
+const toolbarIconShellSizeMap: Record<ToolbarSize, 'sm' | 'default' | 'lg'> = {
+  sm: 'sm',
+  reg: 'sm',
+  lg: 'default',
+};
+
+/** Divider length along the toolbar cross-axis (Figma .baseTab_spacer). */
+const toolbarSeparatorLengthMap: Record<ToolbarSize, string> = {
+  sm: 'h-5',
   reg: 'h-7',
-  lg: 'h-10',
+  lg: 'h-8',
+};
+
+/** Horizontal divider width (Figma spacer w-[8px] / w-[12px]). */
+const toolbarSeparatorWidthMap: Record<ToolbarSize, string> = {
+  sm: 'w-2',
+  reg: 'w-2',
+  lg: 'w-3',
+};
+
+/** Vertical divider height (Figma spacer h-[8px]). */
+const toolbarSeparatorHeightMap: Record<ToolbarSize, string> = {
+  sm: 'h-2',
+  reg: 'h-2',
+  lg: 'h-3',
+};
+
+/** Vertical divider width (Figma spacer w-[28px] etc.). */
+const toolbarSeparatorCrossSpanMap: Record<ToolbarSize, string> = {
+  sm: 'w-6',
+  reg: 'w-7',
+  lg: 'w-8',
 };
 
 const toolbarVariants = cva('inline-flex w-fit items-center', {
   variants: {
     boxed: {
-      true: 'bg-fill-secondary-inverse border border-stroke-tertiary p-2 shadow-elevation-1',
+      true: 'bg-fill-secondary-inverse border border-stroke-tertiary shadow-elevation-1',
       false: '',
     },
     orientation: {
@@ -58,40 +120,8 @@ const toolbarVariants = cva('inline-flex w-fit items-center', {
   compoundVariants: [
     { boxed: true, shape: 'circle', className: 'rounded-full' },
     { boxed: true, shape: 'square', className: 'rounded-md' },
-    {
-      orientation: 'horizontal',
-      boxed: true,
-      className: 'gap-2',
-    },
-    {
-      orientation: 'vertical',
-      boxed: true,
-      className: 'gap-2',
-    },
-    {
-      orientation: 'horizontal',
-      boxed: false,
-      shape: 'circle',
-      className: 'gap-1',
-    },
-    {
-      orientation: 'horizontal',
-      boxed: false,
-      shape: 'square',
-      className: 'gap-2',
-    },
-    {
-      orientation: 'vertical',
-      boxed: false,
-      shape: 'circle',
-      className: 'gap-1',
-    },
-    {
-      orientation: 'vertical',
-      boxed: false,
-      shape: 'square',
-      className: 'gap-2',
-    },
+    { boxed: true, size: ['sm', 'reg'], className: 'p-2' },
+    { boxed: true, size: 'lg', className: 'p-3' },
   ],
   defaultVariants: {
     boxed: false,
@@ -111,9 +141,13 @@ function toolbarItemClasses({
       variant: 'ghost',
       size: toolbarIconSizeMap[size],
     }),
-    shape === 'circle' && 'rounded-full',
+    shape === 'circle' ? 'rounded-full' : 'rounded-md',
     className,
   );
+}
+
+function useToolbar() {
+  return React.useContext(ToolbarContext);
 }
 
 interface ToolbarProps extends React.ComponentProps<
@@ -133,7 +167,7 @@ function Toolbar({
   ...props
 }: ToolbarProps) {
   return (
-    <ToolbarContext.Provider value={{ size, shape, orientation }}>
+    <ToolbarContext.Provider value={{ size, shape, boxed, orientation }}>
       <ToolbarPrimitive.Root
         data-slot="toolbar"
         data-size={size}
@@ -142,6 +176,7 @@ function Toolbar({
         orientation={orientation}
         className={cn(
           toolbarVariants({ boxed, orientation, shape, size }),
+          toolbarGapClass({ boxed, shape, size }),
           className,
         )}
         {...props}
@@ -184,18 +219,29 @@ function ToolbarSeparator({
   className,
   ...props
 }: React.ComponentProps<typeof ToolbarPrimitive.Separator>) {
-  const { size, orientation } = React.useContext(ToolbarContext);
+  const context = React.useContext(ToolbarContext);
 
   return (
     <ToolbarPrimitive.Separator
       data-slot="toolbar-separator"
       decorative
-      orientation={orientation === 'horizontal' ? 'vertical' : 'horizontal'}
+      orientation={
+        context.orientation === 'horizontal' ? 'vertical' : 'horizontal'
+      }
       className={cn(
-        'bg-stroke-tertiary shrink-0',
-        orientation === 'horizontal'
-          ? cn('mx-1 w-px', toolbarSeparatorSizeMap[size])
-          : cn('my-1 h-px w-7'),
+        'border-stroke-tertiary shrink-0',
+        toolbarSeparatorOffsetClass(context),
+        context.orientation === 'horizontal'
+          ? cn(
+              'self-center border-r',
+              toolbarSeparatorWidthMap[context.size],
+              toolbarSeparatorLengthMap[context.size],
+            )
+          : cn(
+              'border-b',
+              toolbarSeparatorHeightMap[context.size],
+              toolbarSeparatorCrossSpanMap[context.size],
+            ),
         className,
       )}
       {...props}
@@ -207,13 +253,14 @@ function ToolbarToggleGroup({
   className,
   ...props
 }: React.ComponentProps<typeof ToolbarPrimitive.ToggleGroup>) {
-  const { orientation } = React.useContext(ToolbarContext);
+  const { boxed, shape, size, orientation } = React.useContext(ToolbarContext);
 
   return (
     <ToolbarPrimitive.ToggleGroup
       data-slot="toolbar-toggle-group"
       className={cn(
-        'inline-flex items-center gap-1',
+        'inline-flex items-center',
+        toolbarGapClass({ boxed, shape, size }),
         orientation === 'vertical' ? 'flex-col' : 'flex-row',
         className,
       )}
@@ -234,6 +281,8 @@ function ToolbarToggleItem({
       className={cn(
         toolbarItemClasses(context),
         'data-[state=on]:bg-fill-active data-[state=on]:text-fg-primary-inverse',
+        'disabled:data-[state=on]:text-fg-disabled disabled:data-[state=on]:bg-transparent',
+        'disabled:data-[state=on]:hover:bg-transparent disabled:data-[state=on]:active:bg-transparent',
         className,
       )}
       {...props}
@@ -248,6 +297,8 @@ export {
   ToolbarSeparator,
   ToolbarToggleGroup,
   ToolbarToggleItem,
+  toolbarIconShellSizeMap,
+  useToolbar,
   type ToolbarSize,
   type ToolbarShape,
 };

--- a/src/components/ui/toolbar.tsx
+++ b/src/components/ui/toolbar.tsx
@@ -26,10 +26,6 @@ const ToolbarContext = React.createContext<ToolbarContextValue>({
 
 type ToolbarGapClass = 'gap-1' | 'gap-2' | 'gap-3';
 
-/**
- * Inter-item gap from Figma Spacing/4, /8, /12 — matrix by size, not a single axis.
- * lg → 12px; reg + circle + unboxed → 4px; all other cells → 8px.
- */
 function toolbarGapClass({
   boxed,
   shape,
@@ -40,7 +36,6 @@ function toolbarGapClass({
   return 'gap-2';
 }
 
-/** Full class names for Tailwind static scanning (see button.tsx). */
 const toolbarSeparatorGapOffset: Record<
   ToolbarGapClass,
   { horizontal: string; vertical: string }
@@ -50,10 +45,6 @@ const toolbarSeparatorGapOffset: Record<
   'gap-3': { horizontal: '-ms-3', vertical: '-mt-3' },
 };
 
-/**
- * Collapse the flex gap before the separator so it sits flush after the
- * preceding control, matching Figma’s spacer-on-last-toggle pattern.
- */
 function toolbarSeparatorOffsetClass(context: ToolbarContextValue) {
   const offset = toolbarSeparatorGapOffset[toolbarGapClass(context)];
   return context.orientation === 'horizontal'
@@ -68,35 +59,30 @@ const toolbarIconSizeMap: Record<ToolbarSize, 'icon-sm' | 'icon' | 'icon-lg'> =
     lg: 'icon-lg',
   };
 
-/** IconShell size paired with each toolbar button size (matches icon toggle demos). */
 const toolbarIconShellSizeMap: Record<ToolbarSize, 'sm' | 'default' | 'lg'> = {
   sm: 'sm',
   reg: 'sm',
   lg: 'default',
 };
 
-/** Divider length along the toolbar cross-axis (Figma .baseTab_spacer). */
 const toolbarSeparatorLengthMap: Record<ToolbarSize, string> = {
   sm: 'h-5',
   reg: 'h-7',
   lg: 'h-8',
 };
 
-/** Horizontal divider width (Figma spacer w-[8px] / w-[12px]). */
 const toolbarSeparatorWidthMap: Record<ToolbarSize, string> = {
   sm: 'w-2',
   reg: 'w-2',
   lg: 'w-3',
 };
 
-/** Vertical divider height (Figma spacer h-[8px]). */
 const toolbarSeparatorHeightMap: Record<ToolbarSize, string> = {
   sm: 'h-2',
   reg: 'h-2',
   lg: 'h-3',
 };
 
-/** Vertical divider width (Figma spacer w-[28px] etc.). */
 const toolbarSeparatorCrossSpanMap: Record<ToolbarSize, string> = {
   sm: 'w-6',
   reg: 'w-7',
@@ -206,21 +192,6 @@ function ToolbarButton({
   );
 }
 
-function ToolbarLink({
-  className,
-  ...props
-}: React.ComponentProps<typeof ToolbarPrimitive.Link>) {
-  const context = React.useContext(ToolbarContext);
-
-  return (
-    <ToolbarPrimitive.Link
-      data-slot="toolbar-link"
-      className={toolbarItemClasses({ ...context, className })}
-      {...props}
-    />
-  );
-}
-
 function ToolbarSeparator({
   className,
   ...props
@@ -302,7 +273,6 @@ function ToolbarToggleItem({
 export {
   Toolbar,
   ToolbarButton,
-  ToolbarLink,
   ToolbarSeparator,
   ToolbarToggleGroup,
   ToolbarToggleItem,

--- a/src/components/ui/toolbar.tsx
+++ b/src/components/ui/toolbar.tsx
@@ -167,7 +167,7 @@ function Toolbar({
         data-slot="toolbar"
         data-size={size}
         data-shape={shape}
-        data-boxed={boxed ? 'true' : 'false'}
+        data-boxed={boxed}
         orientation={orientation}
         className={cn(
           toolbarVariants({ boxed, orientation, shape, size }),

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -138,7 +138,14 @@ export function getUIPrimitivesByCategory() {
       'aspect',
       'scroll',
     ],
-    Navigation: ['menu', 'navigation', 'tabs', 'breadcrumb', 'pagination', 'toolbar'],
+    Navigation: [
+      'menu',
+      'navigation',
+      'tabs',
+      'breadcrumb',
+      'pagination',
+      'toolbar',
+    ],
     Feedback: ['alert', 'progress', 'skeleton', 'badge', 'tag', 'empty'],
     Display: [
       'avatar',

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -138,7 +138,7 @@ export function getUIPrimitivesByCategory() {
       'aspect',
       'scroll',
     ],
-    Navigation: ['menu', 'navigation', 'tabs', 'breadcrumb', 'pagination'],
+    Navigation: ['menu', 'navigation', 'tabs', 'breadcrumb', 'pagination', 'toolbar'],
     Feedback: ['alert', 'progress', 'skeleton', 'badge', 'tag', 'empty'],
     Display: [
       'avatar',

--- a/src/tests/toolbar.test.tsx
+++ b/src/tests/toolbar.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { exampleComponentMaps } from '@/app/demo/[name]/index';
 import { Renderer } from '@/app/demo/[name]/renderer';
@@ -96,7 +96,7 @@ describe(`${componentName} — structure & interaction`, () => {
     );
 
     const toolbar = screen.getByRole('toolbar', { name: 'Tools' });
-    expect(toolbar).toHaveAttribute('data-boxed', 'true');
+    expect(toolbar).toHaveAttribute('data-boxed');
     expect(toolbar).toHaveAttribute('data-shape', 'square');
     expect(toolbar).toHaveAttribute('data-size', 'lg');
   });
@@ -181,15 +181,11 @@ describe(`${componentName} — structure & interaction`, () => {
 
   it('fires onClick for toolbar buttons', async () => {
     const user = userEvent.setup();
-    let clicked = false;
+    const onClick = vi.fn();
 
     render(
       <Toolbar aria-label="Tools">
-        <ToolbarButton
-          aria-label="Run action"
-          onClick={() => {
-            clicked = true;
-          }}>
+        <ToolbarButton aria-label="Run action" onClick={onClick}>
           <IconShell size="sm">
             <Icon icon="crop_free" />
           </IconShell>
@@ -199,6 +195,6 @@ describe(`${componentName} — structure & interaction`, () => {
 
     await user.click(screen.getByRole('button', { name: 'Run action' }));
 
-    expect(clicked).toBe(true);
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/tests/toolbar.test.tsx
+++ b/src/tests/toolbar.test.tsx
@@ -60,6 +60,7 @@ describe(`${componentName} — structure & interaction`, () => {
 
   it.each([
     ['gap-1', 'reg', false, 'circle'],
+    ['gap-2', 'reg', true, 'circle'],
     ['gap-2', 'sm', false, 'circle'],
     ['gap-3', 'lg', false, 'circle'],
     ['gap-3', 'lg', true, 'circle'],
@@ -84,7 +85,7 @@ describe(`${componentName} — structure & interaction`, () => {
     },
   );
 
-  it('applies boxed and variant data attributes', () => {
+  it('applies boxed and variant data attributes when boxed', () => {
     render(
       <Toolbar aria-label="Tools" boxed shape="square" size="lg">
         <ToolbarButton aria-label="Action">
@@ -96,9 +97,26 @@ describe(`${componentName} — structure & interaction`, () => {
     );
 
     const toolbar = screen.getByRole('toolbar', { name: 'Tools' });
-    expect(toolbar).toHaveAttribute('data-boxed');
+    expect(toolbar).toHaveAttribute('data-boxed', 'true');
     expect(toolbar).toHaveAttribute('data-shape', 'square');
     expect(toolbar).toHaveAttribute('data-size', 'lg');
+  });
+
+  it('sets data-boxed to false when unboxed', () => {
+    render(
+      <Toolbar aria-label="Tools">
+        <ToolbarButton aria-label="Action">
+          <IconShell size="sm">
+            <Icon icon="crop_free" />
+          </IconShell>
+        </ToolbarButton>
+      </Toolbar>,
+    );
+
+    expect(screen.getByRole('toolbar', { name: 'Tools' })).toHaveAttribute(
+      'data-boxed',
+      'false',
+    );
   });
 
   it('renders a separator between groups', () => {
@@ -160,9 +178,16 @@ describe(`${componentName} — structure & interaction`, () => {
     );
   });
 
-  it('keeps dropdown trigger as a toolbar button for roving focus', () => {
+  it('moves roving focus to dropdown trigger with arrow keys', async () => {
+    const user = userEvent.setup();
+
     render(
       <Toolbar aria-label="Tools">
+        <ToolbarButton aria-label="First tool">
+          <IconShell size="sm">
+            <Icon icon="crop_free" />
+          </IconShell>
+        </ToolbarButton>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <ToolbarButton aria-label="Open menu">Menu</ToolbarButton>
@@ -174,9 +199,14 @@ describe(`${componentName} — structure & interaction`, () => {
       </Toolbar>,
     );
 
-    const toolbar = screen.getByRole('toolbar', { name: 'Tools' });
-    const trigger = screen.getByRole('button', { name: 'Open menu' });
-    expect(toolbar).toContainElement(trigger);
+    const firstTool = screen.getByRole('button', { name: 'First tool' });
+    const menuTrigger = screen.getByRole('button', { name: 'Open menu' });
+
+    await user.click(firstTool);
+    expect(firstTool).toHaveFocus();
+
+    await user.keyboard('{ArrowRight}');
+    expect(menuTrigger).toHaveFocus();
   });
 
   it('fires onClick for toolbar buttons', async () => {

--- a/src/tests/toolbar.test.tsx
+++ b/src/tests/toolbar.test.tsx
@@ -45,6 +45,32 @@ describe(`${componentName} — structure & interaction`, () => {
     ).toBeInTheDocument();
   });
 
+  it.each([
+    ['reg', false, 'circle', 'gap-1'],
+    ['sm', false, 'circle', 'gap-2'],
+    ['lg', false, 'circle', 'gap-3'],
+    ['lg', true, 'circle', 'gap-3'],
+    ['lg', false, 'square', 'gap-3'],
+    ['reg', false, 'square', 'gap-2'],
+  ] as const)(
+    'applies %s when size=%s boxed=%s shape=%s',
+    (size, boxed, shape, gapClass) => {
+      render(
+        <Toolbar aria-label="Tools" boxed={boxed} shape={shape} size={size}>
+          <ToolbarButton aria-label="Action">
+            <IconShell size="sm">
+              <Icon icon="crop_free" />
+            </IconShell>
+          </ToolbarButton>
+        </Toolbar>,
+      );
+
+      expect(screen.getByRole('toolbar', { name: 'Tools' })).toHaveClass(
+        gapClass,
+      );
+    },
+  );
+
   it('applies boxed and variant data attributes', () => {
     render(
       <Toolbar aria-label="Tools" boxed shape="square" size="lg">

--- a/src/tests/toolbar.test.tsx
+++ b/src/tests/toolbar.test.tsx
@@ -1,0 +1,144 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { exampleComponentMaps } from '@/app/demo/[name]/index';
+import { Icon } from '@/components/ui/icon';
+import { IconShell } from '@/components/ui/icon-shell';
+import {
+  Toolbar,
+  ToolbarButton,
+  ToolbarSeparator,
+  ToolbarToggleGroup,
+  ToolbarToggleItem,
+} from '@/components/ui/toolbar';
+
+const componentName = 'toolbar';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe(`${componentName} — all examples render`, () => {
+  it.each(Object.entries(exampleComponentMaps[componentName]))(
+    'renders "%s" without crashing',
+    (_, Example) => {
+      expect(() => render(<Example />)).not.toThrow();
+    },
+  );
+});
+
+describe(`${componentName} — structure & interaction`, () => {
+  it('renders with toolbar role', () => {
+    render(
+      <Toolbar aria-label="Editor tools">
+        <ToolbarButton aria-label="Action">
+          <IconShell size="sm">
+            <Icon icon="crop_free" />
+          </IconShell>
+        </ToolbarButton>
+      </Toolbar>,
+    );
+
+    expect(screen.getByRole('toolbar', { name: 'Editor tools' })).toBeInTheDocument();
+  });
+
+  it('applies boxed and variant data attributes', () => {
+    render(
+      <Toolbar aria-label="Tools" boxed shape="square" size="lg">
+        <ToolbarButton aria-label="Action">
+          <IconShell size="sm">
+            <Icon icon="crop_free" />
+          </IconShell>
+        </ToolbarButton>
+      </Toolbar>,
+    );
+
+    const toolbar = screen.getByRole('toolbar', { name: 'Tools' });
+    expect(toolbar).toHaveAttribute('data-boxed', 'true');
+    expect(toolbar).toHaveAttribute('data-shape', 'square');
+    expect(toolbar).toHaveAttribute('data-size', 'lg');
+  });
+
+  it('renders a separator between groups', () => {
+    render(
+      <Toolbar aria-label="Tools">
+        <ToolbarButton aria-label="First">
+          <IconShell size="sm">
+            <Icon icon="crop_free" />
+          </IconShell>
+        </ToolbarButton>
+        <ToolbarSeparator />
+        <ToolbarButton aria-label="Second">
+          <IconShell size="sm">
+            <Icon icon="crop_free" />
+          </IconShell>
+        </ToolbarButton>
+      </Toolbar>,
+    );
+
+    expect(
+      document.querySelector('[data-slot="toolbar-separator"]'),
+    ).toBeInTheDocument();
+  });
+
+  it('activates a toggle item when clicked', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Toolbar aria-label="Tools">
+        <ToolbarToggleGroup type="single" defaultValue="a">
+          <ToolbarToggleItem aria-label="Tool A" value="a">
+            <IconShell size="sm">
+              <Icon icon="crop_free" />
+            </IconShell>
+          </ToolbarToggleItem>
+          <ToolbarToggleItem aria-label="Tool B" value="b">
+            <IconShell size="sm">
+              <Icon icon="crop_free" />
+            </IconShell>
+          </ToolbarToggleItem>
+        </ToolbarToggleGroup>
+      </Toolbar>,
+    );
+
+    expect(screen.getByRole('radio', { name: 'Tool A' })).toHaveAttribute(
+      'data-state',
+      'on',
+    );
+
+    await user.click(screen.getByRole('radio', { name: 'Tool B' }));
+
+    expect(screen.getByRole('radio', { name: 'Tool B' })).toHaveAttribute(
+      'data-state',
+      'on',
+    );
+    expect(screen.getByRole('radio', { name: 'Tool A' })).toHaveAttribute(
+      'data-state',
+      'off',
+    );
+  });
+
+  it('fires onClick for toolbar buttons', async () => {
+    const user = userEvent.setup();
+    let clicked = false;
+
+    render(
+      <Toolbar aria-label="Tools">
+        <ToolbarButton
+          aria-label="Run action"
+          onClick={() => {
+            clicked = true;
+          }}>
+          <IconShell size="sm">
+            <Icon icon="crop_free" />
+          </IconShell>
+        </ToolbarButton>
+      </Toolbar>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Run action' }));
+
+    expect(clicked).toBe(true);
+  });
+});

--- a/src/tests/toolbar.test.tsx
+++ b/src/tests/toolbar.test.tsx
@@ -40,7 +40,9 @@ describe(`${componentName} — structure & interaction`, () => {
       </Toolbar>,
     );
 
-    expect(screen.getByRole('toolbar', { name: 'Editor tools' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('toolbar', { name: 'Editor tools' }),
+    ).toBeInTheDocument();
   });
 
   it('applies boxed and variant data attributes', () => {

--- a/src/tests/toolbar.test.tsx
+++ b/src/tests/toolbar.test.tsx
@@ -4,6 +4,12 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { exampleComponentMaps } from '@/app/demo/[name]/index';
 import { Renderer } from '@/app/demo/[name]/renderer';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Icon } from '@/components/ui/icon';
 import { IconShell } from '@/components/ui/icon-shell';
 import {
@@ -152,6 +158,25 @@ describe(`${componentName} — structure & interaction`, () => {
       'data-state',
       'off',
     );
+  });
+
+  it('keeps dropdown trigger as a toolbar button for roving focus', () => {
+    render(
+      <Toolbar aria-label="Tools">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <ToolbarButton aria-label="Open menu">Menu</ToolbarButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </Toolbar>,
+    );
+
+    const toolbar = screen.getByRole('toolbar', { name: 'Tools' });
+    const trigger = screen.getByRole('button', { name: 'Open menu' });
+    expect(toolbar).toContainElement(trigger);
   });
 
   it('fires onClick for toolbar buttons', async () => {

--- a/src/tests/toolbar.test.tsx
+++ b/src/tests/toolbar.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { exampleComponentMaps } from '@/app/demo/[name]/index';
+import { Renderer } from '@/app/demo/[name]/renderer';
 import { Icon } from '@/components/ui/icon';
 import { IconShell } from '@/components/ui/icon-shell';
 import {
@@ -23,7 +24,13 @@ describe(`${componentName} — all examples render`, () => {
   it.each(Object.entries(exampleComponentMaps[componentName]))(
     'renders "%s" without crashing',
     (_, Example) => {
-      expect(() => render(<Example />)).not.toThrow();
+      expect(() =>
+        render(
+          <Renderer>
+            <Example />
+          </Renderer>,
+        ),
+      ).not.toThrow();
     },
   );
 });
@@ -46,15 +53,15 @@ describe(`${componentName} — structure & interaction`, () => {
   });
 
   it.each([
-    ['reg', false, 'circle', 'gap-1'],
-    ['sm', false, 'circle', 'gap-2'],
-    ['lg', false, 'circle', 'gap-3'],
-    ['lg', true, 'circle', 'gap-3'],
-    ['lg', false, 'square', 'gap-3'],
-    ['reg', false, 'square', 'gap-2'],
+    ['gap-1', 'reg', false, 'circle'],
+    ['gap-2', 'sm', false, 'circle'],
+    ['gap-3', 'lg', false, 'circle'],
+    ['gap-3', 'lg', true, 'circle'],
+    ['gap-3', 'lg', false, 'square'],
+    ['gap-2', 'reg', false, 'square'],
   ] as const)(
-    'applies %s when size=%s boxed=%s shape=%s',
-    (size, boxed, shape, gapClass) => {
+    'applies %s gap when size=%s boxed=%s shape=%s',
+    (gapClass, size, boxed, shape) => {
       render(
         <Toolbar aria-label="Tools" boxed={boxed} shape={shape} size={size}>
           <ToolbarButton aria-label="Action">


### PR DESCRIPTION
## Description
Closes https://github.com/McK-Internal/qbds-internal/issues/92

- Adds Toolbar to the QBDS registry, aligned with Figma [ToolBar-Button](https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr/QBDS-v2.0.0?node-id=38586-26970&m=dev).
- Based on Radix toolbar + ghost icon Buttons (variants: sm / reg / lg, boxed, circle/square, horizontal/vertical)
- Includes demos, registry entry, and tests.

## Screenshot
<img width="1920" height="1080" alt="Screenshot 2026-06-03 at 18 30 22" src="https://github.com/user-attachments/assets/9a5f03a8-1e8b-4a40-82ac-c8eddfd78461" />
