### PR TITLE
refactor(badge): migrate from Radix Slot to Base UI useRender

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -92,7 +92,7 @@
       "type": "registry:ui",
       "title": "Badge",
       "description": "A badge component.",
-      "dependencies": ["@radix-ui/react-slot"],
+      "dependencies": ["@base-ui/react"],
       "registryDependencies": [
         "__REGISTRY_URL__/r/theme.json",
         "__REGISTRY_URL__/r/utils.json"

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,4 +1,5 @@
-import { Slot } from '@radix-ui/react-slot';
+import { mergeProps } from '@base-ui/react/merge-props';
+import { useRender } from '@base-ui/react/use-render';
 import { type VariantProps, cva } from 'class-variance-authority';
 import * as React from 'react';
 
@@ -104,12 +105,8 @@ const badgeVariants = cva(
   },
 );
 
-export type BadgeProps = Omit<
-  React.ComponentProps<'span'>,
-  keyof VariantProps<typeof badgeVariants>
-> &
+export type BadgeProps = useRender.ComponentProps<'span'> &
   Omit<VariantProps<typeof badgeVariants>, 'withIcon' | 'withDot'> & {
-    asChild?: boolean;
     withIcon?: boolean;
     withDot?: boolean;
   };
@@ -121,31 +118,38 @@ function Badge({
   outline,
   withIcon = false,
   withDot = false,
-  asChild = false,
+  render,
   ...props
 }: BadgeProps) {
-  const Comp = asChild ? Slot : 'span';
-
   const resolvedSize = size ?? 'default';
 
-  return (
-    <Comp
-      data-slot="badge"
-      className={cn(
-        badgeVariants({
-          variant,
-          size: resolvedSize,
-          outline,
-          withIcon,
-          withDot,
-        }),
-        getBadgePadding(resolvedSize, withIcon, withDot),
-        withIcon && resolvedSize === 'sm' && !outline && 'gap-0.5',
-        className,
-      )}
-      {...props}
-    />
-  );
+  return useRender({
+    defaultTagName: 'span',
+    props: mergeProps<'span'>(
+      {
+        className: cn(
+          badgeVariants({
+            variant,
+            size: resolvedSize,
+            outline,
+            withIcon,
+            withDot,
+          }),
+          getBadgePadding(resolvedSize, withIcon, withDot),
+          withIcon && resolvedSize === 'sm' && !outline && 'gap-0.5',
+          className,
+        ),
+      } as React.ComponentProps<'span'>,
+      props,
+    ),
+    render,
+    state: {
+      slot: 'badge',
+      variant,
+      size: resolvedSize,
+      outline: outline ? true : undefined,
+    },
+  });
 }
 
 const numericBadgeVariants = cva(

--- a/src/tests/badge.test.tsx
+++ b/src/tests/badge.test.tsx
@@ -56,4 +56,20 @@ describe(`${componentName} — structure`, () => {
     render(<Badge>Pill</Badge>);
     expect(screen.getByText('Pill')).toHaveClass('rounded-full');
   });
+
+  it('renders with render prop composition', () => {
+    render(
+      <Badge
+        className="custom-badge"
+        render={<a href="#" data-testid="badge-link" />}>
+        Link
+      </Badge>,
+    );
+
+    const link = screen.getByTestId('badge-link');
+    expect(link).toHaveTextContent('Link');
+    expect(link).toHaveAttribute('data-slot', 'badge');
+    expect(link).toHaveClass('custom-badge');
+    expect(link).toHaveClass('rounded-full');
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replace `@radix-ui/react-slot` with Base UI `useRender` + `mergeProps` on `Badge`
- Swap `asChild` for `render` (shadcn Base UI pattern); expose `data-slot` / variant metadata via `state`
- Update registry dependency to `@base-ui/react` and add render-prop composition test
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e75464ca-7e01-4a85-9cb3-4ae0c0f4f160?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e75464ca-7e01-4a85-9cb3-4ae0c0f4f160&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

