### PR TITLE
chore(tidy): Sync tokens and fix sidebar size defaults

### DIFF
--- a/.agents/skills/figma-token-sync/SKILL.md
+++ b/.agents/skills/figma-token-sync/SKILL.md
@@ -17,7 +17,7 @@ Two paths to read variables — pick the first that applies:
 
 | #   | Condition                                                   | Method                                                                                                             |
 | --- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| 1   | `.env` exists and contains a non-empty `FIGMA_ACCESS_TOKEN` | **Figma REST API** (fastest — see step 1 below)                                                                    |
+| 1   | `.env` exists and contains a non-empty `FIGMA_ACCESS_TOKEN` | **Figma REST API** (fastest — see Path A below)                                                                    |
 | 2   | No token available                                          | **Figma MCP** `get_variable_defs` — ask the user to open the QBDS Figma file, select any layer, then call the tool |
 
 Note: `search_design_system` returns metadata only (no values) — do not use it for syncing.

--- a/.agents/skills/figma-token-sync/SKILL.md
+++ b/.agents/skills/figma-token-sync/SKILL.md
@@ -9,11 +9,18 @@ description: Sync QBDS Figma variables (DS_THEMES, Radius, DS-Primitives) into g
 
 ## Figma source
 
-- **File:** [QBDS v2.0.0](https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr/QBDS-v2.0.0?node-id=1878-17156&view=variables&var-set-id=26698-8497&m=dev)
+- **File:** [QBDS v2.0.0](https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr/QBDS-v2.0.0?node-id=1878-17156&view=variables&p=f&t=z4NTULUiQsv5yiJM-0)
 - **Variable sets to read:** `DS_THEMES`, `Radius`, `DS-Primitives`
 - **Modes:** light and dark (both must be synced)
 
-Use Figma MCP (`get_variable_defs` or variable export via the Figma plugin) to read resolved values. Load the **figma-use** skill before `use_figma` calls if needed.
+Two paths to read variables — pick the first that applies:
+
+| #   | Condition                                                   | Method                                                                                                             |
+| --- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| 1   | `.env` exists and contains a non-empty `FIGMA_ACCESS_TOKEN` | **Figma REST API** (fastest — see step 1 below)                                                                    |
+| 2   | No token available                                          | **Figma MCP** `get_variable_defs` — ask the user to open the QBDS Figma file, select any layer, then call the tool |
+
+Note: `search_design_system` returns metadata only (no values) — do not use it for syncing.
 
 ## Code targets (read before editing)
 
@@ -36,10 +43,68 @@ Use Figma MCP (`get_variable_defs` or variable export via the Figma plugin) to r
 
 ### 1 — Read Figma variables
 
