### PR TITLE
dev(ci): block committed Figma URLs via gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,3 +2,17 @@ title = "quantumblack-design-system"
 
 [extend]
 useDefault = true
+
+[[rules]]
+id = "figma-url"
+description = "Do not commit Figma URLs; keep them in .env as FIGMA_URL_*"
+regex = '''https?://([a-zA-Z0-9-]+\.)?figma\.com/'''
+keywords = ["figma.com"]
+
+[[rules.allowlists]]
+description = "Temporary: figma-token-sync skill docs"
+paths = ['''\.agents/skills/figma-token-sync/''']
+
+[[rules.allowlists]]
+description = "Unit tests for figma-url rule"
+paths = ['''src/tests/figma-url-gitleaks\.test\.ts''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,7 +12,3 @@ keywords = ["figma.com"]
 [[rules.allowlists]]
 description = "Temporary: figma-token-sync skill docs"
 paths = ['''\.agents/skills/figma-token-sync/''']
-
-[[rules.allowlists]]
-description = "Unit tests for figma-url rule"
-paths = ['''src/tests/figma-url-gitleaks\.test\.ts''']

--- a/src/tests/figma-url-gitleaks.test.ts
+++ b/src/tests/figma-url-gitleaks.test.ts
@@ -1,13 +1,35 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-const FIGMA_URL_RE = /https?:\/\/([a-zA-Z0-9-]+\.)?figma\.com\//;
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+);
+
+function loadFigmaUrlRe(): RegExp {
+  const toml = fs.readFileSync(path.join(REPO_ROOT, '.gitleaks.toml'), 'utf8');
+  const match = toml.match(
+    /id\s*=\s*"figma-url"[\s\S]*?regex\s*=\s*'''([^']+)'''/,
+  );
+
+  if (!match?.[1]) {
+    throw new Error('figma-url regex missing from .gitleaks.toml');
+  }
+
+  return new RegExp(match[1]);
+}
+
+const FIGMA_URL_RE = loadFigmaUrlRe();
+const HOST = 'figma' + '.com';
 
 describe('figma-url gitleaks regex', () => {
   it.each([
-    'https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr/QBDS-v2.0.0?node-id=36231-110652',
-    'http://figma.com/file/abc',
-    'FIGMA_URL_QBDS_CHECKBOX=https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr/QBDS-v2.0.0?node-id=36231-110652',
-    'See https://figma.com/design/x',
+    `https://www.${HOST}/design/fakeFileKey000000000000/QBDS-v0?node-id=1-2`,
+    `http://${HOST}/file/abc`,
+    `FIGMA_URL_QBDS_CHECKBOX=https://www.${HOST}/design/fakeFileKey000000000000/QBDS-v0?node-id=1-2`,
+    `See https://${HOST}/design/x`,
   ])('blocks %s', line => {
     expect(FIGMA_URL_RE.test(line)).toBe(true);
   });

--- a/src/tests/figma-url-gitleaks.test.ts
+++ b/src/tests/figma-url-gitleaks.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+const FIGMA_URL_RE = /https?:\/\/([a-zA-Z0-9-]+\.)?figma\.com\//;
+
+describe('figma-url gitleaks regex', () => {
+  it.each([
+    'https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr/QBDS-v2.0.0?node-id=36231-110652',
+    'http://figma.com/file/abc',
+    'FIGMA_URL_QBDS_CHECKBOX=https://www.figma.com/design/iuMWqCsIohoKAUB0tBS0xr/QBDS-v2.0.0?node-id=36231-110652',
+    'See https://figma.com/design/x',
+  ])('blocks %s', line => {
+    expect(FIGMA_URL_RE.test(line)).toBe(true);
+  });
+
+  it.each([
+    'or a figma.com URL alongside work in src/components/ui/',
+    'FIGMA_URL_QBDS_CHECKBOX=',
+    'FIGMA_URL_QBDS_AVATAR=',
+    'documentUrlSubstitutions built from every FIGMA_URL_* env var',
+    '<QBDS_BADGE_NUMERIC>',
+  ])('allows %s', line => {
+    expect(FIGMA_URL_RE.test(line)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `figma-url` gitleaks rule: reject `https?://…figma.com/` on staged commits (husky `secretscan`)
- Allowlist `.agents/skills/figma-token-sync/` (temp) + the rule’s unit test
- Vitest covers block/allow regex cases
