### PR TITLE
refactor(collapsible): migrate to Base UI

### DIFF
--- a/code-connect/nav-menu-item.figma.ts
+++ b/code-connect/nav-menu-item.figma.ts
@@ -104,9 +104,7 @@ export default {
         ? figma.code`
             <Collapsible${isExpanded ? ' defaultOpen' : ''} className="group/collapsible">
               <SidebarMenuItem>
-                <CollapsibleTrigger asChild>
-                  ${groupButton}
-                </CollapsibleTrigger>
+                <CollapsibleTrigger render={${groupButton}} />
                 <CollapsibleContent>
                   <SidebarNavMenuSub>
                     ${figma.helpers.react.renderChildren(subItems)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@base-ui/react": "^1.2.0",
         "@hookform/resolvers": "^5.1.1",
         "@radix-ui/react-aspect-ratio": "^1.1.7",
-        "@radix-ui/react-collapsible": "^1.1.11",
         "@radix-ui/react-context-menu": "^2.2.16",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -1643,36 +1642,6 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
-      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@base-ui/react": "^1.2.0",
     "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-aspect-ratio": "^1.1.7",
-    "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/src/app/demo/[name]/ui/sidebar.tsx
+++ b/src/app/demo/[name]/ui/sidebar.tsx
@@ -107,21 +107,23 @@ function NavMenuGroupRow({
       }}
       className={cn('group/collapsible', groupActive && 'bg-fill-muted')}>
       <SidebarMenuItem>
-        <CollapsibleTrigger asChild>
-          <SidebarNavMenuButton showChevron isActive={groupActive}>
-            {withIcons ? navIcon(group.icon, groupActive, iconSize) : null}
-            <span>{group.label}</span>
-            {group.badge ? (
-              <Badge
-                size="sm"
-                variant="high-emphasis"
-                outline
-                className="ml-auto">
-                {group.badge}
-              </Badge>
-            ) : null}
-          </SidebarNavMenuButton>
-        </CollapsibleTrigger>
+        <CollapsibleTrigger
+          render={
+            <SidebarNavMenuButton showChevron isActive={groupActive}>
+              {withIcons ? navIcon(group.icon, groupActive, iconSize) : null}
+              <span>{group.label}</span>
+              {group.badge ? (
+                <Badge
+                  size="sm"
+                  variant="high-emphasis"
+                  outline
+                  className="ml-auto">
+                  {group.badge}
+                </Badge>
+              ) : null}
+            </SidebarNavMenuButton>
+          }
+        />
         <CollapsibleContent>
           <SidebarNavMenuSub>
             {group.items.map(item => {

--- a/src/components/registry/registry-sidebar.tsx
+++ b/src/components/registry/registry-sidebar.tsx
@@ -143,16 +143,19 @@ export function RegistrySidebar() {
                       <Collapsible
                         defaultOpen={true}
                         className="group/subgroup w-full">
-                        <CollapsibleTrigger asChild className="cursor-pointer">
-                          <SidebarMenuButton className="flex w-full items-center justify-between">
-                            <span>{entry.group.label}</span>
-                            <Icon
-                              icon="keyboard_arrow_down"
-                              size="sm"
-                              className="flex-shrink-0 transition-transform duration-200 group-data-open/subgroup:rotate-180"
-                            />
-                          </SidebarMenuButton>
-                        </CollapsibleTrigger>
+                        <CollapsibleTrigger
+                          className="cursor-pointer"
+                          render={
+                            <SidebarMenuButton className="flex w-full items-center justify-between">
+                              <span>{entry.group.label}</span>
+                              <Icon
+                                icon="keyboard_arrow_down"
+                                size="sm"
+                                className="flex-shrink-0 transition-transform duration-200 group-data-open/subgroup:rotate-180"
+                              />
+                            </SidebarMenuButton>
+                          }
+                        />
                         <CollapsibleContent>
                           <SidebarMenuSub>
                             {entry.groupItems.map(item => (

--- a/src/components/registry/registry-sidebar.tsx
+++ b/src/components/registry/registry-sidebar.tsx
@@ -149,7 +149,7 @@ export function RegistrySidebar() {
                             <Icon
                               icon="keyboard_arrow_down"
                               size="sm"
-                              className="flex-shrink-0 transition-transform duration-200 group-data-[state=open]/subgroup:rotate-180"
+                              className="flex-shrink-0 transition-transform duration-200 group-data-open/subgroup:rotate-180"
                             />
                           </SidebarMenuButton>
                         </CollapsibleTrigger>

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,31 +1,34 @@
 'use client';
 
-import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
-import type * as React from 'react';
+import { Collapsible as CollapsiblePrimitive } from '@base-ui/react/collapsible';
+import * as React from 'react';
 
-function Collapsible({
-  ...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+function Collapsible({ ...props }: CollapsiblePrimitive.Root.Props) {
   return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
 }
 
 function CollapsibleTrigger({
+  asChild = false,
+  children,
   ...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+}: CollapsiblePrimitive.Trigger.Props & { asChild?: boolean }) {
+  const child = asChild && React.isValidElement(children) ? children : null;
+
   return (
-    <CollapsiblePrimitive.CollapsibleTrigger
+    <CollapsiblePrimitive.Trigger
       data-slot="collapsible-trigger"
       suppressHydrationWarning
-      {...props}
-    />
+      nativeButton={!child}
+      render={child ?? undefined}
+      {...props}>
+      {child ? null : children}
+    </CollapsiblePrimitive.Trigger>
   );
 }
 
-function CollapsibleContent({
-  ...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+function CollapsibleContent({ ...props }: CollapsiblePrimitive.Panel.Props) {
   return (
-    <CollapsiblePrimitive.CollapsibleContent
+    <CollapsiblePrimitive.Panel
       data-slot="collapsible-content"
       suppressHydrationWarning
       {...props}

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,38 +1,20 @@
 'use client';
 
 import { Collapsible as CollapsiblePrimitive } from '@base-ui/react/collapsible';
-import * as React from 'react';
 
 function Collapsible({ ...props }: CollapsiblePrimitive.Root.Props) {
   return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
 }
 
-function CollapsibleTrigger({
-  asChild = false,
-  children,
-  ...props
-}: CollapsiblePrimitive.Trigger.Props & { asChild?: boolean }) {
-  const child = asChild && React.isValidElement(children) ? children : null;
-
+function CollapsibleTrigger({ ...props }: CollapsiblePrimitive.Trigger.Props) {
   return (
-    <CollapsiblePrimitive.Trigger
-      data-slot="collapsible-trigger"
-      suppressHydrationWarning
-      nativeButton={!child}
-      render={child ?? undefined}
-      {...props}>
-      {child ? null : children}
-    </CollapsiblePrimitive.Trigger>
+    <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />
   );
 }
 
 function CollapsibleContent({ ...props }: CollapsiblePrimitive.Panel.Props) {
   return (
-    <CollapsiblePrimitive.Panel
-      data-slot="collapsible-content"
-      suppressHydrationWarning
-      {...props}
-    />
+    <CollapsiblePrimitive.Panel data-slot="collapsible-content" {...props} />
   );
 }
 

--- a/src/components/ui/sidebar-nav.tsx
+++ b/src/components/ui/sidebar-nav.tsx
@@ -242,7 +242,7 @@ function SidebarNavMenuButton({
               size={chevronShellSize}
               type="neutral"
               variant={shellVariant}
-              className="group-data-[state=open]/collapsible:hidden">
+              className="group-data-open/collapsible:hidden">
               <Icon icon="chevron_right" />
             </IconShell>
             <IconShell
@@ -250,7 +250,7 @@ function SidebarNavMenuButton({
               size={chevronShellSize}
               type="neutral"
               variant={shellVariant}
-              className="hidden group-data-[state=open]/collapsible:inline-flex">
+              className="hidden group-data-open/collapsible:inline-flex">
               <Icon icon="expand_more" />
             </IconShell>
           </>

--- a/src/tests/sidebar-nav-menu.test.tsx
+++ b/src/tests/sidebar-nav-menu.test.tsx
@@ -183,7 +183,7 @@ describe('SidebarNavMenu — collapsible group', () => {
 
     await user.click(trigger);
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
-    expect(trigger).toHaveAttribute('data-state', 'open');
+    expect(trigger).toHaveAttribute('data-panel-open', '');
     expect(screen.getByText('Sub-item')).toBeInTheDocument();
   });
 });

--- a/src/tests/sidebar-nav-menu.test.tsx
+++ b/src/tests/sidebar-nav-menu.test.tsx
@@ -162,9 +162,9 @@ describe('SidebarNavMenu — collapsible group', () => {
         <SidebarNavMenu mode="inline">
           <Collapsible className="group/collapsible">
             <SidebarMenuItem>
-              <CollapsibleTrigger asChild>
-                <SidebarNavMenuButton>Group</SidebarNavMenuButton>
-              </CollapsibleTrigger>
+              <CollapsibleTrigger
+                render={<SidebarNavMenuButton>Group</SidebarNavMenuButton>}
+              />
               <CollapsibleContent>
                 <SidebarNavMenuSub>
                   <SidebarMenuSubItem>

--- a/src/tests/sidebar-nav-menu.test.tsx
+++ b/src/tests/sidebar-nav-menu.test.tsx
@@ -183,7 +183,9 @@ describe('SidebarNavMenu — collapsible group', () => {
 
     await user.click(trigger);
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
-    expect(trigger).toHaveAttribute('data-panel-open', '');
+    expect(trigger.closest('[data-slot="collapsible"]')).toHaveAttribute(
+      'data-open',
+    );
     expect(screen.getByText('Sub-item')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Migrate to `@base-ui/react/collapsible` matching shadcn base-ui wrappers. Consumers use `render` on Trigger (not `asChild`). Sidebar selectors use `group-data-open`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f10563b-f83e-4973-957d-dad8a45af59f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f10563b-f83e-4973-957d-dad8a45af59f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