-1. Confirm designers have published changes in the QBDS v2.0.0 file.
-2. Read [`docs/TOKENS.md`](docs/TOKENS.md) — for each semantic token you will sync, note its **Design name** (e.g. `--fill-active` → `Fill/Content/Active`). Use that exact Figma path when reading `DS_THEMES`; do not match by similar names in the Figma file.
-3. Read all variables from `DS-Primitives`, `DS_THEMES`, and `Radius` for **light** and **dark** modes.
-4. Build a diff table: Design name (from TOKENS.md) → CSS variable → old `var()` binding → new binding. Flag **renames** and **removed** tokens.
+1. Read [`docs/TOKENS.md`](docs/TOKENS.md) — note each token's **Design name** column (e.g. `--fill-active` → `Fill/Content/Active`). These are the canonical Figma paths to match against.
+
+2. **Path A — REST API (preferred when `.env` has `FIGMA_ACCESS_TOKEN`):**
+
+```bash
+source .env
+curl -s -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" \
+  "https://api.figma.com/v1/files/iuMWqCsIohoKAUB0tBS0xr/variables/local" \
+  -o /tmp/figma_vars.json
+```
+
+Then proceed to steps 3–7 below.
+
+**Path B — Figma MCP (no token available):**
+
+Ask the user to open the [QBDS v2.0.0 variables page](https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr/QBDS-v2.0.0?node-id=1878-17156&view=variables&p=f&t=z4NTULUiQsv5yiJM-0) in the Figma desktop app and select any layer. Then use the Figma MCP `get_variable_defs` tool, pointing it at the QBDS v2.0.0 file and node `1878:17156`. The tool returns resolved variable values for the whole file. Extract DS_Themes (light + dark), DS-Primitives, and Radius values from the response and build the diff table manually — skip steps 3–5 and go straight to step 6.
+
+3. The three local collections and their known stable IDs are:
+
+| Collection      | ID                                 | Modes                                |
+| --------------- | ---------------------------------- | ------------------------------------ |
+| `DS_Themes`     | `VariableCollectionId:26698:8497`  | Dark = `32620:0`, Light = `26698:0`  |
+| `DS-Primitives` | `VariableCollectionId:33946:8988`  | Value = `33946:1`                    |
+| `Radius`        | `VariableCollectionId:35241:30757` | Sharp = `35241:0`, Round = `35241:1` |
+
+If collection IDs look wrong (file was recreated), discover them with:
+
+```bash
+jq '.meta.variableCollections | to_entries[] | {id: .key, name: .value.name, modes: (.value.modes | map(.name))}' /tmp/figma_vars.json
+```
+
+4. Resolve the DS_Themes alias chain to primitive names in one `jq` pass:
+
+```bash
+jq -r '
+  (.meta.variables | to_entries | map({key: .key, value: .value.name}) | from_entries) as $idToName |
+  .meta.variables | to_entries[] |
+  select(.value.variableCollectionId == "VariableCollectionId:26698:8497") |
+  .value as $v |
+  {
+    name: $v.name,
+    light: (if ($v.valuesByMode["26698:0"] | type) == "object" and $v.valuesByMode["26698:0"].type == "VARIABLE_ALIAS"
+            then $idToName[$v.valuesByMode["26698:0"].id] else ($v.valuesByMode["26698:0"] | tostring) end),
+    dark:  (if ($v.valuesByMode["32620:0"] | type) == "object" and $v.valuesByMode["32620:0"].type == "VARIABLE_ALIAS"
+            then $idToName[$v.valuesByMode["32620:0"].id] else ($v.valuesByMode["32620:0"] | tostring) end)
+  }
+' /tmp/figma_vars.json
+```
+
+5. Extract Radius values:
+
+```bash
+jq -r '
+  .meta.variables | to_entries[] |
+  select(.value.variableCollectionId == "VariableCollectionId:35241:30757") |
+  {name: .value.name, sharp: .value.valuesByMode["35241:0"], round: .value.valuesByMode["35241:1"]}
+' /tmp/figma_vars.json
+```
+
+6. Build a diff table: Design name (from TOKENS.md) → CSS variable → current `var()` binding → new binding. Flag **renames** and **removed** tokens.
+
+7. Remove the temp file when done: `rm /tmp/figma_vars.json`
 
 ### 2 — Update `globals.css`
 
@@ -90,10 +155,3 @@ Report a summary: tokens added/changed/removed, files touched, grep hits fixed, 
 - [ ] `docs/TOKENS.md` matches `globals.css` (including Design name column)
 - [ ] Renamed/removed tokens grepped and fixed in `src/`
 - [ ] `npm run build` and `npm run lint` pass
-
-## Minimal trigger prompt
-
-```
-Designers updated Figma variables. Sync tokens into code.
-Variable sets: DS_THEMES, Radius, DS-Primitives
-```

--- a/.agents/skills/figma-token-sync/SKILL.md
+++ b/.agents/skills/figma-token-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figma-token-sync
-description: Sync QBDS Figma variables (DS_THEMES, Radius, DS-Primitives) into globals.css and TOKENS.md. Use only when designers have updated Figma variables and tokens need to flow into code (light + dark modes). Triggers — "sync tokens", "figma token sync", "designers updated variables", or a Figma variables URL for the QBDS v2.0.0 file. For component-only work use figma-parity instead.
+description: Sync QBDS Figma variables (DS_Themes, Radius, DS-Primitives) into globals.css and TOKENS.md. Use only when designers have updated Figma variables and tokens need to flow into code (light + dark modes). Triggers — "sync tokens", "figma token sync", "designers updated variables", or a Figma variables URL for the QBDS v2.0.0 file. For component-only work use figma-parity instead.
 ---
 
 # Figma → code token sync (QBDS)
