### PR TITLE
fix(button): use primary text in default state

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,16 +6,16 @@ import { cn } from '@/lib/utils';
 
 const hoverGradient = {
   normal:
-    'hover:[background-image:linear-gradient(var(--color-stateslayer-overlay-hover),var(--color-stateslayer-overlay-hover))] disabled:hover:[background-image:none]',
+    'hover:[background-image:linear-gradient(var(--color-stateslayer-overlay-hover),var(--color-stateslayer-overlay-hover))] disabled:hover:[background-image:linear-gradient(var(--color-stateslayer-overlay-disabled),var(--color-stateslayer-overlay-disabled))]!',
   inverse:
-    'hover:[background-image:linear-gradient(var(--color-stateslayer-overlay-hover-inverse),var(--color-stateslayer-overlay-hover-inverse))] disabled:hover:[background-image:none]',
+    'hover:[background-image:linear-gradient(var(--color-stateslayer-overlay-hover-inverse),var(--color-stateslayer-overlay-hover-inverse))] disabled:hover:[background-image:linear-gradient(var(--color-stateslayer-overlay-disabled),var(--color-stateslayer-overlay-disabled))]!',
 } as const;
 
 const activeGradient = {
   normal:
-    'active:[background-image:linear-gradient(var(--color-stateslayer-overlay-pressed),var(--color-stateslayer-overlay-pressed))] disabled:active:[background-image:none]',
+    'active:[background-image:linear-gradient(var(--color-stateslayer-overlay-pressed),var(--color-stateslayer-overlay-pressed))] disabled:active:[background-image:linear-gradient(var(--color-stateslayer-overlay-disabled),var(--color-stateslayer-overlay-disabled))]!',
   inverse:
-    'active:[background-image:linear-gradient(var(--color-stateslayer-overlay-pressed-inverse),var(--color-stateslayer-overlay-pressed-inverse))] disabled:active:[background-image:none]',
+    'active:[background-image:linear-gradient(var(--color-stateslayer-overlay-pressed-inverse),var(--color-stateslayer-overlay-pressed-inverse))] disabled:active:[background-image:linear-gradient(var(--color-stateslayer-overlay-disabled),var(--color-stateslayer-overlay-disabled))]!',
 } as const;
 
 const disabledOverlayGradient =
