### PR TITLE
refactor(separator): migrate to Base UI

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -613,7 +613,7 @@
       "type": "registry:ui",
       "title": "Separator",
       "description": "A visual divider that separates content. Supports horizontal and vertical orientation.",
-      "dependencies": ["@radix-ui/react-separator"],
+      "dependencies": ["@base-ui/react"],
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
         "__REGISTRY_URL__/r/utils.json"

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as SeparatorPrimitive from '@radix-ui/react-separator';
+import { Separator as SeparatorPrimitive } from '@base-ui/react/separator';
 import type * as React from 'react';
 
 import { cn } from '@/lib/utils';
@@ -10,12 +10,15 @@ function Separator({
   orientation = 'horizontal',
   decorative = true,
   ...props
-}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+}: React.ComponentProps<typeof SeparatorPrimitive> & {
+  decorative?: boolean;
+}) {
   return (
-    <SeparatorPrimitive.Root
+    <SeparatorPrimitive
       data-slot="separator-root"
-      decorative={decorative}
       orientation={orientation}
+      role={decorative ? 'none' : 'separator'}
+      aria-orientation={decorative ? undefined : orientation}
       className={cn(
         'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
         className,


### PR DESCRIPTION
## Summary
- Swap `@radix-ui/react-separator` for `@base-ui/react/separator` in `separator.tsx`
- Preserve exported API (`orientation`, `decorative`, `data-slot`)
- Map `decorative` to `role="none"` vs `role="separator"` for a11y parity with Radix
- Update `registry.json` dependency to `@base-ui/react`