@@ -10,17 +10,10 @@ description: Sync QBDS Figma variables (DS_THEMES, Radius, DS-Primitives) into g
 ## Figma source
 
 - **File:** [QBDS v2.0.0](https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr/QBDS-v2.0.0?node-id=1878-17156&view=variables&p=f&t=z4NTULUiQsv5yiJM-0)
-- **Variable sets to read:** `DS_THEMES`, `Radius`, `DS-Primitives`
+- **Variable sets to read:** `DS_Themes`, `Radius`, `DS-Primitives`
 - **Modes:** light and dark (both must be synced)
 
-Two paths to read variables — pick the first that applies:
-
-| #   | Condition                                                   | Method                                                                                                             |
-| --- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| 1   | `.env` exists and contains a non-empty `FIGMA_ACCESS_TOKEN` | **Figma REST API** (fastest — see step 1 below)                                                                    |
-| 2   | No token available                                          | **Figma MCP** `get_variable_defs` — ask the user to open the QBDS Figma file, select any layer, then call the tool |
-
-Note: `search_design_system` returns metadata only (no values) — do not use it for syncing.
+Use the Figma MCP `get_variable_defs` tool to read resolved values. Note: `search_design_system` returns metadata only (no values) — do not use it for syncing.
 
 ## Code targets (read before editing)
 
@@ -45,71 +38,25 @@ Note: `search_design_system` returns metadata only (no values) — do not use it
 
 1. Read [`docs/TOKENS.md`](docs/TOKENS.md) — note each token's **Design name** column (e.g. `--fill-active` → `Fill/Content/Active`). These are the canonical Figma paths to match against.
 
-2. **Path A — REST API (preferred when `.env` has `FIGMA_ACCESS_TOKEN`):**
+2. Call the Figma MCP `get_variable_defs` tool pointing at the QBDS v2.0.0 file and node `1878:17156`.
+   - If the tool responds "nothing selected": this is a known limitation of the Figma plugin sandbox — it checks for an active selection before running, even though `fileKey` and `nodeId` are provided explicitly. Ask the user to open the [QBDS v2.0.0 variables page](https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr/QBDS-v2.0.0?node-id=1878-17156&view=variables&p=f&t=z4NTULUiQsv5yiJM-0) in the Figma desktop app, click any layer, and retry. The selection does not affect the data returned.
+   - The response contains all file variables with `valuesByMode` entries. Most semantic tokens will be `VARIABLE_ALIAS` references — follow the `id` to the primitive variable (also in the response) to get the resolved name (e.g. `Slate 900/opacity-88`).
+   - Focus on the three local collections:
 
-```bash
-source .env
-curl -s -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" \
-  "https://api.figma.com/v1/files/iuMWqCsIohoKAUB0tBS0xr/variables/local" \
-  -o /tmp/figma_vars.json
-```
+   | Collection      | Modes           |
+   | --------------- | --------------- |
+   | `DS_Themes`     | Dark and Light  |
+   | `DS-Primitives` | Value           |
+   | `Radius`        | Sharp and Round |
 
-Then proceed to steps 3–7 below.
+3. For each `DS_Themes` token, resolve both Light and Dark mode aliases to their primitive name and compare against the current `var()` binding in `globals.css`.
 
