### PR TITLE
refactor(props): align size prop naming across components

### DIFF
--- a/src/app/demo/[name]/ui/segmented-controls.tsx
+++ b/src/app/demo/[name]/ui/segmented-controls.tsx
@@ -53,7 +53,7 @@ export function SegmentedControlsGhost() {
 export function SegmentedControlsSizes() {
   return (
     <div className="flex flex-col items-start gap-4">
-      <SegmentedControls defaultValue="week" size="reg">
+      <SegmentedControls defaultValue="week" size="default">
         <SegmentedControlsItem value="day">Day</SegmentedControlsItem>
         <SegmentedControlsItem value="week">Week</SegmentedControlsItem>
         <SegmentedControlsItem value="month">Month</SegmentedControlsItem>
@@ -65,7 +65,7 @@ export function SegmentedControlsSizes() {
         <SegmentedControlsItem value="month">Month</SegmentedControlsItem>
       </SegmentedControls>
 
-      <SegmentedControls defaultValue="week" size="xsm">
+      <SegmentedControls defaultValue="week" size="xs">
         <SegmentedControlsItem value="day">Day</SegmentedControlsItem>
         <SegmentedControlsItem value="week">Week</SegmentedControlsItem>
         <SegmentedControlsItem value="month">Month</SegmentedControlsItem>
@@ -137,7 +137,7 @@ export const examples: DemoExample[] = [
   {
     name: 'SegmentedControlsSizes',
     title: 'Sizes',
-    description: 'Reg, sm, xsm, and xxs sizes.',
+    description: 'Default, sm, xs, and xxs sizes.',
   },
   {
     name: 'SegmentedControlsIconOnly',

--- a/src/app/demo/[name]/ui/table.tsx
+++ b/src/app/demo/[name]/ui/table.tsx
@@ -185,11 +185,11 @@ export function TableSizes() {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead size="small">Invoice</TableHead>
-              <TableHead size="small">Users</TableHead>
-              <TableHead size="small">Status</TableHead>
-              <TableHead size="small">Amount</TableHead>
-              <TableHead size="small" className="text-right">
+              <TableHead size="sm">Invoice</TableHead>
+              <TableHead size="sm">Users</TableHead>
+              <TableHead size="sm">Status</TableHead>
+              <TableHead size="sm">Amount</TableHead>
+              <TableHead size="sm" className="text-right">
                 Actions
               </TableHead>
             </TableRow>
@@ -197,10 +197,10 @@ export function TableSizes() {
           <TableBody>
             {invoices.slice(0, 3).map(invoice => (
               <TableRow key={invoice.invoice}>
-                <TableCell size="small" className="font-medium">
+                <TableCell size="sm" className="font-medium">
                   {invoice.invoice}
                 </TableCell>
-                <TableCell size="small">
+                <TableCell size="sm">
                   <AvatarGroup>
                     {invoice.avatars.map(src => (
                       <Avatar key={src} size="xs">
@@ -210,9 +210,9 @@ export function TableSizes() {
                     ))}
                   </AvatarGroup>
                 </TableCell>
-                <TableCell size="small">{invoice.paymentStatus}</TableCell>
-                <TableCell size="small">{invoice.totalAmount}</TableCell>
-                <TableCell size="small" className="text-right">
+                <TableCell size="sm">{invoice.paymentStatus}</TableCell>
+                <TableCell size="sm">{invoice.totalAmount}</TableCell>
+                <TableCell size="sm" className="text-right">
                   <Button variant="outline" size="sm">
                     Label
                   </Button>
@@ -579,7 +579,7 @@ export const examples = [
   {
     name: 'TableSizes',
     title: 'Size Comparison',
-    description: 'Default and small table sizes side by side.',
+    description: 'Default and sm table sizes side by side.',
   },
   {
     name: 'DataTableDemo',

--- a/src/components/ui/segmented-controls.tsx
+++ b/src/components/ui/segmented-controls.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils';
 
 type SegmentedControlsType = 'secondary-filled' | 'ghost';
 
-type SegmentedControlsSize = 'reg' | 'sm' | 'xsm' | 'xxs';
+type SegmentedControlsSize = 'default' | 'sm' | 'xs' | 'xxs';
 
 /**
  * State overlay gradients for the secondary-filled variant.
@@ -33,14 +33,14 @@ const segmentedControlsVariants = cva(
   {
     variants: {
       size: {
-        reg: 'gap-1',
+        default: 'gap-1',
         sm: 'gap-0.5',
-        xsm: 'gap-0.5',
+        xs: 'gap-0.5',
         xxs: 'gap-0.5',
       },
     },
     defaultVariants: {
-      size: 'reg',
+      size: 'default',
     },
   },
 );
@@ -76,15 +76,15 @@ const segmentedControlsItemVariants = cva(
         ],
       },
       size: {
-        reg: 'min-h-9 p-2 gap-2 cta-button-02',
+        default: 'min-h-9 p-2 gap-2 cta-button-02',
         sm: 'min-h-7 px-2 py-1 gap-1 cta-button-02',
-        xsm: 'h-6 px-1 py-0.5 gap-0.5 cta-button-03',
+        xs: 'h-6 px-1 py-0.5 gap-0.5 cta-button-03',
         xxs: 'h-5 px-1 py-0.5 gap-0.5 cta-button-03',
       },
     },
     defaultVariants: {
       type: 'secondary-filled',
-      size: 'reg',
+      size: 'default',
     },
   },
 );
@@ -97,7 +97,7 @@ interface SegmentedControlsContextValue {
 const SegmentedControlsContext =
   React.createContext<SegmentedControlsContextValue>({
     type: 'secondary-filled',
-    size: 'reg',
+    size: 'default',
   });
 
 // Single-select only: Radix's own `type`/`value`/`onValueChange` are pinned to the
@@ -116,7 +116,7 @@ interface SegmentedControlsProps extends Omit<
 function SegmentedControls({
   className,
   type = 'secondary-filled',
-  size = 'reg',
+  size = 'default',
   children,
   ...props
 }: SegmentedControlsProps) {

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -768,13 +768,13 @@ function SidebarMenuSubItem({
 
 function SidebarMenuSubButton({
   asChild = false,
-  size = 'md',
+  size = 'default',
   isActive = false,
   className,
   ...props
 }: React.ComponentProps<'a'> & {
   asChild?: boolean;
-  size?: 'sm' | 'md';
+  size?: 'sm' | 'default';
   isActive?: boolean;
 }) {
   const Comp = asChild ? Slot : 'a';
@@ -789,7 +789,7 @@ function SidebarMenuSubButton({
         'text-fg-primary ring-stroke-status-focus hover:bg-stateslayer-overlay-hover hover:text-fg-primary active:bg-fill-subtle active:text-fg-primary [&>svg]:text-fg-primary flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
         'data-[active=true]:bg-fill-subtle data-[active=true]:text-fg-primary',
         size === 'sm' && 'text-xs',
-        size === 'md' && 'text-sm',
+        size === 'default' && 'text-sm',
         'group-data-[collapsible=icon]:hidden',
         className,
       )}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -54,7 +54,7 @@ function TableRow({ className, selected = false, ...props }: TableRowProps) {
 }
 
 interface TableHeadProps extends React.ComponentProps<'th'> {
-  size?: 'small' | 'default';
+  size?: 'sm' | 'default';
   selected?: boolean;
 }
 
@@ -76,7 +76,7 @@ function TableHead({
         'label-regular-primary',
         'pt-3 pb-4',
         {
-          'px-3': size === 'small',
+          'px-3': size === 'sm',
           'px-4': size === 'default',
         },
         className,
@@ -87,7 +87,7 @@ function TableHead({
 }
 
 interface TableCellProps extends React.ComponentProps<'td'> {
-  size?: 'small' | 'default';
+  size?: 'sm' | 'default';
 }
 
 function TableCell({ className, size = 'default', ...props }: TableCellProps) {
@@ -103,7 +103,7 @@ function TableCell({ className, size = 'default', ...props }: TableCellProps) {
         'pt-2 pb-2',
         'h-[60px]',
         {
-          'px-3': size === 'small',
+          'px-3': size === 'sm',
           'px-4': size === 'default',
         },
         className,


### PR DESCRIPTION
Aligns React `size` prop values where the same concept used inconsistent names.

## Changes

| Component | Before | After |
|-----------|--------|-------|
| `TableHead` / `TableCell` | `small` | `sm` |
| `SidebarMenuSubButton` | `md` (default) | `default` |
| `SegmentedControls` | `reg`, `xsm` | `default`, `xs` |


Note:
One Table sm is not having any visual change.
SegmentedControls also has issues with icons etc.

This PR just renames the props.
