### PR TITLE
dev(ci): add workflow to link PR stacks

### DIFF
--- a/.github/workflows/link-pr-stack.yml
+++ b/.github/workflows/link-pr-stack.yml
@@ -1,0 +1,25 @@
+name: Link PR stack
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_requests:
+        description: Comma-separated PR numbers bottom-to-top (e.g. 184,185,186)
+        required: true
+        type: string
+
+permissions:
+  pull-requests: write
+
+jobs:
+  link:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create stack
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PRS: ${{ inputs.pull_requests }}
+        run: |
+          json=$(printf '%s' "$PRS" | tr ',' '\n' | jq -R 'tonumber' | jq -s '{pull_requests: .}')
+          echo "$json" | gh api --method POST "repos/$GH_REPO/stacks" --input -


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add workflow_dispatch workflow to link PRs into a GitHub stack via the Stacks REST API
- Needed because the cloud agent token cannot call `POST /repos/.../stacks` (403)

## Usage

After merge, run:

```bash
gh workflow run link-pr-stack.yml -f pull_requests=184,185,186
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4ac5644-0f57-4565-9e0a-e52e64744e27?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4ac5644-0f57-4565-9e0a-e52e64744e27&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