-**Path B — Figma MCP (no token available):**
-
-Ask the user to open the [QBDS v2.0.0 variables page](https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr/QBDS-v2.0.0?node-id=1878-17156&view=variables&p=f&t=z4NTULUiQsv5yiJM-0) in the Figma desktop app and select any layer. Then use the Figma MCP `get_variable_defs` tool, pointing it at the QBDS v2.0.0 file and node `1878:17156`. The tool returns resolved variable values for the whole file. Extract DS_Themes (light + dark), DS-Primitives, and Radius values from the response and build the diff table manually — skip steps 3–5 and go straight to step 6.
-
-3. The three local collections and their known stable IDs are:
-
-| Collection      | ID                                 | Modes                                |
-| --------------- | ---------------------------------- | ------------------------------------ |
-| `DS_Themes`     | `VariableCollectionId:26698:8497`  | Dark = `32620:0`, Light = `26698:0`  |
-| `DS-Primitives` | `VariableCollectionId:33946:8988`  | Value = `33946:1`                    |
-| `Radius`        | `VariableCollectionId:35241:30757` | Sharp = `35241:0`, Round = `35241:1` |
-
-If collection IDs look wrong (file was recreated), discover them with:
-
-```bash
-jq '.meta.variableCollections | to_entries[] | {id: .key, name: .value.name, modes: (.value.modes | map(.name))}' /tmp/figma_vars.json
-```
-
-4. Resolve the DS_Themes alias chain to primitive names in one `jq` pass:
-
-```bash
-jq -r '
-  (.meta.variables | to_entries | map({key: .key, value: .value.name}) | from_entries) as $idToName |
-  .meta.variables | to_entries[] |
-  select(.value.variableCollectionId == "VariableCollectionId:26698:8497") |
-  .value as $v |
-  {
-    name: $v.name,
-    light: (if ($v.valuesByMode["26698:0"] | type) == "object" and $v.valuesByMode["26698:0"].type == "VARIABLE_ALIAS"
-            then $idToName[$v.valuesByMode["26698:0"].id] else ($v.valuesByMode["26698:0"] | tostring) end),
-    dark:  (if ($v.valuesByMode["32620:0"] | type) == "object" and $v.valuesByMode["32620:0"].type == "VARIABLE_ALIAS"
-            then $idToName[$v.valuesByMode["32620:0"].id] else ($v.valuesByMode["32620:0"] | tostring) end)
-  }
-' /tmp/figma_vars.json
-```
-
-5. Extract Radius values:
-
-```bash
-jq -r '
-  .meta.variables | to_entries[] |
-  select(.value.variableCollectionId == "VariableCollectionId:35241:30757") |
-  {name: .value.name, sharp: .value.valuesByMode["35241:0"], round: .value.valuesByMode["35241:1"]}
-' /tmp/figma_vars.json
-```
-
-6. Build a diff table: Design name (from TOKENS.md) → CSS variable → current `var()` binding → new binding. Flag **renames** and **removed** tokens.
-
-7. Remove the temp file when done: `rm /tmp/figma_vars.json`
+4. Build a diff table: Design name (from TOKENS.md) → CSS variable → current `var()` binding → new binding. Flag **renames** and **removed** tokens.
 
 ### 2 — Update `globals.css`
 
 1. Update **primitives** in `@theme inline` if `DS-Primitives` changed (oklch values, opacity steps).
-2. Update **semantic mappings** in `:root` (light) and `.dark` (dark) from `DS_THEMES`.
+2. Update **semantic mappings** in `:root` (light) and `.dark` (dark) from `DS_Themes`.
 3. Update **radius** in `:root` / `.dark` (sharp defaults) and `.radius-mode` (rounded overrides) from `Radius`.
 4. Keep semantic tokens referencing primitives via `var(...)` — do not inline raw oklch in semantic blocks unless Figma aliases require it.
 5. Verify the `@theme inline` bridge still maps every semantic token to a `--color-*` utility.
@@ -149,7 +96,7 @@ Report a summary: tokens added/changed/removed, files touched, grep hits fixed, 
 
 ## Acceptance checklist
 
-- [ ] Figma variables read from `DS_THEMES`, `Radius`, `DS-Primitives` (light + dark)
+- [ ] Figma variables read from `DS_Themes`, `Radius`, `DS-Primitives` (light + dark)
 - [ ] `globals.css` updated: primitives, `:root`, `.dark`, `.radius-mode` as needed
 - [ ] `@theme inline` bridge intact; no broken `var()` chains
 - [ ] `docs/TOKENS.md` matches `globals.css` (including Design name column)

--- a/docs/TOKENS.md
+++ b/docs/TOKENS.md
@@ -42,7 +42,7 @@ Content-bearing fills: button bodies, tooltip backgrounds, icons, sliders, tags,
 | `--fill-secondary`    | `bg-fill-secondary`    | Medium contrast accent backgrounds.                                                                                    | `Fill/Content/Secondary`         |
 | `--fill-tertiary`     | `bg-fill-tertiary`     | Medium colour contrast overlay on high contrast items, UI shells / panels, tiles.                                      | `Fill/Content/Tertiary`          |
 | `--fill-active`       | `bg-fill-active`       | Active state fill for icons, button backgrounds, tags, switches, toggle items, sliders.                                | `Fill/Content/Active`            |