@@ -68,7 +68,7 @@ const buttonVariants = cva(
         ],
         outline: [
           'inset-ring inset-ring-stroke-secondary bg-fill-muted-inverse text-fg-primary',
-          'hover:inset-ring-stroke-primary',
+          'hover:inset-ring-stroke-primary disabled:hover:inset-ring-stroke-tertiary disabled:active:inset-ring-stroke-tertiary',
           'focus-visible:inset-ring-0 data-[state=open]:inset-ring-0',
           hoverGradient.normal,
           activeGradient.normal,
@@ -193,7 +193,7 @@ function wrapTextNodes(children: React.ReactNode): React.ReactNode {
       return (
         <span
           data-slot="button-label"
-          className="[text-underline-position:from-font] group-hover/button:underline group-focus/button:underline group-active/button:underline group-disabled/button:no-underline group-aria-disabled/button:no-underline group-data-[state=open]/button:underline"
+          className="[text-underline-position:from-font] group-hover/button:underline group-focus/button:underline group-active/button:underline group-disabled/button:no-underline! group-aria-disabled/button:no-underline! group-data-[state=open]/button:underline"
           key={String(child)}>
           {child}
         </span>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -43,7 +43,6 @@ const buttonVariants = cva(
       variant: {
         default: [
           'bg-fill-primary text-fg-primary-inverse',
-          'hover:text-fg-primary-inverse active:text-fg-primary-inverse focus-visible:text-fg-primary-inverse data-[state=open]:text-fg-primary-inverse',
           hoverGradient.inverse,
           activeGradient.inverse,
           'focus-visible:bg-stateslayer-overlay-active',
@@ -53,7 +52,6 @@ const buttonVariants = cva(
         ],
         accent: [
           'bg-brand-accents-qb-accent text-[var(--slate-900-opacity-88)]',
-          'hover:text-[var(--slate-900-opacity-88)] active:text-[var(--slate-900-opacity-88)] focus-visible:text-[var(--slate-900-opacity-88)] data-[state=open]:text-[var(--slate-900-opacity-88)]',
           hoverGradient.normal,
           activeGradient.normal,
           'data-[state=open]:bg-stateslayer-overlay-active-inverse',
@@ -62,7 +60,6 @@ const buttonVariants = cva(
         ],
         secondary: [
           'bg-fill-muted text-fg-primary',
-          'hover:text-fg-primary active:text-fg-primary focus-visible:text-fg-primary data-[state=open]:text-fg-primary',
           hoverGradient.normal,
           activeGradient.normal,
           'data-[state=open]:bg-stateslayer-overlay-active-inverse',
@@ -71,7 +68,6 @@ const buttonVariants = cva(
         ],
         outline: [
           'inset-ring inset-ring-stroke-secondary bg-fill-muted-inverse text-fg-primary',
-          'hover:text-fg-primary active:text-fg-primary focus-visible:text-fg-primary data-[state=open]:text-fg-primary',
           'hover:inset-ring-stroke-primary',
           'focus-visible:inset-ring-0 data-[state=open]:inset-ring-0',
           hoverGradient.normal,
@@ -82,7 +78,6 @@ const buttonVariants = cva(
         ],
         ghost: [
           'bg-transparent text-fg-primary',
-          'hover:text-fg-primary active:text-fg-primary focus-visible:text-fg-primary data-[state=open]:text-fg-primary',
           '[&>span:not([data-slot^=icon])]:underline disabled:[&>span:not([data-slot^=icon])]:no-underline aria-disabled:[&>span:not([data-slot^=icon])]:no-underline',
           'hover:bg-stateslayer-overlay-hover active:bg-stateslayer-overlay-pressed',
           'focus-visible:bg-stateslayer-overlay-active-inverse data-[state=open]:bg-stateslayer-overlay-active-inverse',

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -42,7 +42,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: [
-          'bg-fill-primary text-fg-secondary-inverse',
+          'bg-fill-primary text-fg-primary-inverse',
           'hover:text-fg-primary-inverse active:text-fg-primary-inverse focus-visible:text-fg-primary-inverse data-[state=open]:text-fg-primary-inverse',
           hoverGradient.inverse,
           activeGradient.inverse,
@@ -52,7 +52,7 @@ const buttonVariants = cva(
           disabledOverlayGradient,
         ],
         accent: [
-          'bg-brand-accents-qb-accent text-[var(--slate-900-opacity-60)]',
+          'bg-brand-accents-qb-accent text-[var(--slate-900-opacity-88)]',
           'hover:text-[var(--slate-900-opacity-88)] active:text-[var(--slate-900-opacity-88)] focus-visible:text-[var(--slate-900-opacity-88)] data-[state=open]:text-[var(--slate-900-opacity-88)]',
           hoverGradient.normal,
           activeGradient.normal,
@@ -61,7 +61,7 @@ const buttonVariants = cva(
           disabledOverlayGradient,
         ],
         secondary: [
-          'bg-fill-muted text-fg-secondary',
+          'bg-fill-muted text-fg-primary',
           'hover:text-fg-primary active:text-fg-primary focus-visible:text-fg-primary data-[state=open]:text-fg-primary',
           hoverGradient.normal,
           activeGradient.normal,
@@ -70,7 +70,7 @@ const buttonVariants = cva(
           disabledOverlayGradient,
         ],
         outline: [
-          'inset-ring inset-ring-stroke-secondary bg-fill-muted-inverse text-fg-secondary',
+          'inset-ring inset-ring-stroke-secondary bg-fill-muted-inverse text-fg-primary',
           'hover:text-fg-primary active:text-fg-primary focus-visible:text-fg-primary data-[state=open]:text-fg-primary',
           'hover:inset-ring-stroke-primary',
           'focus-visible:inset-ring-0 data-[state=open]:inset-ring-0',
@@ -81,7 +81,7 @@ const buttonVariants = cva(
           'disabled:inset-ring-stroke-tertiary',
         ],
         ghost: [
-          'bg-transparent text-fg-secondary',
+          'bg-transparent text-fg-primary',
           'hover:text-fg-primary active:text-fg-primary focus-visible:text-fg-primary data-[state=open]:text-fg-primary',
           '[&>span:not([data-slot^=icon])]:underline disabled:[&>span:not([data-slot^=icon])]:no-underline aria-disabled:[&>span:not([data-slot^=icon])]:no-underline',
           'hover:bg-stateslayer-overlay-hover active:bg-stateslayer-overlay-pressed',

--- a/src/components/ui/icon-shell.tsx
+++ b/src/components/ui/icon-shell.tsx
@@ -36,6 +36,8 @@ const iconVariants = cva(
           'active:opacity-88',
           'group-hover/button:opacity-88',
           'group-active/button:opacity-88',
+          'group-disabled/button:opacity-30',
+          'group-aria-disabled/button:opacity-30',
           'group-data-[state=open]/button:opacity-88',
           'group-data-pressed/button:opacity-88',
         ],


### PR DESCRIPTION
- Button label text uses primary foreground tokens at rest across all variants. Redundant hover/active/focus/open text classes removed since rest state is already primary.
- Fixed hover bug on disabled buttons (gradient/ring/underline overrides).
- IconShell: disabled/aria-disabled hoverable icons use opacity-30 inside buttons to match disabled label treatment.