### PR TITLE
feat(number-field): stepper component

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -75,45 +75,66 @@ export const inputInlineFocusBorderWidth = {
 export const inputInlineLgFocusUnderline =
   'focus-visible:shadow-[0_1px_0_0_var(--color-stroke-status-focus)] aria-invalid:focus-visible:shadow-[0_1px_0_0_var(--color-stroke-status-error)]';
 
-export const inputGroupFocusRingWidth = {
-  sm: 'has-[[data-slot=input-group-control]:focus-visible]:ring-[1px]',
-  default: 'has-[[data-slot=input-group-control]:focus-visible]:ring-[1px]',
-  lg: 'has-[[data-slot=input-group-control]:focus-visible]:ring-[2px]',
-} as const;
+export function createGroupControlStyles(slot: string) {
+  return {
+    focusRingWidth: {
+      sm: `has-[[data-slot=${slot}]:focus-visible]:ring-[1px]`,
+      default: `has-[[data-slot=${slot}]:focus-visible]:ring-[1px]`,
+      lg: `has-[[data-slot=${slot}]:focus-visible]:ring-[2px]`,
+    },
+    inlineFocusBorderWidth: {
+      sm: `has-[[data-slot=${slot}]:focus-visible]:border-b-[1px]`,
+      default: `has-[[data-slot=${slot}]:focus-visible]:border-b-[1px]`,
+      lg: `has-[[data-slot=${slot}]:focus-visible]:border-b-[2px]`,
+    },
+    defaultFocusStyles: [
+      `has-[[data-slot=${slot}]:focus-visible]:overlay-active-inverse`,
+      `has-[[data-slot=${slot}]:focus-visible]:ring-stroke-status-focus`,
+      `has-[[data-slot=${slot}]:focus-visible]:shadow-elevation-0`,
+    ] as const,
+    inlineFocusStyles: [
+      `has-[[data-slot=${slot}]:focus-visible]:border-b-stroke-status-focus`,
+      `has-[[data-slot=${slot}]:focus-visible]:ring-0`,
+    ] as const,
+    defaultErrorStyles: [
+      `has-[[data-slot=${slot}][aria-invalid]]:border-stroke-status-error`,
+      `has-[[data-slot=${slot}][aria-invalid]:focus-visible]:ring-stroke-status-error`,
+    ] as const,
+    inlineErrorStyles: [
+      `has-[[data-slot=${slot}][aria-invalid]]:border-b-stroke-status-error`,
+    ] as const,
+    inlineLgFocusUnderline: `has-[[data-slot=${slot}]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-focus)] has-[[data-slot=${slot}][aria-invalid]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-error)]`,
+    defaultDisabledStyles: [
+      `has-[[data-slot=${slot}]:disabled]:cursor-not-allowed`,
+      `has-[[data-slot=${slot}]:disabled]:overlay-disabled`,
+    ] as const,
+  };
+}
 
-export const inputGroupInlineFocusBorderWidth = {
-  sm: 'has-[[data-slot=input-group-control]:focus-visible]:border-b-[1px]',
-  default: 'has-[[data-slot=input-group-control]:focus-visible]:border-b-[1px]',
-  lg: 'has-[[data-slot=input-group-control]:focus-visible]:border-b-[2px]',
-} as const;
+const inputGroupControlStyles = createGroupControlStyles('input-group-control');
 
-export const inputGroupDefaultFocusStyles = [
-  'has-[[data-slot=input-group-control]:focus-visible]:overlay-active-inverse',
-  'has-[[data-slot=input-group-control]:focus-visible]:ring-stroke-status-focus',
-  'has-[[data-slot=input-group-control]:focus-visible]:shadow-elevation-0',
-] as const;
+export const inputGroupFocusRingWidth = inputGroupControlStyles.focusRingWidth;
 
-export const inputGroupInlineFocusStyles = [
-  'has-[[data-slot=input-group-control]:focus-visible]:border-b-stroke-status-focus',
-  'has-[[data-slot=input-group-control]:focus-visible]:ring-0',
-] as const;
+export const inputGroupInlineFocusBorderWidth =
+  inputGroupControlStyles.inlineFocusBorderWidth;
 
-export const inputGroupDefaultErrorStyles = [
-  'has-[[data-slot=input-group-control][aria-invalid]]:border-stroke-status-error',
-  'has-[[data-slot=input-group-control][aria-invalid]:focus-visible]:ring-stroke-status-error',
-] as const;
+export const inputGroupDefaultFocusStyles =
+  inputGroupControlStyles.defaultFocusStyles;
 
-export const inputGroupInlineErrorStyles = [
-  'has-[[data-slot=input-group-control][aria-invalid]]:border-b-stroke-status-error',
-] as const;
+export const inputGroupInlineFocusStyles =
+  inputGroupControlStyles.inlineFocusStyles;
+
+export const inputGroupDefaultErrorStyles =
+  inputGroupControlStyles.defaultErrorStyles;
+
+export const inputGroupInlineErrorStyles =
+  inputGroupControlStyles.inlineErrorStyles;
 
 export const inputGroupInlineLgFocusUnderline =
-  'has-[[data-slot=input-group-control]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-focus)] has-[[data-slot=input-group-control][aria-invalid]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-error)]';
+  inputGroupControlStyles.inlineLgFocusUnderline;
 
-export const inputGroupDefaultDisabledStyles = [
-  'has-[[data-slot=input-group-control]:disabled]:cursor-not-allowed',
-  'has-[[data-slot=input-group-control]:disabled]:overlay-disabled',
-] as const;
+export const inputGroupDefaultDisabledStyles =
+  inputGroupControlStyles.defaultDisabledStyles;
 
 const inputVariants = cva(
   `flex w-full min-w-0 rounded-none outline-none transition-[border-color,box-shadow,background-color,background-image] font-normal ${searchCancelButtonStyles}`,

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -117,51 +117,6 @@ export const inputGroupDefaultDisabledStyles = [
   'has-[[data-slot=input-group-control]:disabled]:hover:overlay-disabled',
 ] as const;
 
-export const numberFieldGroupFocusRingWidth = {
-  sm: 'has-[[data-slot=number-field-control]:focus-visible]:ring-[1px]',
-  default: 'has-[[data-slot=number-field-control]:focus-visible]:ring-[1px]',
-  lg: 'has-[[data-slot=number-field-control]:focus-visible]:ring-[2px]',
-} as const;
-
-export const numberFieldGroupInlineFocusBorderWidth = {
-  sm: 'has-[[data-slot=number-field-control]:focus-visible]:border-b-[1px]',
-  default:
-    'has-[[data-slot=number-field-control]:focus-visible]:border-b-[1px]',
-  lg: 'has-[[data-slot=number-field-control]:focus-visible]:border-b-[2px]',
-} as const;
-
-export const numberFieldGroupDefaultFocusStyles = [
-  'has-[[data-slot=number-field-control]:focus]:overlay-active-inverse',
-  'has-[[data-slot=number-field-control]:focus-visible]:overlay-active-inverse',
-  'has-[[data-slot=number-field-control]:focus-visible]:ring-stroke-status-focus',
-  'has-[[data-slot=number-field-control]:focus-visible]:shadow-elevation-0',
-] as const;
-
-export const numberFieldGroupInlineFocusStyles = [
-  'has-[[data-slot=number-field-control]:focus-visible]:border-b-stroke-status-focus',
-  'has-[[data-slot=number-field-control]:focus-visible]:ring-0',
-] as const;
-
-export const numberFieldGroupDefaultErrorStyles = [
-  'has-[[data-slot=number-field-control][aria-invalid]]:border-stroke-status-error',
-  'has-[[data-slot=number-field-control][aria-invalid]:focus-visible]:ring-stroke-status-error',
-  'data-[invalid]:border-stroke-status-error',
-] as const;
-
-export const numberFieldGroupInlineErrorStyles = [
-  'has-[[data-slot=number-field-control][aria-invalid]]:border-b-stroke-status-error',
-  'data-[invalid]:border-b-stroke-status-error',
-] as const;
-
-export const numberFieldGroupInlineLgFocusUnderline =
-  'has-[[data-slot=number-field-control]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-focus)] has-[[data-slot=number-field-control][aria-invalid]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-error)]';
-
-export const numberFieldGroupDefaultDisabledStyles = [
-  'has-[[data-slot=number-field-control]:disabled]:cursor-not-allowed',
-  'has-[[data-slot=number-field-control]:disabled]:overlay-disabled',
-  'has-[[data-slot=number-field-control]:disabled]:hover:overlay-disabled',
-] as const;
-
 const inputVariants = cva(
   `flex w-full min-w-0 rounded-none outline-none transition-[border-color,box-shadow,background-color,background-image] font-normal ${searchCancelButtonStyles}`,
   {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -75,66 +75,92 @@ export const inputInlineFocusBorderWidth = {
 export const inputInlineLgFocusUnderline =
   'focus-visible:shadow-[0_1px_0_0_var(--color-stroke-status-focus)] aria-invalid:focus-visible:shadow-[0_1px_0_0_var(--color-stroke-status-error)]';
 
-export function createGroupControlStyles(slot: string) {
-  return {
-    focusRingWidth: {
-      sm: `has-[[data-slot=${slot}]:focus-visible]:ring-[1px]`,
-      default: `has-[[data-slot=${slot}]:focus-visible]:ring-[1px]`,
-      lg: `has-[[data-slot=${slot}]:focus-visible]:ring-[2px]`,
-    },
-    inlineFocusBorderWidth: {
-      sm: `has-[[data-slot=${slot}]:focus-visible]:border-b-[1px]`,
-      default: `has-[[data-slot=${slot}]:focus-visible]:border-b-[1px]`,
-      lg: `has-[[data-slot=${slot}]:focus-visible]:border-b-[2px]`,
-    },
-    defaultFocusStyles: [
-      `has-[[data-slot=${slot}]:focus-visible]:overlay-active-inverse`,
-      `has-[[data-slot=${slot}]:focus-visible]:ring-stroke-status-focus`,
-      `has-[[data-slot=${slot}]:focus-visible]:shadow-elevation-0`,
-    ] as const,
-    inlineFocusStyles: [
-      `has-[[data-slot=${slot}]:focus-visible]:border-b-stroke-status-focus`,
-      `has-[[data-slot=${slot}]:focus-visible]:ring-0`,
-    ] as const,
-    defaultErrorStyles: [
-      `has-[[data-slot=${slot}][aria-invalid]]:border-stroke-status-error`,
-      `has-[[data-slot=${slot}][aria-invalid]:focus-visible]:ring-stroke-status-error`,
-    ] as const,
-    inlineErrorStyles: [
-      `has-[[data-slot=${slot}][aria-invalid]]:border-b-stroke-status-error`,
-    ] as const,
-    inlineLgFocusUnderline: `has-[[data-slot=${slot}]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-focus)] has-[[data-slot=${slot}][aria-invalid]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-error)]`,
-    defaultDisabledStyles: [
-      `has-[[data-slot=${slot}]:disabled]:cursor-not-allowed`,
-      `has-[[data-slot=${slot}]:disabled]:overlay-disabled`,
-    ] as const,
-  };
-}
+export const inputGroupFocusRingWidth = {
+  sm: 'has-[[data-slot=input-group-control]:focus-visible]:ring-[1px]',
+  default: 'has-[[data-slot=input-group-control]:focus-visible]:ring-[1px]',
+  lg: 'has-[[data-slot=input-group-control]:focus-visible]:ring-[2px]',
+} as const;
 
-const inputGroupControlStyles = createGroupControlStyles('input-group-control');
+export const inputGroupInlineFocusBorderWidth = {
+  sm: 'has-[[data-slot=input-group-control]:focus-visible]:border-b-[1px]',
+  default: 'has-[[data-slot=input-group-control]:focus-visible]:border-b-[1px]',
+  lg: 'has-[[data-slot=input-group-control]:focus-visible]:border-b-[2px]',
+} as const;
 
-export const inputGroupFocusRingWidth = inputGroupControlStyles.focusRingWidth;
+export const inputGroupDefaultFocusStyles = [
+  'has-[[data-slot=input-group-control]:focus]:overlay-active-inverse',
+  'has-[[data-slot=input-group-control]:focus-visible]:overlay-active-inverse',
+  'has-[[data-slot=input-group-control]:focus-visible]:ring-stroke-status-focus',
+  'has-[[data-slot=input-group-control]:focus-visible]:shadow-elevation-0',
+] as const;
 
-export const inputGroupInlineFocusBorderWidth =
-  inputGroupControlStyles.inlineFocusBorderWidth;
+export const inputGroupInlineFocusStyles = [
+  'has-[[data-slot=input-group-control]:focus-visible]:border-b-stroke-status-focus',
+  'has-[[data-slot=input-group-control]:focus-visible]:ring-0',
+] as const;
 
-export const inputGroupDefaultFocusStyles =
-  inputGroupControlStyles.defaultFocusStyles;
+export const inputGroupDefaultErrorStyles = [
+  'has-[[data-slot=input-group-control][aria-invalid]]:border-stroke-status-error',
+  'has-[[data-slot=input-group-control][aria-invalid]:focus-visible]:ring-stroke-status-error',
+] as const;
 
-export const inputGroupInlineFocusStyles =
-  inputGroupControlStyles.inlineFocusStyles;
-
-export const inputGroupDefaultErrorStyles =
-  inputGroupControlStyles.defaultErrorStyles;
-
-export const inputGroupInlineErrorStyles =
-  inputGroupControlStyles.inlineErrorStyles;
+export const inputGroupInlineErrorStyles = [
+  'has-[[data-slot=input-group-control][aria-invalid]]:border-b-stroke-status-error',
+] as const;
 
 export const inputGroupInlineLgFocusUnderline =
-  inputGroupControlStyles.inlineLgFocusUnderline;
+  'has-[[data-slot=input-group-control]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-focus)] has-[[data-slot=input-group-control][aria-invalid]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-error)]';
 
-export const inputGroupDefaultDisabledStyles =
-  inputGroupControlStyles.defaultDisabledStyles;
+export const inputGroupDefaultDisabledStyles = [
+  'has-[[data-slot=input-group-control]:disabled]:cursor-not-allowed',
+  'has-[[data-slot=input-group-control]:disabled]:overlay-disabled',
+  'has-[[data-slot=input-group-control]:disabled]:hover:overlay-disabled',
+] as const;
+
+export const numberFieldGroupFocusRingWidth = {
+  sm: 'has-[[data-slot=number-field-control]:focus-visible]:ring-[1px]',
+  default: 'has-[[data-slot=number-field-control]:focus-visible]:ring-[1px]',
+  lg: 'has-[[data-slot=number-field-control]:focus-visible]:ring-[2px]',
+} as const;
+
+export const numberFieldGroupInlineFocusBorderWidth = {
+  sm: 'has-[[data-slot=number-field-control]:focus-visible]:border-b-[1px]',
+  default:
+    'has-[[data-slot=number-field-control]:focus-visible]:border-b-[1px]',
+  lg: 'has-[[data-slot=number-field-control]:focus-visible]:border-b-[2px]',
+} as const;
+
+export const numberFieldGroupDefaultFocusStyles = [
+  'has-[[data-slot=number-field-control]:focus]:overlay-active-inverse',
+  'has-[[data-slot=number-field-control]:focus-visible]:overlay-active-inverse',
+  'has-[[data-slot=number-field-control]:focus-visible]:ring-stroke-status-focus',
+  'has-[[data-slot=number-field-control]:focus-visible]:shadow-elevation-0',
+] as const;
+
+export const numberFieldGroupInlineFocusStyles = [
+  'has-[[data-slot=number-field-control]:focus-visible]:border-b-stroke-status-focus',
+  'has-[[data-slot=number-field-control]:focus-visible]:ring-0',
+] as const;
+
+export const numberFieldGroupDefaultErrorStyles = [
+  'has-[[data-slot=number-field-control][aria-invalid]]:border-stroke-status-error',
+  'has-[[data-slot=number-field-control][aria-invalid]:focus-visible]:ring-stroke-status-error',
+  'data-[invalid]:border-stroke-status-error',
+] as const;
+
+export const numberFieldGroupInlineErrorStyles = [
+  'has-[[data-slot=number-field-control][aria-invalid]]:border-b-stroke-status-error',
+  'data-[invalid]:border-b-stroke-status-error',
+] as const;
+
+export const numberFieldGroupInlineLgFocusUnderline =
+  'has-[[data-slot=number-field-control]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-focus)] has-[[data-slot=number-field-control][aria-invalid]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-error)]';
+
+export const numberFieldGroupDefaultDisabledStyles = [
+  'has-[[data-slot=number-field-control]:disabled]:cursor-not-allowed',
+  'has-[[data-slot=number-field-control]:disabled]:overlay-disabled',
+  'has-[[data-slot=number-field-control]:disabled]:hover:overlay-disabled',
+] as const;
 
 const inputVariants = cva(
   `flex w-full min-w-0 rounded-none outline-none transition-[border-color,box-shadow,background-color,background-image] font-normal ${searchCancelButtonStyles}`,

--- a/src/components/ui/number-field.tsx
+++ b/src/components/ui/number-field.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/ui/icon';
 import { IconShell } from '@/components/ui/icon-shell';
 import {
+  createGroupControlStyles,
   inputSizeDefinitions,
   inputSizeStyles,
   inputVariantStyles,
@@ -17,51 +18,13 @@ import { cn } from '@/lib/utils';
 type NumberFieldSize = 'sm' | 'default' | 'lg';
 type NumberFieldVariant = 'default' | 'inline';
 
+const controlSlot = 'number-field-control';
+
+const numberFieldControlStyles = createGroupControlStyles(controlSlot);
+
 const NumberFieldSizeContext = React.createContext<NumberFieldSize>('default');
 const NumberFieldVariantContext =
   React.createContext<NumberFieldVariant>('default');
-
-const controlSlot = 'number-field-control';
-
-const numberFieldDefaultFocusStyles = [
-  `has-[[data-slot=${controlSlot}]:focus-visible]:overlay-active-inverse`,
-  `has-[[data-slot=${controlSlot}]:focus-visible]:ring-stroke-status-focus`,
-  `has-[[data-slot=${controlSlot}]:focus-visible]:shadow-elevation-0`,
-] as const;
-
-const numberFieldInlineFocusStyles = [
-  `has-[[data-slot=${controlSlot}]:focus-visible]:border-b-stroke-status-focus`,
-  `has-[[data-slot=${controlSlot}]:focus-visible]:ring-0`,
-] as const;
-
-const numberFieldDefaultErrorStyles = [
-  `has-[[data-slot=${controlSlot}][aria-invalid=true]]:border-stroke-status-error`,
-  `has-[[data-slot=${controlSlot}][aria-invalid=true]:focus-visible]:ring-stroke-status-error`,
-] as const;
-
-const numberFieldInlineErrorStyles = [
-  `has-[[data-slot=${controlSlot}][aria-invalid=true]]:border-b-stroke-status-error`,
-  `has-[[data-slot=${controlSlot}][aria-invalid=true]:focus-visible]:border-b-stroke-status-error`,
-] as const;
-
-const numberFieldDefaultDisabledStyles = [
-  `has-[[data-slot=${controlSlot}]:disabled]:cursor-not-allowed`,
-  `has-[[data-slot=${controlSlot}]:disabled]:overlay-disabled`,
-] as const;
-
-const numberFieldFocusRingWidth = {
-  sm: `has-[[data-slot=${controlSlot}]:focus-visible]:ring-[1px]`,
-  default: `has-[[data-slot=${controlSlot}]:focus-visible]:ring-[1px]`,
-  lg: `has-[[data-slot=${controlSlot}]:focus-visible]:ring-[2px]`,
-} as const;
-
-const numberFieldInlineFocusBorderWidth = {
-  sm: `has-[[data-slot=${controlSlot}]:focus-visible]:border-b-[1px]`,
-  default: `has-[[data-slot=${controlSlot}]:focus-visible]:border-b-[1px]`,
-  lg: `has-[[data-slot=${controlSlot}]:focus-visible]:border-b-[2px]`,
-} as const;
-
-const numberFieldInlineLgFocusUnderline = `has-[[data-slot=${controlSlot}]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-focus)] has-[[data-slot=${controlSlot}][aria-invalid=true]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-error)]`;
 
 const numberFieldControlDisabledTextStyles = {
   default:
@@ -75,26 +38,37 @@ const stepperButtonClass = {
   lg: 'size-5 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0',
 } as const;
 
+const stepperButtonStyles = [
+  'paragraph-regular-primary shadow-none',
+  'focus-visible:ring-0 focus-visible:ring-offset-0',
+  'group-has-[[data-slot=number-field-control]:disabled]/number-field:pointer-events-none',
+  'group-has-[[data-slot=number-field-control]:disabled]/number-field:hover:bg-transparent',
+  'group-has-[[data-slot=number-field-control]:disabled]/number-field:hover:text-fg-secondary',
+  'group-has-[[data-slot=number-field-control]:disabled]/number-field:active:bg-transparent',
+] as const;
+
 const numberFieldGroupVariants = cva(
-  'group/number-field relative flex w-full min-w-0 items-center rounded-none border-0 transition-[background-color,background-image,box-shadow,border-color] outline-none',
+  'group/number-field relative flex min-w-0 items-center rounded-none border-0 transition-[background-color,background-image,box-shadow,border-color] outline-none',
   {
     variants: {
       variant: {
         default: [
+          'w-[120px]',
           'gap-1',
           inputVariantStyles.default.base,
           inputVariantStyles.default.hover,
-          ...numberFieldDefaultFocusStyles,
-          ...numberFieldDefaultErrorStyles,
-          ...numberFieldDefaultDisabledStyles,
+          ...numberFieldControlStyles.defaultFocusStyles,
+          ...numberFieldControlStyles.defaultErrorStyles,
+          ...numberFieldControlStyles.defaultDisabledStyles,
         ],
         inline: [
+          'w-[96px]',
           'gap-1 px-0!',
           inputVariantStyles.inline.base,
           inputVariantStyles.inline.border,
           inputVariantStyles.inline.hover,
-          ...numberFieldInlineFocusStyles,
-          ...numberFieldInlineErrorStyles,
+          ...numberFieldControlStyles.inlineFocusStyles,
+          ...numberFieldControlStyles.inlineErrorStyles,
         ],
       },
       size: {
@@ -107,32 +81,32 @@ const numberFieldGroupVariants = cva(
       {
         variant: 'default',
         size: 'sm',
-        className: numberFieldFocusRingWidth.sm,
+        className: numberFieldControlStyles.focusRingWidth.sm,
       },
       {
         variant: 'default',
         size: 'default',
-        className: numberFieldFocusRingWidth.default,
+        className: numberFieldControlStyles.focusRingWidth.default,
       },
       {
         variant: 'default',
         size: 'lg',
-        className: numberFieldFocusRingWidth.lg,
+        className: numberFieldControlStyles.focusRingWidth.lg,
       },
       {
         variant: 'inline',
         size: 'sm',
-        className: numberFieldInlineFocusBorderWidth.sm,
+        className: numberFieldControlStyles.inlineFocusBorderWidth.sm,
       },
       {
         variant: 'inline',
         size: 'default',
-        className: numberFieldInlineFocusBorderWidth.default,
+        className: numberFieldControlStyles.inlineFocusBorderWidth.default,
       },
       {
         variant: 'inline',
         size: 'lg',
-        className: numberFieldInlineLgFocusUnderline,
+        className: numberFieldControlStyles.inlineLgFocusUnderline,
       },
     ],
     defaultVariants: {
@@ -142,11 +116,15 @@ const numberFieldGroupVariants = cva(
   },
 );
 
+function focusNumberFieldControl(group: HTMLElement | null) {
+  group?.querySelector<HTMLElement>(`[data-slot="${controlSlot}"]`)?.focus();
+}
+
 function NumberField({ className, ...props }: NumberFieldPrimitive.Root.Props) {
   return (
     <NumberFieldPrimitive.Root
       data-slot="number-field"
-      className={cn('w-full', className)}
+      className={cn('w-fit', className)}
       {...props}
     />
   );
@@ -245,6 +223,7 @@ function NumberFieldDecrement({
   className,
   size,
   children,
+  onClick,
   ...props
 }: Readonly<NumberFieldDecrementProps>) {
   const groupSize = React.useContext(NumberFieldSizeContext);
@@ -253,13 +232,23 @@ function NumberFieldDecrement({
   return (
     <NumberFieldPrimitive.Decrement
       data-slot="number-field-decrement"
+      onClick={event => {
+        onClick?.(event);
+
+        if (!event.defaultPrevented) {
+          focusNumberFieldControl(
+            event.currentTarget.closest('[data-slot="number-field-group"]'),
+          );
+        }
+      }}
       render={
         <Button
           variant="ghost"
           size="icon-xxs"
+          tabIndex={-1}
           aria-label="Decrease"
           className={cn(
-            'paragraph-regular-primary shadow-none',
+            stepperButtonStyles,
             stepperButtonClass[resolvedSize],
             className,
           )}
@@ -280,6 +269,7 @@ function NumberFieldIncrement({
   className,
   size,
   children,
+  onClick,
   ...props
 }: Readonly<NumberFieldIncrementProps>) {
   const groupSize = React.useContext(NumberFieldSizeContext);
@@ -288,13 +278,23 @@ function NumberFieldIncrement({
   return (
     <NumberFieldPrimitive.Increment
       data-slot="number-field-increment"
+      onClick={event => {
+        onClick?.(event);
+
+        if (!event.defaultPrevented) {
+          focusNumberFieldControl(
+            event.currentTarget.closest('[data-slot="number-field-group"]'),
+          );
+        }
+      }}
       render={
         <Button
           variant="ghost"
           size="icon-xxs"
+          tabIndex={-1}
           aria-label="Increase"
           className={cn(
-            'paragraph-regular-primary shadow-none',
+            stepperButtonStyles,
             stepperButtonClass[resolvedSize],
             className,
           )}

--- a/src/components/ui/number-field.tsx
+++ b/src/components/ui/number-field.tsx
@@ -30,7 +30,6 @@ const controlSlot = 'input-group-control';
 const NumberFieldSizeContext = React.createContext<NumberFieldSize>('default');
 const NumberFieldVariantContext =
   React.createContext<NumberFieldVariant>('default');
-const NumberFieldDisabledContext = React.createContext<boolean>(false);
 
 const numberFieldControlDisabledTextStyles = {
   default:
@@ -138,14 +137,12 @@ function NumberField({
   ...props
 }: NumberFieldPrimitive.Root.Props) {
   return (
-    <NumberFieldDisabledContext.Provider value={disabled ?? false}>
-      <NumberFieldPrimitive.Root
-        data-slot="number-field"
-        className={cn('w-fit', className)}
-        disabled={disabled}
-        {...props}
-      />
-    </NumberFieldDisabledContext.Provider>
+    <NumberFieldPrimitive.Root
+      data-slot="number-field"
+      className={cn('w-fit', className)}
+      disabled={disabled}
+      {...props}
+    />
   );
 }
 
@@ -231,7 +228,7 @@ function NumberFieldStepperIcon({
   disabled?: boolean;
 }) {
   return (
-    <IconShell size="sm" type="neutral" variant="secondary" disabled={disabled}>
+    <IconShell size="sm" type="neutral" hoverable disabled={disabled}>
       <Icon icon={icon} />
     </IconShell>
   );
@@ -270,7 +267,7 @@ function NumberFieldDecrement({
           variant="ghost"
           size="icon-xxs"
           tabIndex={-1}
-          aria-label="Decrease"
+          aria-label={btnProps['aria-label'] ?? 'Decrease'}
           className={cn(
             stepperButtonStyles,
             stepperButtonClass[resolvedSize],
@@ -320,7 +317,7 @@ function NumberFieldIncrement({
           variant="ghost"
           size="icon-xxs"
           tabIndex={-1}
-          aria-label="Increase"
+          aria-label={btnProps['aria-label'] ?? 'Increase'}
           className={cn(
             stepperButtonStyles,
             stepperButtonClass[resolvedSize],

--- a/src/components/ui/number-field.tsx
+++ b/src/components/ui/number-field.tsx
@@ -30,6 +30,7 @@ const controlSlot = 'input-group-control';
 const NumberFieldSizeContext = React.createContext<NumberFieldSize>('default');
 const NumberFieldVariantContext =
   React.createContext<NumberFieldVariant>('default');
+const NumberFieldDisabledContext = React.createContext<boolean>(false);
 
 const numberFieldControlDisabledTextStyles = {
   default:
@@ -50,7 +51,6 @@ const stepperButtonStyles = [
   'group-has-[[data-slot=input-group-control]:disabled]/number-field:hover:bg-transparent',
   'group-has-[[data-slot=input-group-control]:disabled]/number-field:hover:text-fg-secondary',
   'group-has-[[data-slot=input-group-control]:disabled]/number-field:active:bg-transparent',
-  'group-has-[[data-slot=input-group-control]:disabled]/number-field:[&_[data-slot=icon-shell]]:opacity-50',
   'disabled:hover:bg-transparent disabled:pointer-events-none',
 ] as const;
 
@@ -129,13 +129,20 @@ function focusNumberFieldControl(group: HTMLElement | null) {
   group?.querySelector<HTMLElement>(`[data-slot="${controlSlot}"]`)?.focus();
 }
 
-function NumberField({ className, ...props }: NumberFieldPrimitive.Root.Props) {
+function NumberField({
+  className,
+  disabled,
+  ...props
+}: NumberFieldPrimitive.Root.Props) {
   return (
-    <NumberFieldPrimitive.Root
-      data-slot="number-field"
-      className={cn('w-fit', className)}
-      {...props}
-    />
+    <NumberFieldDisabledContext.Provider value={disabled ?? false}>
+      <NumberFieldPrimitive.Root
+        data-slot="number-field"
+        className={cn('w-fit', className)}
+        disabled={disabled}
+        {...props}
+      />
+    </NumberFieldDisabledContext.Provider>
   );
 }
 
@@ -207,17 +214,17 @@ function NumberFieldInput({
   );
 }
 
-function NumberFieldStepperIcon() {
+function NumberFieldStepperIcon({ disabled }: { disabled?: boolean }) {
   return (
-    <IconShell size="sm" type="neutral" variant="secondary">
+    <IconShell size="sm" type="neutral" variant="secondary" disabled={disabled}>
       <Icon icon="remove" />
     </IconShell>
   );
 }
 
-function NumberFieldStepperIconIncrement() {
+function NumberFieldStepperIconIncrement({ disabled }: { disabled?: boolean }) {
   return (
-    <IconShell size="sm" type="neutral" variant="secondary">
+    <IconShell size="sm" type="neutral" variant="secondary" disabled={disabled}>
       <Icon icon="add" />
     </IconShell>
   );
@@ -236,6 +243,7 @@ function NumberFieldDecrement({
   ...props
 }: Readonly<NumberFieldDecrementProps>) {
   const groupSize = React.useContext(NumberFieldSizeContext);
+  const disabled = React.useContext(NumberFieldDisabledContext);
   const resolvedSize = size ?? groupSize;
 
   return (
@@ -264,7 +272,7 @@ function NumberFieldDecrement({
         />
       }
       {...props}>
-      {children ?? <NumberFieldStepperIcon />}
+      {children ?? <NumberFieldStepperIcon disabled={disabled} />}
     </NumberFieldPrimitive.Decrement>
   );
 }
@@ -282,6 +290,7 @@ function NumberFieldIncrement({
   ...props
 }: Readonly<NumberFieldIncrementProps>) {
   const groupSize = React.useContext(NumberFieldSizeContext);
+  const disabled = React.useContext(NumberFieldDisabledContext);
   const resolvedSize = size ?? groupSize;
 
   return (
@@ -310,7 +319,7 @@ function NumberFieldIncrement({
         />
       }
       {...props}>
-      {children ?? <NumberFieldStepperIconIncrement />}
+      {children ?? <NumberFieldStepperIconIncrement disabled={disabled} />}
     </NumberFieldPrimitive.Increment>
   );
 }

--- a/src/components/ui/number-field.tsx
+++ b/src/components/ui/number-field.tsx
@@ -8,10 +8,17 @@ import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/ui/icon';
 import { IconShell } from '@/components/ui/icon-shell';
 import {
-  createGroupControlStyles,
   inputSizeDefinitions,
   inputSizeStyles,
   inputVariantStyles,
+  numberFieldGroupDefaultDisabledStyles,
+  numberFieldGroupDefaultErrorStyles,
+  numberFieldGroupDefaultFocusStyles,
+  numberFieldGroupFocusRingWidth,
+  numberFieldGroupInlineErrorStyles,
+  numberFieldGroupInlineFocusBorderWidth,
+  numberFieldGroupInlineFocusStyles,
+  numberFieldGroupInlineLgFocusUnderline,
 } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 
@@ -19,8 +26,6 @@ type NumberFieldSize = 'sm' | 'default' | 'lg';
 type NumberFieldVariant = 'default' | 'inline';
 
 const controlSlot = 'number-field-control';
-
-const numberFieldControlStyles = createGroupControlStyles(controlSlot);
 
 const NumberFieldSizeContext = React.createContext<NumberFieldSize>('default');
 const NumberFieldVariantContext =
@@ -45,6 +50,8 @@ const stepperButtonStyles = [
   'group-has-[[data-slot=number-field-control]:disabled]/number-field:hover:bg-transparent',
   'group-has-[[data-slot=number-field-control]:disabled]/number-field:hover:text-fg-secondary',
   'group-has-[[data-slot=number-field-control]:disabled]/number-field:active:bg-transparent',
+  'group-has-[[data-slot=number-field-control]:disabled]/number-field:[&_[data-slot=icon-shell]]:opacity-50',
+  'disabled:hover:bg-transparent disabled:pointer-events-none',
 ] as const;
 
 const numberFieldGroupVariants = cva(
@@ -57,9 +64,9 @@ const numberFieldGroupVariants = cva(
           'gap-1',
           inputVariantStyles.default.base,
           inputVariantStyles.default.hover,
-          ...numberFieldControlStyles.defaultFocusStyles,
-          ...numberFieldControlStyles.defaultErrorStyles,
-          ...numberFieldControlStyles.defaultDisabledStyles,
+          ...numberFieldGroupDefaultFocusStyles,
+          ...numberFieldGroupDefaultErrorStyles,
+          ...numberFieldGroupDefaultDisabledStyles,
         ],
         inline: [
           'w-[96px]',
@@ -67,8 +74,8 @@ const numberFieldGroupVariants = cva(
           inputVariantStyles.inline.base,
           inputVariantStyles.inline.border,
           inputVariantStyles.inline.hover,
-          ...numberFieldControlStyles.inlineFocusStyles,
-          ...numberFieldControlStyles.inlineErrorStyles,
+          ...numberFieldGroupInlineFocusStyles,
+          ...numberFieldGroupInlineErrorStyles,
         ],
       },
       size: {
@@ -81,32 +88,32 @@ const numberFieldGroupVariants = cva(
       {
         variant: 'default',
         size: 'sm',
-        className: numberFieldControlStyles.focusRingWidth.sm,
+        className: numberFieldGroupFocusRingWidth.sm,
       },
       {
         variant: 'default',
         size: 'default',
-        className: numberFieldControlStyles.focusRingWidth.default,
+        className: numberFieldGroupFocusRingWidth.default,
       },
       {
         variant: 'default',
         size: 'lg',
-        className: numberFieldControlStyles.focusRingWidth.lg,
+        className: numberFieldGroupFocusRingWidth.lg,
       },
       {
         variant: 'inline',
         size: 'sm',
-        className: numberFieldControlStyles.inlineFocusBorderWidth.sm,
+        className: numberFieldGroupInlineFocusBorderWidth.sm,
       },
       {
         variant: 'inline',
         size: 'default',
-        className: numberFieldControlStyles.inlineFocusBorderWidth.default,
+        className: numberFieldGroupInlineFocusBorderWidth.default,
       },
       {
         variant: 'inline',
         size: 'lg',
-        className: numberFieldControlStyles.inlineLgFocusUnderline,
+        className: numberFieldGroupInlineLgFocusUnderline,
       },
     ],
     defaultVariants: {

--- a/src/components/ui/number-field.tsx
+++ b/src/components/ui/number-field.tsx
@@ -170,7 +170,13 @@ function NumberFieldGroup({
           data-slot="number-field-group"
           data-variant={resolvedVariant}
           data-size={resolvedSize}
-          className={cn(numberFieldGroupVariants({ variant, size }), className)}
+          className={cn(
+            numberFieldGroupVariants({
+              variant: resolvedVariant,
+              size: resolvedSize,
+            }),
+            className,
+          )}
           {...props}
         />
       </NumberFieldVariantContext.Provider>
@@ -217,18 +223,16 @@ function NumberFieldInput({
   );
 }
 
-function NumberFieldStepperIcon({ disabled }: { disabled?: boolean }) {
+function NumberFieldStepperIcon({
+  icon,
+  disabled,
+}: {
+  icon: 'remove' | 'add';
+  disabled?: boolean;
+}) {
   return (
     <IconShell size="sm" type="neutral" variant="secondary" disabled={disabled}>
-      <Icon icon="remove" />
-    </IconShell>
-  );
-}
-
-function NumberFieldStepperIconIncrement({ disabled }: { disabled?: boolean }) {
-  return (
-    <IconShell size="sm" type="neutral" variant="secondary" disabled={disabled}>
-      <Icon icon="add" />
+      <Icon icon={icon} />
     </IconShell>
   );
 }
@@ -246,7 +250,6 @@ function NumberFieldDecrement({
   ...props
 }: Readonly<NumberFieldDecrementProps>) {
   const groupSize = React.useContext(NumberFieldSizeContext);
-  const disabled = React.useContext(NumberFieldDisabledContext);
   const resolvedSize = size ?? groupSize;
 
   return (
@@ -261,8 +264,9 @@ function NumberFieldDecrement({
           );
         }
       }}
-      render={
+      render={(btnProps, state) => (
         <Button
+          {...btnProps}
           variant="ghost"
           size="icon-xxs"
           tabIndex={-1}
@@ -271,12 +275,15 @@ function NumberFieldDecrement({
             stepperButtonStyles,
             stepperButtonClass[resolvedSize],
             className,
+            btnProps.className,
+          )}>
+          {children ?? (
+            <NumberFieldStepperIcon icon="remove" disabled={state.disabled} />
           )}
-        />
-      }
-      {...props}>
-      {children ?? <NumberFieldStepperIcon disabled={disabled} />}
-    </NumberFieldPrimitive.Decrement>
+        </Button>
+      )}
+      {...props}
+    />
   );
 }
 
@@ -293,7 +300,6 @@ function NumberFieldIncrement({
   ...props
 }: Readonly<NumberFieldIncrementProps>) {
   const groupSize = React.useContext(NumberFieldSizeContext);
-  const disabled = React.useContext(NumberFieldDisabledContext);
   const resolvedSize = size ?? groupSize;
 
   return (
@@ -308,8 +314,9 @@ function NumberFieldIncrement({
           );
         }
       }}
-      render={
+      render={(btnProps, state) => (
         <Button
+          {...btnProps}
           variant="ghost"
           size="icon-xxs"
           tabIndex={-1}
@@ -318,12 +325,15 @@ function NumberFieldIncrement({
             stepperButtonStyles,
             stepperButtonClass[resolvedSize],
             className,
+            btnProps.className,
+          )}>
+          {children ?? (
+            <NumberFieldStepperIcon icon="add" disabled={state.disabled} />
           )}
-        />
-      }
-      {...props}>
-      {children ?? <NumberFieldStepperIconIncrement disabled={disabled} />}
-    </NumberFieldPrimitive.Increment>
+        </Button>
+      )}
+      {...props}
+    />
   );
 }
 

--- a/src/components/ui/number-field.tsx
+++ b/src/components/ui/number-field.tsx
@@ -1,0 +1,316 @@
+'use client';
+
+import { NumberField as NumberFieldPrimitive } from '@base-ui/react/number-field';
+import { type VariantProps, cva } from 'class-variance-authority';
+import * as React from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Icon } from '@/components/ui/icon';
+import { IconShell } from '@/components/ui/icon-shell';
+import {
+  inputSizeDefinitions,
+  inputSizeStyles,
+  inputVariantStyles,
+} from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+type NumberFieldSize = 'sm' | 'default' | 'lg';
+type NumberFieldVariant = 'default' | 'inline';
+
+const NumberFieldSizeContext = React.createContext<NumberFieldSize>('default');
+const NumberFieldVariantContext =
+  React.createContext<NumberFieldVariant>('default');
+
+const controlSlot = 'number-field-control';
+
+const numberFieldDefaultFocusStyles = [
+  `has-[[data-slot=${controlSlot}]:focus-visible]:overlay-active-inverse`,
+  `has-[[data-slot=${controlSlot}]:focus-visible]:ring-stroke-status-focus`,
+  `has-[[data-slot=${controlSlot}]:focus-visible]:shadow-elevation-0`,
+] as const;
+
+const numberFieldInlineFocusStyles = [
+  `has-[[data-slot=${controlSlot}]:focus-visible]:border-b-stroke-status-focus`,
+  `has-[[data-slot=${controlSlot}]:focus-visible]:ring-0`,
+] as const;
+
+const numberFieldDefaultErrorStyles = [
+  `has-[[data-slot=${controlSlot}][aria-invalid=true]]:border-stroke-status-error`,
+  `has-[[data-slot=${controlSlot}][aria-invalid=true]:focus-visible]:ring-stroke-status-error`,
+] as const;
+
+const numberFieldInlineErrorStyles = [
+  `has-[[data-slot=${controlSlot}][aria-invalid=true]]:border-b-stroke-status-error`,
+  `has-[[data-slot=${controlSlot}][aria-invalid=true]:focus-visible]:border-b-stroke-status-error`,
+] as const;
+
+const numberFieldDefaultDisabledStyles = [
+  `has-[[data-slot=${controlSlot}]:disabled]:cursor-not-allowed`,
+  `has-[[data-slot=${controlSlot}]:disabled]:overlay-disabled`,
+] as const;
+
+const numberFieldFocusRingWidth = {
+  sm: `has-[[data-slot=${controlSlot}]:focus-visible]:ring-[1px]`,
+  default: `has-[[data-slot=${controlSlot}]:focus-visible]:ring-[1px]`,
+  lg: `has-[[data-slot=${controlSlot}]:focus-visible]:ring-[2px]`,
+} as const;
+
+const numberFieldInlineFocusBorderWidth = {
+  sm: `has-[[data-slot=${controlSlot}]:focus-visible]:border-b-[1px]`,
+  default: `has-[[data-slot=${controlSlot}]:focus-visible]:border-b-[1px]`,
+  lg: `has-[[data-slot=${controlSlot}]:focus-visible]:border-b-[2px]`,
+} as const;
+
+const numberFieldInlineLgFocusUnderline = `has-[[data-slot=${controlSlot}]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-focus)] has-[[data-slot=${controlSlot}][aria-invalid=true]:focus-visible]:shadow-[0_1px_0_0_var(--color-stroke-status-error)]`;
+
+const numberFieldControlDisabledTextStyles = {
+  default:
+    'disabled:cursor-not-allowed disabled:text-fg-disabled disabled:placeholder:text-fg-disabled',
+  inline: 'disabled:text-fg-disabled disabled:placeholder:text-fg-disabled',
+} as const;
+
+const stepperButtonClass = {
+  sm: 'size-4 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0',
+  default: 'size-4 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0',
+  lg: 'size-5 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0',
+} as const;
+
+const numberFieldGroupVariants = cva(
+  'group/number-field relative flex w-full min-w-0 items-center rounded-none border-0 transition-[background-color,background-image,box-shadow,border-color] outline-none',
+  {
+    variants: {
+      variant: {
+        default: [
+          'gap-1',
+          inputVariantStyles.default.base,
+          inputVariantStyles.default.hover,
+          ...numberFieldDefaultFocusStyles,
+          ...numberFieldDefaultErrorStyles,
+          ...numberFieldDefaultDisabledStyles,
+        ],
+        inline: [
+          'gap-1 px-0!',
+          inputVariantStyles.inline.base,
+          inputVariantStyles.inline.border,
+          inputVariantStyles.inline.hover,
+          ...numberFieldInlineFocusStyles,
+          ...numberFieldInlineErrorStyles,
+        ],
+      },
+      size: {
+        sm: `${inputSizeDefinitions.sm} pl-2 pr-2`,
+        default: `${inputSizeDefinitions.default} pl-2 pr-2`,
+        lg: `${inputSizeDefinitions.lg} pl-3 pr-3`,
+      },
+    },
+    compoundVariants: [
+      {
+        variant: 'default',
+        size: 'sm',
+        className: numberFieldFocusRingWidth.sm,
+      },
+      {
+        variant: 'default',
+        size: 'default',
+        className: numberFieldFocusRingWidth.default,
+      },
+      {
+        variant: 'default',
+        size: 'lg',
+        className: numberFieldFocusRingWidth.lg,
+      },
+      {
+        variant: 'inline',
+        size: 'sm',
+        className: numberFieldInlineFocusBorderWidth.sm,
+      },
+      {
+        variant: 'inline',
+        size: 'default',
+        className: numberFieldInlineFocusBorderWidth.default,
+      },
+      {
+        variant: 'inline',
+        size: 'lg',
+        className: numberFieldInlineLgFocusUnderline,
+      },
+    ],
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+function NumberField({ className, ...props }: NumberFieldPrimitive.Root.Props) {
+  return (
+    <NumberFieldPrimitive.Root
+      data-slot="number-field"
+      className={cn('w-full', className)}
+      {...props}
+    />
+  );
+}
+
+export interface NumberFieldGroupProps
+  extends
+    React.ComponentProps<typeof NumberFieldPrimitive.Group>,
+    VariantProps<typeof numberFieldGroupVariants> {}
+
+function NumberFieldGroup({
+  className,
+  variant,
+  size,
+  ...props
+}: NumberFieldGroupProps) {
+  const resolvedSize = size ?? 'default';
+  const resolvedVariant = variant ?? 'default';
+
+  return (
+    <NumberFieldSizeContext.Provider value={resolvedSize}>
+      <NumberFieldVariantContext.Provider value={resolvedVariant}>
+        <NumberFieldPrimitive.Group
+          data-slot="number-field-group"
+          data-variant={resolvedVariant}
+          data-size={resolvedSize}
+          className={cn(numberFieldGroupVariants({ variant, size }), className)}
+          {...props}
+        />
+      </NumberFieldVariantContext.Provider>
+    </NumberFieldSizeContext.Provider>
+  );
+}
+
+export interface NumberFieldInputProps extends Omit<
+  NumberFieldPrimitive.Input.Props,
+  'size'
+> {
+  size?: NumberFieldSize;
+}
+
+function NumberFieldInput({
+  className,
+  size,
+  ...props
+}: Readonly<NumberFieldInputProps>) {
+  const groupSize = React.useContext(NumberFieldSizeContext);
+  const variant = React.useContext(NumberFieldVariantContext);
+  const resolvedSize = size ?? groupSize;
+  const isInline = variant === 'inline';
+  const textStyles = isInline
+    ? inputVariantStyles.inline.text
+    : inputVariantStyles.default.text;
+  const disabledTextStyles = isInline
+    ? numberFieldControlDisabledTextStyles.inline
+    : numberFieldControlDisabledTextStyles.default;
+
+  return (
+    <NumberFieldPrimitive.Input
+      data-slot={controlSlot}
+      className={cn(
+        'h-full w-full min-w-0 flex-1 rounded-none border-0 bg-transparent px-0! py-0! text-center font-normal shadow-none ring-0 transition-[color] outline-none',
+        'selection:bg-fill-active selection:text-fg-primary-inverse',
+        inputSizeStyles[resolvedSize],
+        textStyles,
+        disabledTextStyles,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function NumberFieldStepperIcon() {
+  return (
+    <IconShell size="sm" type="neutral" variant="secondary">
+      <Icon icon="remove" />
+    </IconShell>
+  );
+}
+
+function NumberFieldStepperIconIncrement() {
+  return (
+    <IconShell size="sm" type="neutral" variant="secondary">
+      <Icon icon="add" />
+    </IconShell>
+  );
+}
+
+export interface NumberFieldDecrementProps
+  extends NumberFieldPrimitive.Decrement.Props {
+  size?: NumberFieldSize;
+}
+
+function NumberFieldDecrement({
+  className,
+  size,
+  children,
+  ...props
+}: Readonly<NumberFieldDecrementProps>) {
+  const groupSize = React.useContext(NumberFieldSizeContext);
+  const resolvedSize = size ?? groupSize;
+
+  return (
+    <NumberFieldPrimitive.Decrement
+      data-slot="number-field-decrement"
+      render={
+        <Button
+          variant="ghost"
+          size="icon-xxs"
+          aria-label="Decrease"
+          className={cn(
+            'paragraph-regular-primary shadow-none',
+            stepperButtonClass[resolvedSize],
+            className,
+          )}
+        />
+      }
+      {...props}>
+      {children ?? <NumberFieldStepperIcon />}
+    </NumberFieldPrimitive.Decrement>
+  );
+}
+
+export interface NumberFieldIncrementProps
+  extends NumberFieldPrimitive.Increment.Props {
+  size?: NumberFieldSize;
+}
+
+function NumberFieldIncrement({
+  className,
+  size,
+  children,
+  ...props
+}: Readonly<NumberFieldIncrementProps>) {
+  const groupSize = React.useContext(NumberFieldSizeContext);
+  const resolvedSize = size ?? groupSize;
+
+  return (
+    <NumberFieldPrimitive.Increment
+      data-slot="number-field-increment"
+      render={
+        <Button
+          variant="ghost"
+          size="icon-xxs"
+          aria-label="Increase"
+          className={cn(
+            'paragraph-regular-primary shadow-none',
+            stepperButtonClass[resolvedSize],
+            className,
+          )}
+        />
+      }
+      {...props}>
+      {children ?? <NumberFieldStepperIconIncrement />}
+    </NumberFieldPrimitive.Increment>
+  );
+}
+
+export {
+  NumberField,
+  NumberFieldGroup,
+  NumberFieldInput,
+  NumberFieldDecrement,
+  NumberFieldIncrement,
+  numberFieldGroupVariants,
+};

--- a/src/components/ui/number-field.tsx
+++ b/src/components/ui/number-field.tsx
@@ -35,7 +35,8 @@ const NumberFieldDisabledContext = React.createContext<boolean>(false);
 const numberFieldControlDisabledTextStyles = {
   default:
     'disabled:cursor-not-allowed disabled:text-fg-disabled disabled:placeholder:text-fg-disabled',
-  inline: 'disabled:text-fg-disabled disabled:placeholder:text-fg-disabled',
+  inline:
+    'disabled:cursor-not-allowed disabled:text-fg-disabled disabled:placeholder:text-fg-disabled',
 } as const;
 
 const stepperButtonClass = {
@@ -75,6 +76,8 @@ const numberFieldGroupVariants = cva(
           inputVariantStyles.inline.base,
           inputVariantStyles.inline.border,
           inputVariantStyles.inline.hover,
+          'has-[[data-slot=input-group-control]:disabled]:cursor-not-allowed',
+          'has-[[data-slot=input-group-control]:disabled]:hover:border-b-stroke-tertiary',
           ...inputGroupInlineFocusStyles,
           ...inputGroupInlineErrorStyles,
           'data-[invalid]:border-b-stroke-status-error',

--- a/src/components/ui/number-field.tsx
+++ b/src/components/ui/number-field.tsx
@@ -52,7 +52,7 @@ const stepperButtonStyles = [
   'group-has-[[data-slot=input-group-control]:disabled]/number-field:hover:bg-transparent',
   'group-has-[[data-slot=input-group-control]:disabled]/number-field:hover:text-fg-secondary',
   'group-has-[[data-slot=input-group-control]:disabled]/number-field:active:bg-transparent',
-  'disabled:hover:bg-transparent disabled:pointer-events-none',
+  'disabled:cursor-not-allowed disabled:hover:bg-transparent',
 ] as const;
 
 const numberFieldGroupVariants = cva(

--- a/src/components/ui/number-field.tsx
+++ b/src/components/ui/number-field.tsx
@@ -8,24 +8,24 @@ import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/ui/icon';
 import { IconShell } from '@/components/ui/icon-shell';
 import {
+  inputGroupDefaultDisabledStyles,
+  inputGroupDefaultErrorStyles,
+  inputGroupDefaultFocusStyles,
+  inputGroupFocusRingWidth,
+  inputGroupInlineErrorStyles,
+  inputGroupInlineFocusBorderWidth,
+  inputGroupInlineFocusStyles,
+  inputGroupInlineLgFocusUnderline,
   inputSizeDefinitions,
   inputSizeStyles,
   inputVariantStyles,
-  numberFieldGroupDefaultDisabledStyles,
-  numberFieldGroupDefaultErrorStyles,
-  numberFieldGroupDefaultFocusStyles,
-  numberFieldGroupFocusRingWidth,
-  numberFieldGroupInlineErrorStyles,
-  numberFieldGroupInlineFocusBorderWidth,
-  numberFieldGroupInlineFocusStyles,
-  numberFieldGroupInlineLgFocusUnderline,
 } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 
 type NumberFieldSize = 'sm' | 'default' | 'lg';
 type NumberFieldVariant = 'default' | 'inline';
 
-const controlSlot = 'number-field-control';
+const controlSlot = 'input-group-control';
 
 const NumberFieldSizeContext = React.createContext<NumberFieldSize>('default');
 const NumberFieldVariantContext =
@@ -46,11 +46,11 @@ const stepperButtonClass = {
 const stepperButtonStyles = [
   'paragraph-regular-primary shadow-none',
   'focus-visible:ring-0 focus-visible:ring-offset-0',
-  'group-has-[[data-slot=number-field-control]:disabled]/number-field:pointer-events-none',
-  'group-has-[[data-slot=number-field-control]:disabled]/number-field:hover:bg-transparent',
-  'group-has-[[data-slot=number-field-control]:disabled]/number-field:hover:text-fg-secondary',
-  'group-has-[[data-slot=number-field-control]:disabled]/number-field:active:bg-transparent',
-  'group-has-[[data-slot=number-field-control]:disabled]/number-field:[&_[data-slot=icon-shell]]:opacity-50',
+  'group-has-[[data-slot=input-group-control]:disabled]/number-field:pointer-events-none',
+  'group-has-[[data-slot=input-group-control]:disabled]/number-field:hover:bg-transparent',
+  'group-has-[[data-slot=input-group-control]:disabled]/number-field:hover:text-fg-secondary',
+  'group-has-[[data-slot=input-group-control]:disabled]/number-field:active:bg-transparent',
+  'group-has-[[data-slot=input-group-control]:disabled]/number-field:[&_[data-slot=icon-shell]]:opacity-50',
   'disabled:hover:bg-transparent disabled:pointer-events-none',
 ] as const;
 
@@ -64,9 +64,10 @@ const numberFieldGroupVariants = cva(
           'gap-1',
           inputVariantStyles.default.base,
           inputVariantStyles.default.hover,
-          ...numberFieldGroupDefaultFocusStyles,
-          ...numberFieldGroupDefaultErrorStyles,
-          ...numberFieldGroupDefaultDisabledStyles,
+          ...inputGroupDefaultFocusStyles,
+          ...inputGroupDefaultErrorStyles,
+          'data-[invalid]:border-stroke-status-error',
+          ...inputGroupDefaultDisabledStyles,
         ],
         inline: [
           'w-[96px]',
@@ -74,8 +75,9 @@ const numberFieldGroupVariants = cva(
           inputVariantStyles.inline.base,
           inputVariantStyles.inline.border,
           inputVariantStyles.inline.hover,
-          ...numberFieldGroupInlineFocusStyles,
-          ...numberFieldGroupInlineErrorStyles,
+          ...inputGroupInlineFocusStyles,
+          ...inputGroupInlineErrorStyles,
+          'data-[invalid]:border-b-stroke-status-error',
         ],
       },
       size: {
@@ -88,32 +90,32 @@ const numberFieldGroupVariants = cva(
       {
         variant: 'default',
         size: 'sm',
-        className: numberFieldGroupFocusRingWidth.sm,
+        className: inputGroupFocusRingWidth.sm,
       },
       {
         variant: 'default',
         size: 'default',
-        className: numberFieldGroupFocusRingWidth.default,
+        className: inputGroupFocusRingWidth.default,
       },
       {
         variant: 'default',
         size: 'lg',
-        className: numberFieldGroupFocusRingWidth.lg,
+        className: inputGroupFocusRingWidth.lg,
       },
       {
         variant: 'inline',
         size: 'sm',
-        className: numberFieldGroupInlineFocusBorderWidth.sm,
+        className: inputGroupInlineFocusBorderWidth.sm,
       },
       {
         variant: 'inline',
         size: 'default',
-        className: numberFieldGroupInlineFocusBorderWidth.default,
+        className: inputGroupInlineFocusBorderWidth.default,
       },
       {
         variant: 'inline',
         size: 'lg',
-        className: numberFieldGroupInlineLgFocusUnderline,
+        className: inputGroupInlineLgFocusUnderline,
       },
     ],
     defaultVariants: {


### PR DESCRIPTION
## Summary

- Base UI NumberField with filled and inline stepper variants
- Static group selectors in input.tsx for focus, error, disabled chrome
- Reuse input-group-control slot and inputGroup* styles (no duplicate exports)
- Stepper buttons pointer-only; refocus input after increment/decrement