-| `--fill-active-alpha` | `bg-fill-active-alpha` | Opacity-based active fill — same hue as `fill-active` but semi-transparent; use where a solid fill would be too harsh. | `Fill/Active`                    |
+| `--fill-active-alpha` | `bg-fill-active-alpha` | Semi-transparent active/highlight fill (Figma: `Fill/Active`). | `Fill/Active` |
 | `--fill-disabled`     | `bg-fill-disabled`     | Any fill for disabled elements that sit on `fill-muted` or surface tokens.                                             | `Fill/Content/Disabled`          |
 | `--slider-track`      | `bg-slider-track`      | Slider track, step markers, stepper track fills.                                                                       | `Fill/Content/StepMarkers-Track` |
 | `--fill-*-inverse`    | `bg-fill-*-inverse`    | Same usage as the non-inverse token, tuned for high-contrast / theme-switch contexts.                                  | `Fill/Content/*-Inverse`         |

--- a/docs/TOKENS.md
+++ b/docs/TOKENS.md
@@ -36,15 +36,16 @@ Page and panel backgrounds. The chrome.
 
 Content-bearing fills: button bodies, tooltip backgrounds, icons, sliders, tags, switches.
 
-| CSS variable       | Tailwind            | Use for                                                                                 | Design name                      |
-| ------------------ | ------------------- | --------------------------------------------------------------------------------------- | -------------------------------- |
-| `--fill-primary`   | `bg-fill-primary`   | Buttons and tooltip backgrounds; high contrast / emphasised items; accents.             | `Fill/Content/Primary`           |
-| `--fill-secondary` | `bg-fill-secondary` | Medium contrast accent backgrounds.                                                     | `Fill/Content/Secondary`         |
-| `--fill-tertiary`  | `bg-fill-tertiary`  | Medium colour contrast overlay on high contrast items, UI shells / panels, tiles.       | `Fill/Content/Tertiary`          |
-| `--fill-active`    | `bg-fill-active`    | Active state fill for icons, button backgrounds, tags, switches, toggle items, sliders. | `Fill/Content/Active`            |
-| `--fill-disabled`  | `bg-fill-disabled`  | Any fill for disabled elements that sit on `fill-muted` or surface tokens.              | `Fill/Content/Disabled`          |
-| `--slider-track`   | `bg-slider-track`   | Slider track, step markers, stepper track fills.                                        | `Fill/Content/StepMarkers-Track` |
-| `--fill-*-inverse` | `bg-fill-*-inverse` | Same usage as the non-inverse token, tuned for high-contrast / theme-switch contexts.   | `Fill/Content/*-Inverse`         |
+| CSS variable          | Tailwind               | Use for                                                                                                                | Design name                      |
+| --------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `--fill-primary`      | `bg-fill-primary`      | Buttons and tooltip backgrounds; high contrast / emphasised items; accents.                                            | `Fill/Content/Primary`           |
+| `--fill-secondary`    | `bg-fill-secondary`    | Medium contrast accent backgrounds.                                                                                    | `Fill/Content/Secondary`         |
+| `--fill-tertiary`     | `bg-fill-tertiary`     | Medium colour contrast overlay on high contrast items, UI shells / panels, tiles.                                      | `Fill/Content/Tertiary`          |
+| `--fill-active`       | `bg-fill-active`       | Active state fill for icons, button backgrounds, tags, switches, toggle items, sliders.                                | `Fill/Content/Active`            |
+| `--fill-active-alpha` | `bg-fill-active-alpha` | Opacity-based active fill — same hue as `fill-active` but semi-transparent; use where a solid fill would be too harsh. | `Fill/Active`                    |
+| `--fill-disabled`     | `bg-fill-disabled`     | Any fill for disabled elements that sit on `fill-muted` or surface tokens.                                             | `Fill/Content/Disabled`          |
+| `--slider-track`      | `bg-slider-track`      | Slider track, step markers, stepper track fills.                                                                       | `Fill/Content/StepMarkers-Track` |
+| `--fill-*-inverse`    | `bg-fill-*-inverse`    | Same usage as the non-inverse token, tuned for high-contrast / theme-switch contexts.                                  | `Fill/Content/*-Inverse`         |
 
 ## Fill — onSurface
 
@@ -58,7 +59,6 @@ UI containers that sit **on top of** surface tokens: tiles, input field backgrou
 | `--fill-onsurface-ui-2`                         | `bg-fill-onsurface-ui-2`                          | Solid avatar (mono) backgrounds, medium contrast tiles, UI containers that sit on surface tokens.                                                     | `Fill/onSurface/bg-ui2`                                         |
 | `--fill-onsurface-ui-3`                         | `bg-fill-onsurface-ui-3`                          | Solid UI backgrounds — field inputs, notification/toast/sonner panels that sit on surface tokens.                                                     | `Fill/onSurface/bg-ui3`                                         |
 | `--fill-subtle-inverse`, `--fill-muted-inverse` | `bg-fill-subtle-inverse`, `bg-fill-muted-inverse` | High-contrast / theme-switch variants of the above.                                                                                                   | `Fill/onSurface/Subtle-Inverse`, `Fill/onSurface/Muted-Inverse` |
-| `--fill-selected-range`                         | `bg-fill-selected-range`                          | Selected range highlight in calendars, sliders, charts.                                                                                               | `Fill/selected-range`                                           |
 
 ## Text
 

--- a/src/app/demo/[name]/ui/sidebar.tsx
+++ b/src/app/demo/[name]/ui/sidebar.tsx
@@ -140,7 +140,7 @@ function AppHeader({
   onToggleFullscreen: () => void;
 }) {
   return (
-    <header className="border-stroke-divider bg-surface-primary flex h-[72px] shrink-0 items-center gap-3 border-b px-6">
+    <header className="border-stroke-divider bg-surface-primary flex h-[64px] shrink-0 items-center gap-3 border-b px-6">
       <RegistryLogo className="h-6 w-6" />
       <span className="headings-h3-regular text-fg-primary">QuantumBlack</span>
       <Button size="sm" className="ml-auto" onClick={onToggleFullscreen}>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -73,7 +73,7 @@ function SidebarProvider({
   defaultOpen = true,
   open: openProp,
   onOpenChange: setOpenProp,
-  size = 'lg',
+  size = 'default',
   className,
   style,
   children,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -318,7 +318,7 @@
   --color-fill-disabled-inverse: var(--fill-disabled-inverse);
   --color-fill-active-inverse: var(--fill-active-inverse);
   --color-fill-muted-inverse: var(--fill-muted-inverse);
-  --color-fill-selected-range: var(--fill-selected-range);
+  --color-fill-active-alpha: var(--fill-active-alpha);
   --color-fill-onsurface-ui-1: var(--fill-onsurface-ui-1);
   --color-fill-onsurface-ui-2: var(--fill-onsurface-ui-2);
   --color-fill-onsurface-ui-3: var(--fill-onsurface-ui-3);
@@ -471,7 +471,7 @@
   --fill-muted-inverse: var(--mist-50-opacity-8);
   --fill-disabled-inverse: var(--mist-50-opacity-38);
   --fill-active-inverse: var(--mist-50);
-  --fill-selected-range: var(--slate-900-opacity-8);
+  --fill-active-alpha: var(--slate-900-opacity-88);
   --fill-onsurface-ui-1: var(--mist-100);
   --fill-onsurface-ui-2: var(--mist-300);
   --fill-onsurface-ui-3: var(--mist-200);
@@ -582,7 +582,7 @@
   --fill-muted-inverse: var(--slate-900-opacity-8);
   --fill-disabled-inverse: var(--slate-900-opacity-38);
   --fill-active-inverse: var(--slate-950);
-  --fill-selected-range: var(--mist-50-opacity-8);
+  --fill-active-alpha: var(--mist-50-opacity-88);
   --fill-onsurface-ui-1: var(--slate-600);
   --fill-onsurface-ui-2: var(--slate-300);
   --fill-onsurface-ui-3: var(--slate-400);


### PR DESCRIPTION
### Description

- Add `--fill-active-alpha` token from Figma (`Fill/Active`) to globals.css and TOKENS.md
- Remove `--fill-selected-range` (no Figma backing, no component usages), confirmed with  @dandumitriu1 
- Fix `SidebarProvider` defaulting to `lg` size - now defaults to `default`
- Fix app shell demo header height to 64px
- Rewrite figma-token-sync skill to use the Figma REST API instead of the MCP plugin (much faster)